### PR TITLE
Lower minimum macOS from 15 to 14 (Sonoma)

### DIFF
--- a/Crisp/Views/BrightnessSliderView.swift
+++ b/Crisp/Views/BrightnessSliderView.swift
@@ -221,9 +221,19 @@ struct BrightnessSliderView: View {
             set { progress = newValue }
         }
         func body(content: Content) -> some View {
-            content.tint(progress <= 0
-                ? Color.accentColor
-                : Color.accentColor.mix(with: .yellow, by: min(1.0, progress)))
+            content.tint(boostTint)
+        }
+
+        private var boostTint: Color {
+            guard progress > 0 else { return .accentColor }
+            let fraction = min(1.0, progress)
+            if #available(macOS 15.0, *) {
+                return Color.accentColor.mix(with: .yellow, by: fraction)
+            }
+            // macOS 14: Color.mix is 15+; AppKit's blend interpolates in a
+            // slightly different space, indistinguishable across a tint ramp.
+            return Color(nsColor: NSColor.controlAccentColor
+                .blended(withFraction: fraction, of: .systemYellow) ?? .controlAccentColor)
         }
     }
 

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -148,6 +148,23 @@ extension View {
     }
 }
 
+extension View {
+    /// Keep scroll content pinned to the top on first layout and while its
+    /// size animates; without this the scroll offset transiently re-anchors
+    /// during expansion and the whole panel content shifts up for a moment.
+    /// The role-scoped anchors are macOS 15+; on 14 the all-roles anchor is
+    /// close enough (it additionally top-aligns short content, which the
+    /// panel fills anyway).
+    @ViewBuilder func topAnchoredScroll() -> some View {
+        if #available(macOS 15.0, *) {
+            self.defaultScrollAnchor(.top, for: .sizeChanges)
+                .defaultScrollAnchor(.top, for: .initialOffset)
+        } else {
+            self.defaultScrollAnchor(.top)
+        }
+    }
+}
+
 // MARK: - SectionDivider
 
 /// The one canonical section separator, used between every group across the
@@ -590,11 +607,7 @@ struct MenuBarView: View {
         }
         // Native menus don't rubber-band unless they actually scroll
         .scrollBounceBehavior(.basedOnSize)
-        // Keep content pinned to the top while its size animates; without
-        // this the scroll offset transiently re-anchors during expansion and
-        // the whole panel content shifts up for a moment.
-        .defaultScrollAnchor(.top, for: .sizeChanges)
-        .defaultScrollAnchor(.top, for: .initialOffset)
+        .topAnchoredScroll()
         // macOS 26 Tahoe: MenuBarExtra(.window) gives ScrollView an ideal height of 0;
         // without an explicit height it collapses into an empty pill. Measure the actual content height so the popover fits its content, capping at 600 before scrolling;
         // if measurement fails (reports 0), fall back to a fixed 520

--- a/project.yml
+++ b/project.yml
@@ -2,7 +2,7 @@ name: Crisp
 options:
   bundleIdPrefix: com.crisp
   deploymentTarget:
-    macOS: "15.0"
+    macOS: "14.0"
   developmentLanguage: en
   knownRegions:
     - en
@@ -13,7 +13,7 @@ targets:
   Crisp:
     type: application
     platform: macOS
-    deploymentTarget: "15.0"
+    deploymentTarget: "14.0"
     sources:
       - path: Crisp
         excludes:
@@ -46,7 +46,7 @@ targets:
   CrispTests:
     type: bundle.unit-test
     platform: macOS
-    deploymentTarget: "15.0"
+    deploymentTarget: "14.0"
     sources:
       - path: CrispTests
       - path: Crisp/Models/DisplayModeGeometry.swift

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -40,7 +40,7 @@ rm -rf "$BUILD"; mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
 echo "==> Compiling universal binary (arm64 + x86_64)…"
 SRC=$(find Crisp -name '*.swift')
 for a in arm64 x86_64; do
-  swiftc -O -parse-as-library -target "$a-apple-macos15.0" \
+  swiftc -O -parse-as-library -target "$a-apple-macos14.0" \
     -import-objc-header Crisp/Crisp-Bridging-Header.h \
     -Xlinker -U -Xlinker _SLSConfigureDisplayEnabled \
     -Xlinker -U -Xlinker _SLSGetDisplayList \
@@ -88,7 +88,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 	<key>CFBundleLocalizations</key><array>${LOC_XML}</array>
 	<key>CFBundleShortVersionString</key><string>${VERSION}</string>
 	<key>CFBundleVersion</key><string>${VERSION}</string>
-	<key>LSMinimumSystemVersion</key><string>15.0</string>
+	<key>LSMinimumSystemVersion</key><string>14.0</string>
 	<key>LSUIElement</key><true/>
 	<key>NSHumanReadableCopyright</key><string>Crisp - Free &amp; Open Source</string>
 	<key>NSAppleEventsUsageDescription</key><string>Crisp uses System Events to switch Dark Mode with the system's animated transition.</string>


### PR DESCRIPTION
Part of #22.

## What
- Lower the deployment target from 15.0 to 14.0 (project.yml; release.sh `-target` and `LSMinimumSystemVersion`)
- Add macOS 14 fallbacks for the two 15-only API sites:
  - `defaultScrollAnchor(_:for:)` x2 (MenuBarView): falls back to the all-roles `defaultScrollAnchor(_:)`
  - `Color.mix` (boost tint): falls back to `NSColor.blended(withFraction:)`

## Verified
- Typecheck at `-target arm64-apple-macos14.0`: clean
- `./scripts/release.sh` dry run: universal (arm64 + x86_64) build, DMG packaged, `LSMinimumSystemVersion` 14.0
- CI's release dry run compiles at target 14.0, so any new 15-only API use fails CI