### PR TITLE
ci: run unit tests and enforce localization-key coverage on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,34 @@ jobs:
       # The macos-26 image ships no swiftlint, so the lint step used to hit
       # "command not found" that `|| true` swallowed, making it a silent no-op.
       # Install it explicitly; the runner has full Xcode so its SourceKit loads.
-      - name: Install SwiftLint
-        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install swiftlint
+      - name: Install SwiftLint and xcodegen
+        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install swiftlint xcodegen
       - name: Lint (SwiftLint, advisory)
         run: swiftlint lint --reporter github-actions-logging || true
+      # Unit tests. The dev machine is CLT-only and cannot run xcodebuild, so CI
+      # is the only place the suite actually executes; without this step the
+      # tests in CrispTests are dead weight (that is how the "-- Hz" bug and the
+      # untested doc-comment contract in DisplayMode survived to a release).
+      - name: Test
+        run: make test
+      # Every localization key the code uses must exist in the String Catalog.
+      # SwiftUI coalesces interpolated text into "%@"-style lookup keys, and a
+      # key missing from the catalog silently falls back to English at runtime
+      # (issue class fixed in PR #34). Export what the compiler extracts and
+      # diff it against the catalog. Pre-existing gaps are tracked in the
+      # allowlist next to the script; remove entries as they get fixed.
+      - name: Check localization keys
+        run: |
+          xcodebuild -quiet -exportLocalizations -project Crisp.xcodeproj \
+            -localizationPath build/loc CODE_SIGNING_ALLOWED=NO \
+            SWIFT_EMIT_LOC_STRINGS=YES SWIFT_VERSION=5 SWIFT_STRICT_CONCURRENCY=minimal
+          python3 scripts/check-localization-keys.py build/loc/en.xcloc \
+            Crisp/Resources/Localizable.xcstrings scripts/i18n-missing-allowlist.txt
+      # Advisory here: completeness is enforced in the release path
+      # (release.sh --publish) so a PR adding an English string never blocks a
+      # contributor. This run only surfaces the current gaps on the PR.
+      - name: Translation completeness (advisory)
+        run: python3 scripts/check-translations.py Crisp/Resources/Localizable.xcstrings || true
       # Reuses the release script's dry run: compiles the universal binary,
       # builds the icon, compiles the String Catalog, and packages the DMG,
       # so a green check means the real release path builds. Publishes nothing.

--- a/scripts/check-localization-keys.py
+++ b/scripts/check-localization-keys.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Fail if code uses a localization key that Localizable.xcstrings lacks.
+
+SwiftUI coalesces interpolated LocalizedStringKey text into "%@"-style lookup
+keys, and NSLocalizedString looks up its literal key. When the catalog has no
+entry for that key, the UI silently falls back to English at runtime, which no
+catalog-side check can see (the key simply is not there). This script compares
+the keys the compiler actually extracts (xcodebuild -exportLocalizations)
+against the catalog, so a key used in code but missing from the catalog fails
+CI instead of shipping.
+
+Usage: check-localization-keys.py <en.xcloc> <Localizable.xcstrings> [allowlist]
+
+The allowlist holds pre-existing gaps (one key per line, '#' for comments) so
+the check can be enforcing for regressions from day one. Remove entries as the
+gaps get fixed; stale entries are reported so the list cannot rot silently.
+"""
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+XLIFF_NS = "urn:oasis:names:tc:xliff:document:1.2"
+
+
+def extracted_keys(xcloc: Path, catalog_name: str) -> set:
+    """Keys the compiler extracted for the given catalog, across all xliffs."""
+    keys = set()
+    for xliff in (xcloc / "Localized Contents").glob("*.xliff"):
+        root = ET.parse(xliff).getroot()
+        for file_el in root.iter(f"{{{XLIFF_NS}}}file"):
+            if Path(file_el.get("original", "")).name != catalog_name:
+                continue
+            for unit in file_el.iter(f"{{{XLIFF_NS}}}trans-unit"):
+                key = unit.get("id")
+                if key:
+                    keys.add(key)
+    return keys
+
+
+def main(argv: list) -> int:
+    xcloc = Path(argv[1])
+    catalog_path = Path(argv[2])
+    allowlist_path = Path(argv[3]) if len(argv) > 3 else None
+
+    catalog_keys = set(json.load(open(catalog_path, encoding="utf-8"))["strings"])
+    used = extracted_keys(xcloc, catalog_path.name)
+    if not used:
+        print(f"error: no keys extracted from {xcloc}; export likely failed", file=sys.stderr)
+        return 1
+
+    allowed = set()
+    if allowlist_path and allowlist_path.exists():
+        for line in open(allowlist_path, encoding="utf-8"):
+            line = line.rstrip("\n")
+            if line and not line.lstrip().startswith("#"):
+                allowed.add(line)
+
+    missing = used - catalog_keys
+    stale = allowed - missing
+    if stale:
+        print(f"note: {len(stale)} stale allowlist entr(ies), remove them:")
+        for key in sorted(stale):
+            print(f"  {key!r}")
+
+    unexpected = sorted(missing - allowed)
+    if unexpected:
+        print(f"{len(unexpected)} key(s) used in code but missing from {catalog_path.name}:", file=sys.stderr)
+        for key in unexpected:
+            print(f"  {key!r}", file=sys.stderr)
+        print("Add the key(s) to the catalog (or, for a pre-existing gap, to the allowlist).", file=sys.stderr)
+        return 1
+
+    print(f"OK: all {len(used)} extracted keys exist in {catalog_path.name} ({len(missing & allowed)} allowlisted).")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv))

--- a/scripts/i18n-missing-allowlist.txt
+++ b/scripts/i18n-missing-allowlist.txt
@@ -1,0 +1,5 @@
+# Localization keys used in code but not yet present in Localizable.xcstrings.
+# Consumed by scripts/check-localization-keys.py in CI: keys listed here do not
+# fail the build, everything else missing does. One key per line, exactly as
+# extracted (leading spaces and format specifiers matter). Remove entries as
+# the gaps get fixed; the checker flags stale entries.


### PR DESCRIPTION
Hardens CI against the two bug classes that slipped into the last release.

**1. Tests now actually run.** CI only did a release dry-run build, and the dev machine is CLT-only, so the unit tests in `CrispTests` never executed anywhere. `make test` now runs on every PR (xcodegen installed alongside swiftlint).

**2. Missing localization keys now fail CI.** SwiftUI coalesces interpolated text into `%@`-style lookup keys; when such a key (or a bare `NSLocalizedString` key) is absent from `Localizable.xcstrings`, the UI silently falls back to English at runtime. `check-translations.py` cannot see this, the key simply is not in the catalog. New `scripts/check-localization-keys.py` diffs the compiler-extracted keys (`xcodebuild -exportLocalizations`) against the catalog and fails on any key used in code but missing from it. Pre-existing gaps go in `scripts/i18n-missing-allowlist.txt` (seeded from the first CI run of this PR; entries get removed as #34 and friends land), so the check is enforcing for regressions from day one. Stale allowlist entries are reported so the list cannot rot.

**3. Translation completeness surfaces on PRs** (advisory): the existing `check-translations.py` still hard-gates only the `--publish` release path, but its output now shows on every PR run.

The checker script's parsing and allowlist logic is verified against a synthetic `.xcloc` fixture (fail, pass, and stale-entry cases). The `make test` step and the export step can only be validated by this PR's own CI run, since the dev machine has no full Xcode.