### PR TITLE
Fix stale color profile subtitle after switching profiles

### DIFF
--- a/Crisp/Views/ColorProfileView.swift
+++ b/Crisp/Views/ColorProfileView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// checkmark on the active profile.
 struct ColorProfileView: View {
     @ObservedObject var display: DisplayInfo
+    @Binding var activeProfileName: String
     @State private var profiles: [ICCProfile] = []
     @State private var isLoading: Bool = false
     @State private var selectedPath: URL?
@@ -109,6 +110,8 @@ struct ColorProfileView: View {
                 try? await Task.sleep(nanoseconds: 3_000_000_000)
                 applyError = nil
             }
+        } else if activeProfileName != profile.name {
+            activeProfileName = profile.name
         }
     }
 }

--- a/Crisp/Views/DisplayDetailView.swift
+++ b/Crisp/Views/DisplayDetailView.swift
@@ -9,7 +9,7 @@ struct DisplayDetailView: View {
     @State private var showPreset: Bool = false
     @State private var showColorProfile: Bool = false
     @State private var showImageAdjustment: Bool = false
-    @State private var colorSpaceName: String = ""
+    @State private var activeProfileName: String = ""
     @State private var presetName: String = ""
 
     var body: some View {
@@ -73,13 +73,16 @@ struct DisplayDetailView: View {
                     icon: "paintpalette.fill",
                     iconColor: .purple,
                     label: "Color Profile",
-                    subtitle: colorSpaceName,
+                    subtitle: activeProfileName,
                     isExpanded: $showColorProfile
                 )
 
                 VStack(spacing: 0) {
                     if showColorProfile {
-                        ColorProfileView(display: display)
+                        ColorProfileView(
+                            display: display,
+                            activeProfileName: $activeProfileName
+                        )
                             .padding(.leading, 8)
                             .transition(.opacity)
                     }
@@ -130,10 +133,10 @@ struct DisplayDetailView: View {
             showImageAdjustment = false
         }
         .task(id: display.displayID) {
-            colorSpaceName = ""
+            activeProfileName = ""
             presetName = ""
             guard !Task.isCancelled else { return }
-            colorSpaceName = ColorProfileService.shared.currentColorSpaceName(for: display.displayID)
+            activeProfileName = ColorProfileService.shared.currentColorSpaceName(for: display.displayID)
             let svc = DisplayPresetService.shared
             if let idx = svc.activePresetIndex(for: display.displayID) {
                 presetName = svc.presets(for: display.displayID)
@@ -142,4 +145,3 @@ struct DisplayDetailView: View {
         }
     }
 }
-


### PR DESCRIPTION
## Summary

- Share the active color profile name between the display detail row and the profile picker through a binding.
- Update the row subtitle immediately after ColorSync applies a new profile successfully.
- Preserve the existing subtitle and selection when profile application fails.

## Root cause

DisplayDetailView loaded the subtitle when its display ID task ran, while ColorProfileView managed the picker selection locally. A successful profile change therefore updated the picker state without refreshing the parent subtitle.

## Testing

- Ran a full-project Swift type check.
- Built and launched Crisp 1.2.0 locally on macOS 27.
- Switched an external display to the Mi Monitor profile and confirmed that the row subtitle updates immediately.