### PR TITLE
fix: render display-default refresh rate as 60hz

### DIFF
--- a/Crisp/Models/DisplayMode.swift
+++ b/Crisp/Models/DisplayMode.swift
@@ -29,13 +29,7 @@ struct DisplayMode: Identifiable, Equatable {
     }
 
     var refreshRateString: String {
-        guard refreshRate > 0 else { return "-- Hz" }
-        let rounded = refreshRate.rounded()
-        // Whole-number timings render clean ("60Hz"). NTSC fractional timings keep two
-        // decimals ("59.94Hz", "47.95Hz") so they don't collapse onto the neighbouring
-        // whole rate and show up as duplicate rows, matching System Settings.
-        if abs(refreshRate - rounded) < 0.01 { return "\(Int(rounded))Hz" }
-        return String(format: "%.2fHz", refreshRate)
+        RefreshRateFormat.label(refreshRate)
     }
 
     // MARK: - Enumeration helpers

--- a/Crisp/Models/RefreshRateFormat.swift
+++ b/Crisp/Models/RefreshRateFormat.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Pure refresh-rate label formatter, extracted from `DisplayMode.refreshRateString`
+/// for headless XCTest (the rest of `DisplayMode` reaches private CGS APIs through the
+/// bridging header, which the test target does not carry — see `project.yml`). Mirrors
+/// what System Settings shows:
+///   - a zero ("display default") rate renders as `60Hz`, honouring the
+///     `DisplayMode.refreshRate` contract ("0 means display default, shown as 60");
+///   - whole-number timings render clean (`60Hz`);
+///   - NTSC fractional timings keep two decimals (`59.94Hz`, `47.95Hz`) so they don't
+///     collapse onto the neighbouring whole rate and show up as duplicate rows.
+enum RefreshRateFormat {
+    /// Formats a refresh rate (in Hz) for display.
+    static func label(_ refreshRate: Double) -> String {
+        // CGDisplayMode.refreshRate reports 0 for the display's default timing. macOS
+        // treats that as the panel default (60 Hz for external monitors), so render it
+        // as 60 Hz rather than a placeholder that reads as broken next to real rates.
+        // The built-in's variable refresh is relabelled to "ProMotion" upstream.
+        guard refreshRate > 0 else { return "60Hz" }
+        let rounded = refreshRate.rounded()
+        if abs(refreshRate - rounded) < 0.01 { return "\(Int(rounded))Hz" }
+        return String(format: "%.2fHz", refreshRate)
+    }
+}

--- a/CrispTests/RefreshRateFormatTests.swift
+++ b/CrispTests/RefreshRateFormatTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import CoreGraphics
+
+/// Headless tests for the refresh-rate label formatter.
+///
+/// `RefreshRateFormat` is compiled directly into this test target (see `project.yml`
+/// sources, same route as `DisplayModeGeometry`), so no `@testable import Crisp` is
+/// needed. Each test names the behaviour it pins in a trailing comment.
+final class RefreshRateFormatTests: XCTestCase {
+
+    // MARK: - Display-default (0 Hz)
+
+    /// CGDisplayMode.refreshRate returns 0 for the panel's default timing. It must render
+    /// as the default 60 Hz (honouring `DisplayMode.refreshRate`'s "0 means display
+    /// default, shown as 60" contract), not a placeholder, so a real mode never reads as
+    /// broken next to its labelled siblings.
+    /// Kills mutation: "guard returns the old '-- Hz' placeholder".
+    func testZeroRefreshRateRendersAsDefaultSixty() {
+        XCTAssertEqual(RefreshRateFormat.label(0), "60Hz")
+    }
+
+    /// Negative rates don't occur (CG reports 0 or a positive timing) but the guard must
+    /// still map any non-positive value to the default rather than formatting garbage.
+    func testNegativeRefreshRateFallsBackToDefault() {
+        XCTAssertEqual(RefreshRateFormat.label(-1), "60Hz")
+    }
+
+    // MARK: - Whole-number timings
+
+    /// A clean whole rate renders without a decimal, matching System Settings.
+    func testWholeNumberRendersWithoutDecimals() {
+        XCTAssertEqual(RefreshRateFormat.label(60), "60Hz")
+        XCTAssertEqual(RefreshRateFormat.label(144), "144Hz")
+        XCTAssertEqual(RefreshRateFormat.label(30), "30Hz")
+    }
+
+    /// A rate within the whole-rounding threshold (float noise around an integer) still
+    /// collapses to the clean integer label.
+    /// Kills mutation: "threshold tightened so 59.999 stops rendering as 60Hz".
+    func testNearWholeRateCollapsesToInteger() {
+        XCTAssertEqual(RefreshRateFormat.label(59.999), "60Hz")
+        XCTAssertEqual(RefreshRateFormat.label(60.005), "60Hz")
+    }
+
+    // MARK: - NTSC fractional timings
+
+    /// NTSC fractional timings keep two decimals so they don't collapse onto the
+    /// neighbouring whole rate (59.94 vs 60) and duplicate a row, matching System Settings.
+    /// Kills mutation: "fractional branch lost, everything rounds to a whole Hz".
+    func testNTSCFractionalRatesKeepTwoDecimals() {
+        XCTAssertEqual(RefreshRateFormat.label(59.94), "59.94Hz")
+        XCTAssertEqual(RefreshRateFormat.label(29.97), "29.97Hz")
+        XCTAssertEqual(RefreshRateFormat.label(119.88), "119.88Hz")
+    }
+
+    /// Cinema 23.976 rounds to two decimals as 23.98 (NSString %.2f rounding), not the
+    /// raw 23.976 and not a collapse to 24.
+    func testCinemaRateRoundsToTwoDecimals() {
+        XCTAssertEqual(RefreshRateFormat.label(23.976), "23.98Hz")
+        XCTAssertEqual(RefreshRateFormat.label(47.952), "47.95Hz")
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -51,6 +51,7 @@ targets:
       - path: CrispTests
       - path: Crisp/Models/DisplayModeGeometry.swift
       - path: Crisp/Models/DDCServiceMatcher.swift
+      - path: Crisp/Models/RefreshRateFormat.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.crisp.tests


### PR DESCRIPTION
## What & why
- `CGDisplayMode.refreshRate` returns `0` for a display's default timing. `DisplayMode.refreshRateString` rendered that as `\"-- Hz\"`, contradicting the `DisplayMode.refreshRate` contract documented right on the stored property — *\"Refresh rate in Hz (0 means display default, shown as 60)\"* — and reading as broken next to real rates in the resolution slider and refresh-rate list.
- Render `0` (and any non-positive value) as the `60Hz` default, matching how System Settings presents the default timing and honouring the existing doc. Whole-number (`60Hz`) and NTSC fractional (`59.94Hz`, `47.95Hz`) formatting is unchanged.
- Extracted the formatting into a pure `RefreshRateFormat` helper so it can run under a headless `XCTest`: the rest of `DisplayMode` reaches private CGS APIs through the bridging header the test target does not carry (same extraction route the DDC matcher already uses).

## How tested
- `make test` — all 21 tests pass (6 new in `RefreshRateFormatTests`: zero/negative default, whole-number, near-whole collapse, NTSC two-decimal, cinema rounding)
- `make compile` — clean swiftc -swift-version 5 build
- N/A — pure decision logic, headless XCTest (no hardware/monitor verification needed)

## Checklist
- [x] Builds locally (`make test` / `make compile`)
- [x] N/A — pure decision logic, no new user-facing strings (the only label change is `-- Hz` → `60Hz` for the display-default timing)
- [x] N/A — no UI change