### PR TITLE
Add on-the-fly display disconnect/reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ DerivedData/
 Crisp.xcodeproj/
 Crisp.dmg
 .superpowers/
+Crisp-bin

--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -222,6 +222,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 // touching display state.
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
                 dm.refreshDisplays()
+                // Re-disconnect any physical displays macOS re-enabled on wake.
+                await PhysicalDisplayToggleService.shared.reapplyOnWake()
+                dm.refreshDisplays()
                 try? await Task.sleep(nanoseconds: 500_000_000)
                 for display in dm.displays {
                     // Apply software brightness factor first so GammaService

--- a/Crisp/Crisp-Bridging-Header.h
+++ b/Crisp/Crisp-Bridging-Header.h
@@ -64,6 +64,21 @@ typedef int CGSConnectionID_t;
 extern CGError CGSConfigureDisplayMode(CGSConnectionID_t connection, CGDirectDisplayID display, uint32_t modeID);
 extern CGSConnectionID_t CGSMainConnectionID(void);
 
+// MARK: - SkyLight Private API (physical display disconnect/reconnect, Apple Silicon)
+
+// Enable/disable an individual display inside a CGBeginDisplayConfiguration transaction.
+// On Apple Silicon (macOS 13+) disabling performs a true hardware disconnect (identical to
+// clamshell): the display is removed from CGGetOnlineDisplayList / CGGetActiveDisplayList.
+extern CGError SLSConfigureDisplayEnabled(CGDisplayConfigRef config,
+                                          CGDirectDisplayID display,
+                                          bool enabled);
+
+// Enumerates ALL displays including ones disabled via SLSConfigureDisplayEnabled. Required to
+// recover a disabled display's ID for reconnect, since CGGetOnlineDisplayList omits it.
+extern CGError SLSGetDisplayList(uint32_t maxDisplays,
+                                 CGDirectDisplayID *displays,
+                                 uint32_t *displayCount);
+
 // MARK: - IOAVService Private API (Apple Silicon DDC)
 
 typedef void * IOAVServiceRef;

--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -1,6 +1,76 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Disconnect Display" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "断开显示器"
+          }
+        }
+      }
+    },
+    "Disconnected" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已断开"
+          }
+        }
+      }
+    },
+    "Display configuration failed (CGError %@)." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示器配置失败（CGError %@）。"
+          }
+        }
+      }
+    },
+    "Display not found." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未找到显示器。"
+          }
+        }
+      }
+    },
+    "Physical display disconnect requires Apple Silicon (macOS 13+)." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "断开物理显示器需要 Apple 芯片（macOS 13+）。"
+          }
+        }
+      }
+    },
+    "Reconnect" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新连接"
+          }
+        }
+      }
+    },
+    "Refusing to disconnect: it would leave no active display." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已拒绝断开：这会导致没有可用的显示器。"
+          }
+        }
+      }
+    },
     "%@ color" : {
       "localizations" : {
         "zh-Hans" : {

--- a/Crisp/Services/DisplayManager.swift
+++ b/Crisp/Services/DisplayManager.swift
@@ -118,6 +118,10 @@ class DisplayManager: ObservableObject {
             display.bounds = CGDisplayBounds(display.displayID)
             display.isMain = CGDisplayIsMain(display.displayID) != 0
         }
+
+        // Keep the physical-disconnect list honest: drop any record whose display came back
+        // online (re-plugged, or macOS re-enabled it).
+        PhysicalDisplayToggleService.shared.reconcile()
     }
 
     /// Auto-enables HiDPI plist override for external 2K+ displays that don't have it yet.
@@ -180,13 +184,14 @@ class DisplayManager: ObservableObject {
         }
     }
 
-    /// Toggle a display on/off.
-    /// NOTE: macOS has no public API for enabling/disabling individual displays
-    /// (CGConfigureDisplayEnabled is private). This function always returns false
-    /// to signal to callers that the operation is not supported.
+    /// Disconnects a physical display from the layout (Apple Silicon only) via
+    /// PhysicalDisplayToggleService. Returns false if unsupported or refused (e.g. it would
+    /// leave no active display). The display list refreshes via the reconfiguration callback.
     @discardableResult
-    func toggleDisplay(_ display: DisplayInfo) -> Bool {
-        // No-op: cannot enable/disable displays via public API
+    func disconnectDisplay(_ display: DisplayInfo) async -> Bool {
+        let result = await PhysicalDisplayToggleService.shared.disconnect(display)
+        refreshDisplays()
+        if case .success = result { return true }
         return false
     }
 

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -1,0 +1,238 @@
+import Foundation
+import CoreGraphics
+import ColorSync
+
+/// Disconnects / reconnects REAL (physical) displays on the fly, the way BetterDisplay's
+/// "Disconnect Display" works. This is fundamentally different from VirtualDisplayService:
+/// there we create/destroy a CGVirtualDisplay object; here we toggle an existing hardware
+/// display in/out of the layout via the private SkyLight API `SLSConfigureDisplayEnabled`.
+///
+/// PLATFORM: Apple Silicon + macOS 13+ ONLY. On Intel the API does not perform a true
+/// disconnect. Everything is gated behind `isSupported`.
+///
+/// KEY QUIRK: once a display is disabled it disappears from `CGGetOnlineDisplayList`
+/// (and `CGGetActiveDisplayList`). To reconnect it we must find it again via
+/// `SLSGetDisplayList`, which still enumerates disabled displays. Because the disconnected
+/// display is also gone from DisplayManager's list, this service keeps its own snapshot
+/// (`disconnected`) of what we turned off so the UI can still offer a Reconnect action.
+@MainActor
+final class PhysicalDisplayToggleService: ObservableObject {
+    static let shared = PhysicalDisplayToggleService()
+    private init() {
+        loadDesired()
+    }
+
+    /// Snapshot of a display we disconnected — kept because a disconnected display no longer
+    /// appears in DisplayManager.displays, so we need its metadata to render a Reconnect row.
+    struct DisconnectedDisplay: Identifiable, Codable, Sendable, Equatable {
+        let uuid: String            // stable identity across CGDirectDisplayID reassignment
+        var displayID: CGDirectDisplayID  // last-known ID (used to reconnect)
+        var name: String
+        var width: Int
+        var height: Int
+        var id: String { uuid }
+    }
+
+    enum ToggleError: Error, Sendable, CustomStringConvertible {
+        case unsupportedPlatform
+        case wouldLeaveNoActiveDisplay
+        case configurationFailed(CGError)
+        case displayNotFound
+
+        var description: String {
+            switch self {
+            case .unsupportedPlatform:
+                return String(localized: "Physical display disconnect requires Apple Silicon (macOS 13+).")
+            case .wouldLeaveNoActiveDisplay:
+                return String(localized: "Refusing to disconnect: it would leave no active display.")
+            case .configurationFailed(let err):
+                return String(localized: "Display configuration failed (CGError \(String(err.rawValue))).")
+            case .displayNotFound:
+                return String(localized: "Display not found.")
+            }
+        }
+    }
+
+    // MARK: - State
+
+    /// Displays the user has disconnected and can reconnect. Persisted (by UUID) so wake and
+    /// relaunch can restore the intended state.
+    @Published private(set) var disconnected: [DisconnectedDisplay] = []
+
+    private let desiredKey = "crisp.PhysicalDisconnectedUUIDs"
+
+    // MARK: - Support gate
+
+    /// True only on Apple Silicon. The disconnect API is a no-op / misbehaves on Intel.
+    let isSupported: Bool = {
+        #if arch(arm64)
+        return true
+        #else
+        return false
+        #endif
+    }()
+
+    // MARK: - Queries
+
+    /// True if the display is currently in our disconnected set.
+    func isDisconnected(uuid: String) -> Bool {
+        disconnected.contains { $0.uuid == uuid }
+    }
+
+    /// True if disconnecting `display` right now would leave zero active displays.
+    func wouldLeaveNoActiveDisplay(_ displayID: CGDirectDisplayID) -> Bool {
+        CGDisplayIsActive(displayID) != 0 && activeDisplayCount() <= 1
+    }
+
+    /// All display IDs known to the window server, INCLUDING ones disabled via
+    /// `SLSConfigureDisplayEnabled` (which `CGGetOnlineDisplayList` omits).
+    private func allDisplaysIncludingDisabled() -> [CGDirectDisplayID] {
+        var count: UInt32 = 0
+        guard SLSGetDisplayList(0, nil, &count) == .success, count > 0 else { return [] }
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard SLSGetDisplayList(count, &ids, &count) == .success else { return [] }
+        return Array(ids.prefix(Int(count)))
+    }
+
+    private func activeDisplayCount() -> Int {
+        var count: UInt32 = 0
+        CGGetActiveDisplayList(0, nil, &count)
+        return Int(count)
+    }
+
+    private func uuid(for displayID: CGDirectDisplayID) -> String {
+        if let cf = CGDisplayCreateUUIDFromDisplayID(displayID),
+           let s = CFUUIDCreateString(nil, cf.takeRetainedValue()) {
+            return s as String
+        }
+        return "id-\(displayID)"
+    }
+
+    // MARK: - Disconnect / Reconnect
+
+    /// Disconnects a physical display and records a snapshot for later reconnect. Refuses if it
+    /// would leave zero active displays, so the user can never black out their only screen.
+    @discardableResult
+    func disconnect(_ display: DisplayInfo) async -> Result<Void, ToggleError> {
+        guard isSupported else { return .failure(.unsupportedPlatform) }
+        let displayID = display.displayID
+        if wouldLeaveNoActiveDisplay(displayID) { return .failure(.wouldLeaveNoActiveDisplay) }
+
+        // Snapshot BEFORE disabling — afterwards the display is gone from the normal APIs.
+        let snapshot = DisconnectedDisplay(
+            uuid: display.displayUUID,
+            displayID: displayID,
+            name: display.name,
+            width: display.pixelWidth,
+            height: display.pixelHeight
+        )
+
+        let result = await setEnabled(false, displayID: displayID)
+        if case .success = result {
+            disconnected.removeAll { $0.uuid == snapshot.uuid }
+            disconnected.append(snapshot)
+            saveDesired()
+        }
+        return result
+    }
+
+    /// Reconnects a previously disconnected display and drops it from the disconnected set.
+    @discardableResult
+    func reconnect(uuid: String) async -> Result<Void, ToggleError> {
+        guard isSupported else { return .failure(.unsupportedPlatform) }
+        guard let record = disconnected.first(where: { $0.uuid == uuid }) else {
+            return .failure(.displayNotFound)
+        }
+        // The CGDirectDisplayID can be reassigned; re-resolve by UUID against the full list.
+        let targetID = resolveCurrentID(for: record) ?? record.displayID
+        let result = await setEnabled(true, displayID: targetID)
+        if case .success = result {
+            disconnected.removeAll { $0.uuid == uuid }
+            saveDesired()
+        }
+        return result
+    }
+
+    /// Finds the current CGDirectDisplayID for a disconnected record by matching its UUID
+    /// across the full (incl. disabled) display list.
+    private func resolveCurrentID(for record: DisconnectedDisplay) -> CGDirectDisplayID? {
+        allDisplaysIncludingDisabled().first { uuid(for: $0) == record.uuid }
+    }
+
+    /// Runs SLSConfigureDisplayEnabled inside a CG configuration transaction.
+    /// `.permanently` is the flag the proven implementations (Lunar BlackOut, screen_tune,
+    /// BetterDisplay) use — it commits the change so the disconnect actually takes effect.
+    private func setEnabled(_ enabled: Bool, displayID: CGDirectDisplayID) async -> Result<Void, ToggleError> {
+        await CGHelpers.runWithTimeout(seconds: 10, fallback: .failure(.configurationFailed(.failure))) {
+            var config: CGDisplayConfigRef?
+            guard CGBeginDisplayConfiguration(&config) == .success, let cfg = config else {
+                return .failure(.configurationFailed(.failure))
+            }
+            let setErr = SLSConfigureDisplayEnabled(cfg, displayID, enabled)
+            guard setErr == .success else {
+                CGCancelDisplayConfiguration(cfg)
+                return .failure(.configurationFailed(setErr))
+            }
+            let complete = CGCompleteDisplayConfiguration(cfg, .permanently)
+            guard complete == .success else {
+                CGCancelDisplayConfiguration(cfg)
+                return .failure(.configurationFailed(complete))
+            }
+            return .success(())
+        }
+    }
+
+    // MARK: - Reconcile / Wake restore
+
+    /// Drops records for displays that are back online (e.g. physically re-plugged, or macOS
+    /// re-enabled them). Called from DisplayManager.refreshDisplays so the UI stays honest.
+    func reconcile() {
+        guard !disconnected.isEmpty else { return }
+        var onlineCount: UInt32 = 0
+        CGGetOnlineDisplayList(0, nil, &onlineCount)
+        var onlineIDs = [CGDirectDisplayID](repeating: 0, count: Int(onlineCount))
+        CGGetOnlineDisplayList(onlineCount, &onlineIDs, &onlineCount)
+        let onlineUUIDs = Set(onlineIDs.prefix(Int(onlineCount)).map { uuid(for: $0) })
+
+        let before = disconnected.count
+        disconnected.removeAll { onlineUUIDs.contains($0.uuid) }
+        if disconnected.count != before { saveDesired() }
+    }
+
+    /// Re-applies disconnect for displays macOS re-enabled after wake-from-sleep. Called from
+    /// AppDelegate.onWake after WindowServer settles.
+    func reapplyOnWake() async {
+        guard isSupported, !disconnected.isEmpty else { return }
+        var onlineCount: UInt32 = 0
+        CGGetOnlineDisplayList(0, nil, &onlineCount)
+        var onlineIDs = [CGDirectDisplayID](repeating: 0, count: Int(onlineCount))
+        CGGetOnlineDisplayList(onlineCount, &onlineIDs, &onlineCount)
+        let onlineByUUID = Dictionary(uniqueKeysWithValues:
+            onlineIDs.prefix(Int(onlineCount)).map { (uuid(for: $0), $0) })
+
+        for record in disconnected {
+            // Only re-disconnect ones macOS brought back online, and never the last screen.
+            guard let liveID = onlineByUUID[record.uuid] else { continue }
+            guard !wouldLeaveNoActiveDisplay(liveID) else { continue }
+            _ = await setEnabled(false, displayID: liveID)
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func saveDesired() {
+        guard let data = try? JSONEncoder().encode(disconnected) else { return }
+        UserDefaults.standard.set(data, forKey: desiredKey)
+    }
+
+    private func loadDesired() {
+        guard let data = UserDefaults.standard.data(forKey: desiredKey),
+              let decoded = try? JSONDecoder().decode([DisconnectedDisplay].self, from: data)
+        else { return }
+        disconnected = decoded
+        // By design we do NOT auto-disconnect on launch — restarting the app must never
+        // black out a screen on its own. The loaded list only populates the "Disconnected"
+        // UI so the user can reconnect (or ignore) at their choice. Only the sleep/wake path
+        // re-applies disconnect, via reapplyOnWake().
+    }
+}

--- a/Crisp/Views/DisplayDetailView.swift
+++ b/Crisp/Views/DisplayDetailView.swift
@@ -108,6 +108,9 @@ struct DisplayDetailView: View {
             // Set as main display
             MainDisplayView(display: display)
 
+            // Disconnect this physical display (Apple Silicon only; hidden for the last screen)
+            DisconnectDisplayRow(display: display)
+
             // Notch management (built-in with notch only)
             NotchView(display: display)
 

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -338,6 +338,9 @@ struct MenuBarView: View {
                     }
                 }
 
+                // Displays the user disconnected (they no longer have their own row above).
+                ReconnectDisplaysSection()
+
                 // Combined brightness control (Phase 2)
                 if settings.showCombinedBrightness {
                     sectionDivider

--- a/Crisp/Views/PhysicalDisplayToggleView.swift
+++ b/Crisp/Views/PhysicalDisplayToggleView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+import CoreGraphics
+
+/// Per-display "Disconnect Display" control, shown inside DisplayDetailView below the
+/// "Set as Main Display" row. Apple Silicon only; hidden when disconnecting this display
+/// would leave no active screen. Disconnecting removes the display from the layout (a true
+/// hardware disconnect via SkyLight); it then reappears in ReconnectDisplaysSection.
+struct DisconnectDisplayRow: View {
+    @ObservedObject var display: DisplayInfo
+    @EnvironmentObject var displayManager: DisplayManager
+    @ObservedObject private var service = PhysicalDisplayToggleService.shared
+    @State private var isHovered = false
+    @State private var busy = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        // Feature gate: Apple Silicon only, and never offer to black out the last screen.
+        if service.isSupported, !service.wouldLeaveNoActiveDisplay(display.displayID) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    MenuItemIcon(systemName: "rectangle.slash", color: .orange)
+                    Text("Disconnect Display")
+                        .font(.body)
+                    Spacer()
+                    if busy {
+                        ProgressView().scaleEffect(0.6).frame(width: 16, height: 16)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .menuRowHover(isHovered)
+                .onHover { isHovered = $0 }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    guard !busy else { return }
+                    busy = true
+                    errorMessage = nil
+                    Task { @MainActor in
+                        let result = await service.disconnect(display)
+                        displayManager.refreshDisplays()
+                        if case .failure(let err) = result {
+                            errorMessage = err.description
+                            Task { @MainActor in
+                                try? await Task.sleep(nanoseconds: 3_000_000_000)
+                                errorMessage = nil
+                            }
+                        }
+                        busy = false
+                    }
+                }
+
+                if let msg = errorMessage {
+                    Text(msg)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                        .padding(.horizontal, 12)
+                        .padding(.bottom, 4)
+                }
+            }
+        }
+    }
+}
+
+/// Inline "Disconnected" section for the main display list (MenuBarView). Lists displays the
+/// user disconnected and offers a Reconnect action for each. Rendered only when the
+/// disconnected set is non-empty, since a disconnected display no longer has its own row.
+struct ReconnectDisplaysSection: View {
+    @EnvironmentObject var displayManager: DisplayManager
+    @ObservedObject private var service = PhysicalDisplayToggleService.shared
+    @State private var busyUUIDs: Set<String> = []
+
+    var body: some View {
+        if !service.disconnected.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Disconnected")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.top, 4)
+                    .padding(.bottom, 2)
+
+                ForEach(service.disconnected) { record in
+                    let busy = busyUUIDs.contains(record.uuid)
+                    HStack(spacing: 8) {
+                        MenuItemIcon(systemName: "rectangle.slash", color: .secondary)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(record.name).font(.body).lineLimit(1)
+                            Text("\(record.width)×\(record.height)")
+                                .font(.caption2).foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        if busy {
+                            ProgressView().scaleEffect(0.6).frame(width: 16, height: 16)
+                        } else {
+                            Button("Reconnect") { reconnect(record) }
+                                .buttonStyle(.borderless)
+                                .foregroundColor(.green)
+                                .font(.caption)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                }
+            }
+        }
+    }
+
+    private func reconnect(_ record: PhysicalDisplayToggleService.DisconnectedDisplay) {
+        guard !busyUUIDs.contains(record.uuid) else { return }
+        busyUUIDs.insert(record.uuid)
+        Task { @MainActor in
+            _ = await service.reconnect(uuid: record.uuid)
+            displayManager.refreshDisplays()
+            busyUUIDs.remove(record.uuid)
+        }
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ xcodebuild \
     -configuration Release \
     archive \
     -archivePath "$ARCHIVE_PATH" \
-    | grep -E "error:|warning:|Build succeeded|** ARCHIVE"
+    | grep -E "error:|warning:|Build succeeded|ARCHIVE"
 
 echo "==> Exporting .app…"
 xcodebuild \

--- a/project.yml
+++ b/project.yml
@@ -36,5 +36,10 @@ targets:
         CODE_SIGN_IDENTITY: "Apple Development"
         SWIFT_STRICT_CONCURRENCY: minimal
         SWIFT_OBJC_BRIDGING_HEADER: Crisp/Crisp-Bridging-Header.h
+        # SLSConfigureDisplayEnabled / SLSGetDisplayList live in the private
+        # SkyLight.framework (physical display disconnect). SkyLight is already
+        # loaded in-process via AppKit, so mark just these two symbols as
+        # resolved-at-runtime instead of hard-linking a private framework path.
+        OTHER_LDFLAGS: "-Wl,-U,_SLSConfigureDisplayEnabled -Wl,-U,_SLSGetDisplayList"
         GENERATE_INFOPLIST_FILE: YES
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon


### PR DESCRIPTION
# Add on-the-fly display disconnect/reconnect (virtual + physical)

## Summary

Adds BetterDisplay-style **on-the-fly disconnect/reconnect** for displays, in two
independent layers:

1. **Virtual displays** — a per-config connect/disconnect toggle (previously you could only
   create/delete a config), plus a fix that gives each virtual display a stable, unique
   identity so macOS can restore its arrangement across a reconnect.
2. **Physical displays** — true hardware disconnect/reconnect of real monitors on Apple
   Silicon via the private SkyLight API `SLSConfigureDisplayEnabled`, matching BetterDisplay's
   "Disconnect Display" feature. A disconnected display is removed from the layout (identical
   to clamshell) and can be reconnected from the menu.

Also includes one unrelated one-line fix to `build.sh` (see below).

## Motivation

Crisp already had the core virtual-display machinery (`CGVirtualDisplay` create/destroy) but
exposed it only as "create config / delete config" — there was no way to toggle a saved
virtual display on and off without deleting it. And there was no support at all for
disconnecting a **physical** display; the old `DisplayManager.toggleDisplay` was a dead stub
that always returned `false`.

## What changed

### 1. Virtual display connect/disconnect toggle

- `VirtualDisplayService.setConnected(_:configID:)` — a thin primitive over the existing
  `create()`/`destroy()` that connects/disconnects a **saved** config without mutating the
  configs list. connect = `create()` (system sees an attach); disconnect = `destroy()` (ARC
  releases the `CGVirtualDisplay`, system sees a detach).
- `VirtualDisplayView` — the static "Active" badge on each config row is replaced with a
  switch, with a per-row busy state (a `ProgressView`) while the blocking create/destroy call
  is in flight. Delete is unchanged.

### 2. Stable, unique virtual-display identity (bug fix)

Previously **every** virtual display was created with the same hardcoded
`productID = 0x0001 / serialNum = 0x0001`. macOS keys a display's remembered arrangement and
resolution off `vendorID/productID/serialNum`, so identical values mean two virtual displays
collide and their layout can't be restored reliably on reconnect.

- `VirtualDisplayService.stableIdentity(for:)` now derives a deterministic, effectively-unique
  `(productID, serialNum)` pair from `config.id` (the config UUID), forced non-zero.
- The descriptor `name` now uses the config's name instead of a hardcoded "Crisp Virtual".

### 3. Physical display disconnect/reconnect (Apple Silicon)

- **`Crisp-Bridging-Header.h`** — declares two private SkyLight functions:
  - `SLSConfigureDisplayEnabled(config, display, enabled)` — enable/disable a display inside a
    CG configuration transaction. On Apple Silicon this is a true hardware disconnect.
  - `SLSGetDisplayList(...)` — enumerates **all** displays including disabled ones. Required
    because a disabled display disappears from `CGGetOnlineDisplayList`, so we need this to
    recover its ID for reconnect.
- **`PhysicalDisplayToggleService`** (new) — a `@MainActor` `ObservableObject` singleton:
  - `disconnect(_:)` / `reconnect(uuid:)`, wrapped in
    `CGBeginDisplayConfiguration` → `SLSConfigureDisplayEnabled` →
    `CGCompleteDisplayConfiguration(.permanently)` (the pattern used by Lunar's BlackOut and
    screen_tune).
  - `@Published disconnected: [DisconnectedDisplay]` — a snapshot (UUID/name/resolution) of
    each display we turned off, since a disconnected display is no longer in
    `DisplayManager.displays`. Persisted to `UserDefaults`.
  - Safety: **Apple Silicon only** (gated on `isSupported`), and it **refuses** to disconnect
    a display if doing so would leave zero active displays.
  - `reconcile()` — drops records for displays that came back online.
  - `reapplyOnWake()` — re-disconnects displays that macOS re-enabled after sleep/wake.
  - Reconnect re-resolves the current `CGDirectDisplayID` by UUID, since IDs can be reassigned.
- **`PhysicalDisplayToggleView`** (new) — two integrated UI pieces:
  - `DisconnectDisplayRow` — a "Disconnect Display" row shown inside each display's detail
    view (below "Set as Main Display"), gated on Apple Silicon and hidden for the last screen.
  - `ReconnectDisplaysSection` — a "Disconnected" section under the main display list that
    lists disconnected displays with a Reconnect action (they no longer have their own row).
- **`DisplayManager`**:
  - `refreshDisplays()` calls `PhysicalDisplayToggleService.shared.reconcile()`.
  - The dead `toggleDisplay` stub is replaced by `disconnectDisplay(_:)` that delegates to the
    service.
- **`AppDelegate.onWake`** — after the existing 2s WindowServer-settle delay, calls
  `reapplyOnWake()` so a sleep/wake cycle doesn't silently re-enable a disconnected display.
- **`project.yml`** — `OTHER_LDFLAGS` marks the two `SLS*` symbols as resolved-at-runtime
  (`-Wl,-U,...`). SkyLight is already loaded in-process via AppKit, so this avoids hard-linking
  a private framework path.

### Design decision: no auto-disconnect on launch

On relaunch the persisted list is loaded **for display only** — the app never blacks out a
screen by itself at startup. The user reconnects (or ignores) from the "Disconnected" section.
Only the sleep/wake path re-applies a disconnect (via `reapplyOnWake()`).

### Unrelated fix

- **`build.sh`** — the archive-output `grep -E` filter contained `** ARCHIVE`, an invalid
  regex (`**`) that made BSD grep abort with `repetition-operator operand invalid` and swallow
  the real xcodebuild error. Changed to `ARCHIVE`. Not part of the display feature, but small
  and it unblocks reading real build errors.

## Platform / requirements

- **Physical** disconnect/reconnect requires **Apple Silicon + macOS 13+**. On Intel the API
  does not perform a true disconnect, so the feature is hidden there.
- **Virtual** display changes work everywhere the existing feature does.
- Uses private, undocumented APIs (`CGVirtualDisplay`, `SLSConfigureDisplayEnabled`,
  `SLSGetDisplayList`). Not App Store compatible — consistent with Crisp already being
  distributed unsigned. Field names/behavior may change across major macOS versions.

## Files changed

New:
- `Crisp/Services/PhysicalDisplayToggleService.swift` (238 lines)
- `Crisp/Views/PhysicalDisplayToggleView.swift` (117 lines)

Modified:
- `Crisp/Crisp-Bridging-Header.h` — SkyLight declarations
- `Crisp/Services/VirtualDisplayService.swift` — `setConnected`, `stableIdentity`
- `Crisp/Views/VirtualDisplayView.swift` — connect/disconnect toggle
- `Crisp/Services/DisplayManager.swift` — `reconcile()` call, `disconnectDisplay`
- `Crisp/Views/DisplayDetailView.swift` — `DisconnectDisplayRow`
- `Crisp/Views/MenuBarView.swift` — `ReconnectDisplaysSection`
- `Crisp/App/AppDelegate.swift` — `reapplyOnWake()` on wake
- `project.yml` — `OTHER_LDFLAGS` for SkyLight symbols
- `.gitignore` — ignore the `Crisp-bin` dev-loop artifact
- `build.sh` — unrelated grep fix

## Testing

- Builds clean with `xcodebuild ... CODE_SIGNING_ALLOWED=NO` (full Xcode) — **BUILD
  SUCCEEDED**, no warnings in the new files. Also builds via the Command Line Tools `swiftc`
  path in `docs/BUILDING.md`.
- Manually verified on Apple Silicon (M-series, macOS 15.7) with two external displays:
  - Disconnect removes a display from the layout (true hardware disconnect, not just dimming);
    it appears in the "Disconnected" section and Reconnect restores it.
  - Layout is restored on reconnect.
  - Disconnect is refused / hidden for the last remaining active display.
  - Virtual display toggle connects/disconnects a saved config without deleting it.

### Reviewer note / to re-verify

- Sleep/wake `reapplyOnWake()` and cross-relaunch persistence were implemented against the
  verified disconnect primitive but should get one more pass on the reviewer's hardware.
