### PR TITLE
Crisp 1.3.2

### DIFF
--- a/Crisp/Services/BrightnessKeyService.swift
+++ b/Crisp/Services/BrightnessKeyService.swift
@@ -34,6 +34,11 @@ final class BrightnessKeyService: @unchecked Sendable {
     private var runLoopSource: CFRunLoopSource?
     /// Retained Unmanaged reference passed into the C callback. Released in stop().
     private var selfRetained: Unmanaged<BrightnessKeyService>?
+    /// Monotonic time (systemUptime) of the last tap disable. retryUntilArmed waits a short
+    /// settle delay past this before re-arming, so a revoke (whose trust state briefly lags)
+    /// resolves before we put an active session tap back in the pipeline. Avoids the kome
+    /// input-freeze churn.
+    private var disabledAt: TimeInterval = 0
 
     // MARK: - NX Media Key Constants
     // Marked nonisolated(unsafe) so they can be read from the nonisolated callback method.
@@ -88,10 +93,12 @@ final class BrightnessKeyService: @unchecked Sendable {
         self.eventTap = tap
         self.runLoopSource = source
         stopRetrying()
+        startTrustWatchdog()
     }
 
     /// Removes the event tap and releases the retained self reference.
     func stop() {
+        stopTrustWatchdog()
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
             if let source = runLoopSource {
@@ -121,16 +128,30 @@ final class BrightnessKeyService: @unchecked Sendable {
         if pollTimer == nil {
             pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] timer in
                 guard let self else { timer.invalidate(); return }
-                self.start()
+                self.armIfSettled()
             }
         }
         if activationObserver == nil {
             activationObserver = NotificationCenter.default.addObserver(
                 forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
             ) { [weak self] _ in
-                MainActor.assumeIsolated { self?.start() }
+                MainActor.assumeIsolated { self?.armIfSettled() }
             }
         }
+    }
+
+    /// How long to wait after a tap disable before trying to re-arm, so an Accessibility revoke
+    /// has fully resolved before we put an active session tap back in the pipeline. Long enough
+    /// to outlast the AXIsProcessTrusted()/TCC lag that follows a revoke. (kome)
+    private static let rearmSettleDelay: TimeInterval = 3.0
+
+    /// Re-arm the tap, but not until any recent disable has had time to settle. Re-creating an
+    /// active session tap while a revoke is still propagating is exactly what churns and freezes
+    /// input; once settled, tapCreate cleanly succeeds (still granted) or fails (revoked). On the
+    /// initial grant flow disabledAt is 0, so this arms immediately with no delay.
+    private func armIfSettled() {
+        guard ProcessInfo.processInfo.systemUptime - disabledAt >= Self.rearmSettleDelay else { return }
+        start()
     }
 
     private func stopRetrying() {
@@ -140,6 +161,33 @@ final class BrightnessKeyService: @unchecked Sendable {
             NotificationCenter.default.removeObserver(obs)
             activationObserver = nil
         }
+    }
+
+    // MARK: - Trust watchdog
+    // The freeze on an Accessibility revoke is the WindowServer holding the event stream for
+    // ~1s while it force-times-out our now-untrusted active session tap. Our own teardown is
+    // instant, but it only runs after that timeout event reaches us, i.e. after the freeze. So
+    // while armed we poll trust faster than that ~1s timeout and, the instant it drops, tear our
+    // tap out ourselves so the WindowServer has nothing doomed to wait on. (kome)
+
+    private var trustWatchdog: Timer?
+
+    private func startTrustWatchdog() {
+        guard trustWatchdog == nil else { return }
+        // ponytail: 0.5s poll, well inside the ~1s WindowServer tap-timeout; AXIsProcessTrusted()
+        // is a cheap TCC lookup so 2x/sec while armed is negligible.
+        trustWatchdog = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] timer in
+            guard let self else { timer.invalidate(); return }
+            guard self.eventTap != nil, !AXIsProcessTrusted() else { return }
+            self.disabledAt = ProcessInfo.processInfo.systemUptime
+            self.stop()
+            self.retryUntilArmed()
+        }
+    }
+
+    private func stopTrustWatchdog() {
+        trustWatchdog?.invalidate()
+        trustWatchdog = nil
     }
 
     // MARK: - Event Handling
