### PR TITLE
Crisp 1.3.1

### DIFF
--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -201,7 +201,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 self.repositionWorkItem?.cancel()
                 let work = DispatchWorkItem { [weak self] in
                     guard let self, self.isPanelShown, let p = self.panel else { return }
-                    self.positionPanel(p)
+                    self.positionPanel(p, preferOrigin: true)
                 }
                 self.repositionWorkItem = work
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.4, execute: work)
@@ -395,17 +395,43 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// on. Called on open AND whenever screen parameters change (e.g. the
     /// main display switches, which re-origins global coordinates and would
     /// otherwise leave the panel at a stale position).
-    private func positionPanel(_ p: MenuPanel) {
+    /// Display the open panel was summoned on, by stable UUID (displayIDs are
+    /// reassigned across a soft-reconnect). When that display blanks, the status
+    /// item's window migrates to a surviving display and the post-storm reposition
+    /// would drag the panel there for good; `preferOrigin` re-anchors to this
+    /// display once it's back online.
+    private var panelOriginDisplayUUID: String?
+
+    private func displayUUID(for displayID: CGDirectDisplayID) -> String? {
+        guard let cfUUID = CGDisplayCreateUUIDFromDisplayID(displayID) else { return nil }
+        return CFUUIDCreateString(nil, cfUUID.takeRetainedValue()) as String
+    }
+
+    private func positionPanel(_ p: MenuPanel, preferOrigin: Bool = false) {
         let size = p.lastContentSize ?? p.frame.size
         guard let btnWindow = statusItem?.button?.window else { return }
         let btnFrame = btnWindow.frame
-        let screen = btnWindow.screen ?? NSScreen.main
+        let btnScreen = btnWindow.screen ?? NSScreen.main
+        var screen = btnScreen
+        var anchorMidX = btnFrame.midX
+        var topY = btnFrame.minY - 1
+        // After a reconnect storm, prefer the display the panel was opened on if
+        // it's online again. The menu bar mirrors across displays, so mirror the
+        // status item's offset from the right edge onto the origin screen.
+        if preferOrigin,
+           let uuid = panelOriginDisplayUUID,
+           let bs = btnScreen,
+           let origin = NSScreen.screens.first(where: { displayUUID(for: $0.displayID) == uuid }),
+           origin != bs {
+            screen = origin
+            anchorMidX = origin.frame.maxX - (bs.frame.maxX - btnFrame.midX)
+            topY = origin.visibleFrame.maxY - 1
+        }
         displayManager.activePanelDisplayID = screen?.displayID
-        var x = btnFrame.midX - size.width / 2
+        var x = anchorMidX - size.width / 2
         if let vis = screen?.visibleFrame {
             x = min(max(x, vis.minX + 8), vis.maxX - size.width - 8)
         }
-        let topY = btnFrame.minY - 1
         if let vis = screen?.visibleFrame {
             // Cap like the native Wi-Fi panel: grow to ~80% of the drop below
             // the status item, then scroll, leaving real breathing room at
@@ -428,6 +454,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // Native menus appear at full size with all content visible at once;
         // only size changes AFTER opening animate.
         positionPanel(p)
+        // Remember where this open happened (fresh each open; the menu bar the
+        // user clicked is the anchor, not wherever a previous open ended up).
+        panelOriginDisplayUUID = displayManager.activePanelDisplayID.flatMap { displayUUID(for: $0) }
 
         p.ignoresMouseEvents = false
         // First open only: fade in briefly so the panel's one-time on-screen costs

--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -559,6 +559,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             // tracking menu or an in-panel confirmation alert, which take key.
             if PanelOpenGuard.suppressAutoDismiss || PanelOpenGuard.isMenuTracking
                 || PanelOpenGuard.isConfirmationActive { return }
+            // A soft-reconnect just settled: focus steals in its wake are system
+            // noise, not the user clicking away (those still close via the global
+            // click monitor, which ignores this grace).
+            if Date() < PanelOpenGuard.resignKeyGraceUntil { return }
             // Same overlay caveat as the click monitor: during the crossfade
             // the snapshot window can steal key while the user is clicking
             // INSIDE the panel; don't treat that as clicking away.

--- a/Crisp/Views/DisplayModeListView.swift
+++ b/Crisp/Views/DisplayModeListView.swift
@@ -654,6 +654,12 @@ struct DisplayModeSection: View {
                 // The reconnect rebuilt this display's row (fresh, collapsed). Ask the menu to
                 // re-expand it and reopen Resolution, so the user lands back where they were.
                 displayManager.pendingResolutionExpandUUID = targetUUID
+                // The settle storm keeps stealing key for a few seconds after the
+                // suppression window (the defer above) releases; the makeKey above
+                // re-armed resign-key, so a late steal would close the panel right
+                // after a successful toggle. Ignore bare resigns for a grace period;
+                // real outside clicks still dismiss via the global click monitor.
+                PanelOpenGuard.resignKeyGraceUntil = Date().addingTimeInterval(5)
             }
             smoothBusy = false
         }

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -49,6 +49,12 @@ enum PanelOpenGuard {
     /// if another window started since, so it can't clear that newer window
     /// mid-flight (the smooth-scaling soft-reconnect holds one for ~2s).
     static var suppressGeneration = 0
+    /// Ignore bare resign-key dismissals until this instant. After a smooth-scaling
+    /// soft-reconnect completes (and suppressAutoDismiss releases), WindowServer keeps
+    /// stealing key focus for a few seconds while the display settles; a late steal
+    /// would close the panel out from under the user. Genuine outside clicks still
+    /// dismiss through the global click monitor, which does not consult this.
+    static var resignKeyGraceUntil = Date.distantPast
     /// True while an AppKit menu (a SwiftUI `Menu`, e.g. a row's ⋯) is tracking.
     /// Those popups render in their own window outside the panel frame, so a click
     /// on a menu item reads as an outside-click; suppress dismissal while tracking.

--- a/project.yml
+++ b/project.yml
@@ -24,8 +24,8 @@ targets:
         # Without an explicit MARKETING_VERSION the generated Info.plist omits
         # CFBundleShortVersionString and the app self-reports 1.0.0 forever,
         # which keeps the update banner visible even on the latest release.
-        MARKETING_VERSION: "1.3.0"
-        CURRENT_PROJECT_VERSION: "3"
+        MARKETING_VERSION: "1.3.1"
+        CURRENT_PROJECT_VERSION: "4"
         INFOPLIST_KEY_LSUIElement: true
         INFOPLIST_KEY_NSHumanReadableCopyright: "Crisp - Free & Open Source"
         INFOPLIST_KEY_NSAppleEventsUsageDescription: "Crisp uses System Events to switch Dark Mode with the system's animated transition."


### PR DESCRIPTION
Patch release on top of 1.3.0. Two fixes around the smooth-scaling soft-reconnect:

- Ignore late resign-key steals after a smooth-scaling toggle, so the panel no longer closes on its own a few seconds after the toggle succeeds. (d8d1a86)
- Return the panel to the display you opened it on after the toggle, instead of leaving it on whichever display macOS moved it to while the toggled screen was briefly dark. (203fe24)

Also bumps MARKETING_VERSION to 1.3.1 (build 4).

Release notes: docs/RELEASE_NOTES_1.3.1.md (delta plus the full 1.3.0 notes below it).