### PR TITLE
i18n: fix interpolation-based localization failures and add missing zh-Hans strings

### DIFF
--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -322,6 +322,26 @@
         }
       }
     },
+    ", collapsed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "，已折叠"
+          }
+        }
+      }
+    },
+    ", expanded" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "，已展开"
+          }
+        }
+      }
+    },
     ", main display" : {
       "localizations" : {
         "zh-Hans" : {

--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -322,6 +322,26 @@
         }
       }
     },
+    ", main display" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "，主显示器"
+          }
+        }
+      }
+    },
+    ", selected" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "，已选中"
+          }
+        }
+      }
+    },
     "%@, expanded" : {
       "localizations" : {
         "zh-Hans" : {
@@ -1308,6 +1328,36 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "软件"
+          }
+        }
+      }
+    },
+    "DDC" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DDC"
+          }
+        }
+      }
+    },
+    "Show Volume Sliders" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示音量滑块"
+          }
+        }
+      }
+    },
+    "Speaker volume" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "扬声器音量"
           }
         }
       }

--- a/Crisp/Views/BrightnessSliderView.swift
+++ b/Crisp/Views/BrightnessSliderView.swift
@@ -98,7 +98,13 @@ struct BrightnessSliderView: View {
             }
             .padding(.horizontal, 12)
             .padding(.top, 2)
-            .accessibilityLabel(display.isBuiltin ? "Brightness control mode: System" : "Brightness control mode: \(ddcStatus == true ? "DDC hardware" : "Software emulation")")
+            .accessibilityLabel(
+                display.isBuiltin
+                    ? "Brightness control mode: System"
+                    : (ddcStatus == true
+                        ? "Brightness control mode: DDC hardware"
+                        : "Brightness control mode: Software emulation")
+            )
             }
 
             HStack(spacing: 8) {

--- a/Crisp/Views/DisplayModeListView.swift
+++ b/Crisp/Views/DisplayModeListView.swift
@@ -816,7 +816,7 @@ struct CheckmarkRow: View {
         .onHover { isHovered = $0 }
         .accessibilityLabel(
             isSelected
-                ? "\(NSLocalizedString(label, comment: "")), \(NSLocalizedString(", selected", comment: ""))"
+                ? "\(NSLocalizedString(label, comment: ""))\(NSLocalizedString(", selected", comment: ""))"
                 : NSLocalizedString(label, comment: "")
         )
         .accessibilityAddTraits(.isButton)

--- a/Crisp/Views/DisplayModeListView.swift
+++ b/Crisp/Views/DisplayModeListView.swift
@@ -814,7 +814,11 @@ struct CheckmarkRow: View {
             action()
         }
         .onHover { isHovered = $0 }
-        .accessibilityLabel(isSelected ? "\(label), selected" : label)
+        .accessibilityLabel(
+            isSelected
+                ? "\(NSLocalizedString(label, comment: "")), \(NSLocalizedString(", selected", comment: ""))"
+                : NSLocalizedString(label, comment: "")
+        )
         .accessibilityAddTraits(.isButton)
     }
 }

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -722,7 +722,7 @@ struct DisplayRowView: View {
                 Label("Copy Display Name", systemImage: "doc.on.doc")
             }
         }
-        .accessibilityLabel("Display: \(display.name)\(display.isMain ? ", main display" : "")\(isExpanded ? ", expanded" : ", collapsed")")
+        .accessibilityLabel(Text(verbatim: "Display: \(display.name)\(display.isMain ? NSLocalizedString(", main display", comment: "") : "")\(isExpanded ? NSLocalizedString(", expanded", comment: "") : NSLocalizedString(", collapsed", comment: ""))"))
         .accessibilityHint("Click to expand the control panel")
         .accessibilityAddTraits(.isButton)
     }


### PR DESCRIPTION
Fix three bugs where string interpolation prevented LocalizedStringKey
from matching defined translations:

- BrightnessSliderView: split ternary into three literal branches so
  "Brightness control mode: DDC hardware" and "...Software emulation"
  translations take effect instead of being looked up as "...: %@".
- MenuBarView: use Text(verbatim:) + NSLocalizedString to compose the
  display state accessibility label from individually localized
  fragments (", main display", ", expanded", ", collapsed").
- DisplayModeListView: replace string-interpolated accessibilityLabel
  with explicit NSLocalizedString lookups so both the label and the
  ", selected" suffix are localized.

Add missing zh-Hans keys to Localizable.xcstrings:
- "Show Volume Sliders" -> "显示音量滑块"
- "Speaker volume" -> "扬声器音量"
- "DDC" -> "DDC"
- ", main display" -> "，主显示器"
- ", selected" -> "，已选中"

<!-- Thanks for contributing to Crisp! Keep this short. -->

## What & why
<!-- If this closes an issue, add: Fixes #123 -->


## How tested


## Checklist
- [x] Builds locally (`./dev.sh`, or `./scripts/release.sh v0.0.0-ci` for the full release build)
- [x] Added/updated `Crisp/Resources/Localizable.xcstrings` for any new user-facing strings
- [ ] Screenshot or short clip for any UI change