@@ -153,22 +201,24 @@ final class BrightnessKeyService: @unchecked Sendable {
         type: CGEventType,
         event: CGEvent
     ) -> Unmanaged<CGEvent>? {
-        // The system disabled the tap. If we still hold Accessibility this is a normal
-        // timeout, so re-enable it. If trust was revoked (the user unchecked Crisp under
-        // Privacy > Accessibility), re-enabling churns: the system disables it again at once,
-        // and an active .cgSessionEventTap stuck in that disable/re-enable loop stalls the
-        // window-server input pipeline and freezes clicks system-wide. So tear the tap down
-        // instead and let retryUntilArmed re-install it cleanly once trust returns. (kome)
+        // The system disabled the tap. Never re-enable it here. When the user revokes
+        // Accessibility (unchecks Crisp under Privacy > Accessibility) the system force-disables
+        // the tap, but AXIsProcessTrusted() keeps returning a cached `true` for a second or two.
+        // So any "re-enable while still trusted" (or eager re-create) churns against that
+        // force-disable for the whole lag window, and an active .cgSessionEventTap stuck in that
+        // loop stalls the window-server input pipeline and freezes clicks system-wide. Instead
+        // tear the tap fully out of the run loop at once, which frees input immediately, and let
+        // retryUntilArmed re-install it after a short settle delay, once trust has actually
+        // resolved (tapCreate then cleanly succeeds if still granted, or fails if revoked). A
+        // genuine timeout (rare, only if the main thread stalled past ~1s) recovers the same way,
+        // just a few seconds later, without ever risking the freeze. (kome)
         if type.rawValue == CGEventType.tapDisabledByTimeout.rawValue ||
            type.rawValue == CGEventType.tapDisabledByUserInput.rawValue {
             DispatchQueue.main.async {
                 MainActor.assumeIsolated {
-                    if AXIsProcessTrusted(), let tap = self.eventTap {
-                        CGEvent.tapEnable(tap: tap, enable: true)
-                    } else {
-                        self.stop()
-                        self.retryUntilArmed()
-                    }
+                    self.disabledAt = ProcessInfo.processInfo.systemUptime
+                    self.stop()
+                    self.retryUntilArmed()
                 }
             }
             return Unmanaged.passRetained(event)

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -743,6 +743,12 @@ struct SettingsView: View {
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 4)
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+                // Returning from System Settings: if access still isn't granted (declined, or a
+                // stale grant from a differently-signed build), un-stick the toggle so it can't
+                // sit "on" while the caption still says access is needed and no target menu shows.
+                if !AXIsProcessTrusted() { requesting = false }
+            }
         }
 
         private func requestAccess() {
@@ -880,6 +886,12 @@ struct SettingsView: View {
         .onReceive(NotificationCenter.default.publisher(for: .crispPanelDidOpen)) { _ in
             // Re-read trust on every open so the section reflects a grant/revoke made in
             // System Settings since the last open (the content mounts once). (vx44)
+            isTrusted = AXIsProcessTrusted()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            // Also refresh when the app reactivates (e.g. returning from System Settings after
+            // granting), so the section flips from the opt-in toggle to the target menu without
+            // needing the panel closed and reopened. (brightness-keys zombie toggle fix)
             isTrusted = AXIsProcessTrusted()
         }
         .onReceive(NotificationCenter.default.publisher(for: .crispPanelDidClose)) { _ in

--- a/project.yml
+++ b/project.yml
@@ -24,8 +24,8 @@ targets:
         # Without an explicit MARKETING_VERSION the generated Info.plist omits
         # CFBundleShortVersionString and the app self-reports 1.0.0 forever,
         # which keeps the update banner visible even on the latest release.
-        MARKETING_VERSION: "1.3.1"
-        CURRENT_PROJECT_VERSION: "4"
+        MARKETING_VERSION: "1.3.2"
+        CURRENT_PROJECT_VERSION: "5"
         INFOPLIST_KEY_LSUIElement: true
         INFOPLIST_KEY_NSHumanReadableCopyright: "Crisp - Free & Open Source"
         INFOPLIST_KEY_NSAppleEventsUsageDescription: "Crisp uses System Events to switch Dark Mode with the system's animated transition."


### PR DESCRIPTION
Patch release fixing two brightness-keys bugs left in 1.3.0/1.3.1, both confirmed by manual testing on an M4 Max with an external AOC Q27G3XMN.

## Fixes

**1. Brightness-keys toggle stuck in on/needs-access state** (`MenuBarView.swift`)
The "Use brightness keys on external displays" toggle was bound to a local `requesting` flag decoupled from `AXIsProcessTrusted()`. Tapping it on while the grant wasn't effective (declined, or a stale grant from a differently-signed build) left it visibly on while the section still showed the "needs Accessibility access" hint and no display menu. Now refreshed on `didBecomeActive`, so it always reflects the real access state.

**2. System-wide input freeze on Accessibility revoke** (`BrightnessKeyService.swift`)
Revoking Crisp's Accessibility access while running froze the pointer for a few seconds. Root cause (proven with an `os_log` timeline): the WindowServer holds the event stream ~1s to force-time-out our now-untrusted active `.cgSessionEventTap` (`tapDisabledByTimeout`), and that hold happens before any disable event reaches us. Fix: a trust watchdog (0.5s poll while armed) tears our tap out the instant `AXIsProcessTrusted()` drops, beating the WindowServer timeout so it has nothing doomed to wait on. Also removes the old re-enable churn (tear down + settle-delay retry instead).

## Version
`MARKETING_VERSION` 1.3.1 -> 1.3.2, `CURRENT_PROJECT_VERSION` 4 -> 5.

## Testing
- Zombie toggle: confirmed across grant/decline/stale-grant scenarios.
- Revoke freeze: confirmed gone across multiple revoke/re-grant cycles; log evidence shows the `reason=timeout` disable line replaced by an earlier `watchdog: proactive teardown`.