### PR TITLE
fix: persist gamma adjustments by stable display uuid, not displayID

### DIFF
--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -258,7 +258,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                         // Apply software brightness factor first so GammaService
                         // can read the up-to-date factor when it re-applies its formula.
                         BrightnessService.shared.reapplySoftwareBrightnessIfNeeded(for: display)
-                        GammaService.shared.reapplyIfNeeded(for: display.displayID)
+                        GammaService.shared.reapplyIfNeeded(for: display)
                         // Re-apply any custom resolution that macOS may have reset on wake
                         ResolutionService.shared.reapplySavedModeIfNeeded(for: display.displayID)
                     }

--- a/Crisp/Models/GammaPersistenceKey.swift
+++ b/Crisp/Models/GammaPersistenceKey.swift
@@ -1,0 +1,53 @@
+import Foundation
+import CoreGraphics
+
+/// Pure key-construction and migration-decision logic for `GammaService`'s persisted
+/// per-display adjustments (issue #32: macOS can reassign `CGDirectDisplayID` across
+/// reboots/reconnects, so keying storage by displayID alone can apply a saved color
+/// temperature to the wrong physical display on a dual-external setup). Mirrors the
+/// identity mechanism already used for brightness-key display selection:
+/// `DisplayInfo.displayUUID`.
+///
+/// Owns no `UserDefaults` access itself, so it can be exercised headlessly from an
+/// `XCTestCase` (same route as `DDCServiceMatcher`).
+enum GammaPersistenceKey {
+    private static let base = "crisp.GammaService.savedAdjustment"
+
+    /// Current storage key: keyed by the stable `DisplayInfo.displayUUID`, which
+    /// survives a `CGDirectDisplayID` reassignment.
+    static func uuidKey(for uuid: String) -> String {
+        "\(base).uuid.\(uuid)"
+    }
+
+    /// Legacy storage key from before issue #32's fix: keyed by the volatile
+    /// `CGDirectDisplayID`. Still consulted once, at migration time, for a display
+    /// whose current id happens to still match what was saved under it.
+    static func legacyKey(for displayID: CGDirectDisplayID) -> String {
+        "\(base).\(displayID)"
+    }
+
+    /// One legacy entry that should move to its display's stable UUID key.
+    struct MigrationTarget: Equatable {
+        let legacyKey: String
+        let uuidKey: String
+    }
+
+    /// Pure decision core for the legacy-to-UUID migration: which currently online
+    /// displays have a legacy, displayID-keyed saved adjustment that should move under
+    /// the stable UUID key.
+    ///
+    /// A display's legacy entry migrates only when its *current* `CGDirectDisplayID` is
+    /// in `legacyDisplayIDsWithSavedState` (the caller determines this by checking
+    /// storage for exactly the ids the live displays currently have, nothing else).
+    /// Legacy keys belonging to a displayID that isn't live right now are never
+    /// considered here: guessing at those is exactly the bug being fixed (a stale
+    /// entry silently reassigned to the wrong physical display after a reboot).
+    static func migrationTargets(
+        liveDisplays: [(id: CGDirectDisplayID, uuid: String)],
+        legacyDisplayIDsWithSavedState: Set<CGDirectDisplayID>
+    ) -> [MigrationTarget] {
+        liveDisplays
+            .filter { legacyDisplayIDsWithSavedState.contains($0.id) }
+            .map { MigrationTarget(legacyKey: legacyKey(for: $0.id), uuidKey: uuidKey(for: $0.uuid)) }
+    }
+}

--- a/Crisp/Models/GammaPersistenceKey.swift
+++ b/Crisp/Models/GammaPersistenceKey.swift
@@ -27,7 +27,9 @@ enum GammaPersistenceKey {
     }
 
     /// One legacy entry that should move to its display's stable UUID key.
-    struct MigrationTarget: Equatable {
+    /// Hashable (not just Equatable) so tests can compare migration batches
+    /// order-independently; synthesis has to live in the type's own file.
+    struct MigrationTarget: Hashable {
         let legacyKey: String
         let uuidKey: String
     }

--- a/Crisp/Services/DisplayManager.swift
+++ b/Crisp/Services/DisplayManager.swift
@@ -131,6 +131,10 @@ class DisplayManager: ObservableObject {
         displays = updatedDisplays
         DisplayManagerAccessor.shared.displays = updatedDisplays
 
+        // Reconcile any legacy CGDirectDisplayID-keyed gamma adjustment onto the stable
+        // UUID key before anything below reapplies a saved adjustment (issue #32).
+        GammaService.shared.migrateLegacyStateIfNeeded(for: updatedDisplays)
+
         // Only load details / refresh brightness for newly appeared displays
         for display in addedDisplays {
             Task { await BrightnessService.shared.refreshBrightness(for: display) }
@@ -161,7 +165,7 @@ class DisplayManager: ObservableObject {
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 300_000_000)
                 BrightnessService.shared.reapplySoftwareBrightnessIfNeeded(for: display)
-                GammaService.shared.reapplyIfNeeded(for: display.displayID)
+                GammaService.shared.reapplyIfNeeded(for: display)
             }
         }
 

--- a/Crisp/Services/GammaService.swift
+++ b/Crisp/Services/GammaService.swift
@@ -174,11 +174,13 @@ final class GammaService: @unchecked Sendable {
         }
     }
 
-    private static func stateKey(for displayID: CGDirectDisplayID) -> String {
-        "crisp.GammaService.savedAdjustment.\(displayID)"
-    }
+    // MARK: - Persistence (displayUUID keyed, survives displayID reassignment; issue #32)
 
-    func saveState(_ adj: GammaAdjustment, for displayID: CGDirectDisplayID) {
+    /// Persist an adjustment under the display's stable UUID, not its `CGDirectDisplayID`:
+    /// macOS can reassign the id across reboots/reconnects, which used to apply a saved
+    /// color temperature to the wrong physical display on a dual-external setup.
+    @MainActor
+    func saveState(_ adj: GammaAdjustment, for display: DisplayInfo) {
         let dict: [String: Any] = [
             "contrast": adj.contrast,
             "gammaVal": adj.gammaVal,
@@ -190,11 +192,12 @@ final class GammaService: @unchecked Sendable {
             "isInverted": adj.isInverted,
             "isPaused": adj.isPaused
         ]
-        UserDefaults.standard.set(dict, forKey: GammaService.stateKey(for: displayID))
+        UserDefaults.standard.set(dict, forKey: GammaPersistenceKey.uuidKey(for: display.displayUUID))
     }
 
-    func loadSavedState(for displayID: CGDirectDisplayID) -> GammaAdjustment? {
-        guard let dict = UserDefaults.standard.dictionary(forKey: GammaService.stateKey(for: displayID)) else { return nil }
+    @MainActor
+    func loadSavedState(for display: DisplayInfo) -> GammaAdjustment? {
+        guard let dict = UserDefaults.standard.dictionary(forKey: GammaPersistenceKey.uuidKey(for: display.displayUUID)) else { return nil }
         var adj = GammaAdjustment()
         adj.contrast           = dict["contrast"]           as? Double ?? 0
         adj.gammaVal           = dict["gammaVal"]           as? Double ?? 0
@@ -212,14 +215,45 @@ final class GammaService: @unchecked Sendable {
         return adj
     }
 
-    func clearSavedState(for displayID: CGDirectDisplayID) {
-        UserDefaults.standard.removeObject(forKey: GammaService.stateKey(for: displayID))
+    @MainActor
+    func clearSavedState(for display: DisplayInfo) {
+        UserDefaults.standard.removeObject(forKey: GammaPersistenceKey.uuidKey(for: display.displayUUID))
+    }
+
+    /// Moves any legacy, `CGDirectDisplayID`-keyed saved adjustment onto the stable
+    /// UUID key (issue #32), for every display currently online. Call whenever the
+    /// display list is (re)built, e.g. from `DisplayManager.refreshDisplays()`, before
+    /// anything reapplies a saved adjustment. Safe to call repeatedly: a no-op once a
+    /// display has no legacy entry left, and never overwrites an adjustment already
+    /// saved under the UUID key.
+    ///
+    /// Deliberately does not touch a legacy key whose displayID has no live display
+    /// right now: that id may simply belong to a disconnected monitor, and guessing
+    /// would risk applying a stale adjustment to the wrong physical display, the exact
+    /// bug this migration fixes.
+    @MainActor
+    func migrateLegacyStateIfNeeded(for displays: [DisplayInfo]) {
+        let defaults = UserDefaults.standard
+        let live = displays.map { (id: $0.displayID, uuid: $0.displayUUID) }
+        let legacyIDsWithState = Set(live.map(\.id).filter {
+            defaults.dictionary(forKey: GammaPersistenceKey.legacyKey(for: $0)) != nil
+        })
+        guard !legacyIDsWithState.isEmpty else { return }
+        for target in GammaPersistenceKey.migrationTargets(liveDisplays: live, legacyDisplayIDsWithSavedState: legacyIDsWithState) {
+            guard let legacyDict = defaults.dictionary(forKey: target.legacyKey) else { continue }
+            if defaults.dictionary(forKey: target.uuidKey) == nil {
+                defaults.set(legacyDict, forKey: target.uuidKey)
+            }
+            defaults.removeObject(forKey: target.legacyKey)
+        }
     }
 
     /// Re-applies the persisted gamma adjustment for a display (e.g. after wake from sleep
     /// or display reconnect). No-op if no saved state exists or the adjustment is paused.
-    func reapplyIfNeeded(for displayID: CGDirectDisplayID) {
-        guard let adj = loadSavedState(for: displayID), !adj.isPaused else { return }
+    @MainActor
+    func reapplyIfNeeded(for display: DisplayInfo) {
+        guard let adj = loadSavedState(for: display), !adj.isPaused else { return }
+        let displayID = display.displayID
         adjustmentsLock.withLock { activeAdjustments[displayID] = adj }
         applyInternal(adj, for: displayID)
     }

--- a/Crisp/Views/ImageAdjustmentView.swift
+++ b/Crisp/Views/ImageAdjustmentView.swift
@@ -33,7 +33,7 @@ struct ImageAdjustmentView: View {
     init(display: DisplayInfo, isExpanded: Bool) {
         _display = ObservedObject(wrappedValue: display)
         self.isExpanded = isExpanded
-        let saved = GammaService.shared.loadSavedState(for: display.displayID)
+        let saved = GammaService.shared.loadSavedState(for: display)
         _contrast = State(initialValue: saved?.contrast ?? 0)
         _gammaVal = State(initialValue: saved?.gammaVal ?? 0)
         _gain = State(initialValue: saved?.gain ?? 0)
@@ -215,7 +215,7 @@ struct ImageAdjustmentView: View {
     /// Save the current adjustment, or clear it and restore identity when neutral.
     private func persist() {
         if isIdentity {
-            GammaService.shared.clearSavedState(for: display.displayID)
+            GammaService.shared.clearSavedState(for: display)
             GammaService.shared.resetSingleDisplay(display.displayID)
         } else {
             let adj = GammaAdjustment(
@@ -226,7 +226,7 @@ struct ImageAdjustmentView: View {
                 quantizationLevels: Int(quantLevels),
                 isInverted: isInverted, isPaused: isPaused
             )
-            GammaService.shared.saveState(adj, for: display.displayID)
+            GammaService.shared.saveState(adj, for: display)
         }
     }
 
@@ -262,7 +262,7 @@ struct ImageAdjustmentView: View {
         quantLevels = 256
         isInverted = false
         isPaused = false
-        GammaService.shared.clearSavedState(for: display.displayID)
+        GammaService.shared.clearSavedState(for: display)
         GammaService.shared.resetSingleDisplay(display.displayID)
     }
 }

--- a/CrispTests/GammaPersistenceKeyTests.swift
+++ b/CrispTests/GammaPersistenceKeyTests.swift
@@ -134,8 +134,3 @@ final class GammaPersistenceKeyTests: XCTestCase {
         XCTAssertEqual(GammaPersistenceKey.migrationTargets(liveDisplays: [], legacyDisplayIDsWithSavedState: []), [])
     }
 }
-
-/// `MigrationTarget` needs `Hashable` only for the `Set` comparison in
-/// `testMultipleLiveDisplaysEachMigrateIndependently`, where migration order is not
-/// part of the contract; production code never needs `Set<MigrationTarget>`.
-extension GammaPersistenceKey.MigrationTarget: Hashable {}

--- a/CrispTests/GammaPersistenceKeyTests.swift
+++ b/CrispTests/GammaPersistenceKeyTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+import CoreGraphics
+
+/// Headless tests for the gamma-adjustment persistence key/migration decision core
+/// (issue #32: color temperature applied to the wrong display after a reboot).
+///
+/// `GammaPersistenceKey` is compiled directly into this test target (see `project.yml`
+/// sources, same route as `DDCServiceMatcher`), so no `@testable import Crisp` is needed
+/// (that would pull AppKit/IOKit and the private bridging header and defeat headless
+/// purity). Each test names the behaviour or mutation it pins in a trailing comment.
+final class GammaPersistenceKeyTests: XCTestCase {
+
+    // MARK: - Key construction
+
+    /// The UUID key embeds the display's stable identifier and is distinct from any
+    /// legacy displayID key for the same display (no accidental collision between the
+    /// two schemes).
+    func testUUIDKeyIsDistinctFromLegacyKey() {
+        let uuidKey = GammaPersistenceKey.uuidKey(for: "1234")
+        let legacyKey = GammaPersistenceKey.legacyKey(for: 1234)
+        XCTAssertNotEqual(uuidKey, legacyKey)
+        XCTAssertTrue(uuidKey.contains("1234"))
+        XCTAssertTrue(legacyKey.hasSuffix("1234"))
+    }
+
+    /// Two different displayIDs never produce the same legacy key.
+    /// Kills mutation: legacy key construction dropping the displayID from the string.
+    func testLegacyKeysDifferPerDisplayID() {
+        XCTAssertNotEqual(GammaPersistenceKey.legacyKey(for: 1), GammaPersistenceKey.legacyKey(for: 2))
+    }
+
+    /// Two different UUIDs never produce the same UUID key.
+    /// Kills mutation: UUID key construction dropping the uuid from the string.
+    func testUUIDKeysDifferPerUUID() {
+        XCTAssertNotEqual(GammaPersistenceKey.uuidKey(for: "aaa"), GammaPersistenceKey.uuidKey(for: "bbb"))
+    }
+
+    // MARK: - Migration: the core issue #32 fix
+
+    /// A live display whose current id has a legacy saved entry migrates: exactly one
+    /// target, mapping that display's legacy key to its UUID key.
+    func testLiveDisplayWithMatchingLegacyEntryMigrates() {
+        let targets = GammaPersistenceKey.migrationTargets(
+            liveDisplays: [(id: 501, uuid: "uuid-A")],
+            legacyDisplayIDsWithSavedState: [501]
+        )
+        XCTAssertEqual(targets, [
+            GammaPersistenceKey.MigrationTarget(
+                legacyKey: GammaPersistenceKey.legacyKey(for: 501),
+                uuidKey: GammaPersistenceKey.uuidKey(for: "uuid-A")
+            )
+        ])
+    }
+
+    /// A live display with no legacy entry produces no migration target: nothing to move.
+    func testLiveDisplayWithoutLegacyEntryDoesNotMigrate() {
+        let targets = GammaPersistenceKey.migrationTargets(
+            liveDisplays: [(id: 501, uuid: "uuid-A")],
+            legacyDisplayIDsWithSavedState: []
+        )
+        XCTAssertEqual(targets, [])
+    }
+
+    /// The core regression this issue reports: two live displays, only one whose current
+    /// id matches a legacy entry. Only that one display's legacy state migrates, and it
+    /// migrates to *its own* UUID, never the other display's.
+    /// Kills mutation: migrating every live display regardless of legacy-entry match, or
+    /// pairing the wrong uuid with a legacy key.
+    func testOnlyTheDisplayWithAMatchingLegacyIDMigratesOnDualExternalSetup() {
+        let targets = GammaPersistenceKey.migrationTargets(
+            liveDisplays: [(id: 1, uuid: "uuid-left"), (id: 2, uuid: "uuid-right")],
+            legacyDisplayIDsWithSavedState: [2]
+        )
+        XCTAssertEqual(targets, [
+            GammaPersistenceKey.MigrationTarget(
+                legacyKey: GammaPersistenceKey.legacyKey(for: 2),
+                uuidKey: GammaPersistenceKey.uuidKey(for: "uuid-right")
+            )
+        ])
+    }
+
+    /// A stale legacy entry whose displayID belongs to no currently online display must
+    /// never be guessed at: that display may simply be disconnected, and guessing which
+    /// live display it "really" belongs to is the exact bug being fixed (applying a saved
+    /// adjustment to the wrong physical display).
+    /// Kills mutation: iterating `legacyDisplayIDsWithSavedState` instead of `liveDisplays`,
+    /// which would fabricate a target with no real uuid to migrate to.
+    func testStaleLegacyEntryWithNoLiveDisplayIsIgnored() {
+        let targets = GammaPersistenceKey.migrationTargets(
+            liveDisplays: [(id: 1, uuid: "uuid-A")],
+            legacyDisplayIDsWithSavedState: [999]
+        )
+        XCTAssertEqual(targets, [])
+    }
+
+    /// After a reboot reassigns displayIDs (macOS swaps which physical display gets which
+    /// id), a legacy entry saved under the *old* id for a display now living under a
+    /// different id must not be migrated onto that display: its current id no longer
+    /// matches the legacy key, so nothing pairs it with a (possibly wrong) uuid.
+    func testReassignedDisplayIDDoesNotMigrateUnderNewIdentity() {
+        // Display "uuid-A" used to be id 1 (legacy key saved there); after reboot it is
+        // id 2, and nothing saved a legacy entry under id 2.
+        let targets = GammaPersistenceKey.migrationTargets(
+            liveDisplays: [(id: 2, uuid: "uuid-A")],
+            legacyDisplayIDsWithSavedState: [1]
+        )
+        XCTAssertEqual(targets, [])
+    }
+
+    /// Multiple live displays can each migrate independently in the same pass.
+    func testMultipleLiveDisplaysEachMigrateIndependently() {
+        let targets = GammaPersistenceKey.migrationTargets(
+            liveDisplays: [(id: 1, uuid: "uuid-A"), (id: 2, uuid: "uuid-B"), (id: 3, uuid: "uuid-C")],
+            legacyDisplayIDsWithSavedState: [1, 3]
+        )
+        XCTAssertEqual(Set(targets), Set([
+            GammaPersistenceKey.MigrationTarget(
+                legacyKey: GammaPersistenceKey.legacyKey(for: 1),
+                uuidKey: GammaPersistenceKey.uuidKey(for: "uuid-A")
+            ),
+            GammaPersistenceKey.MigrationTarget(
+                legacyKey: GammaPersistenceKey.legacyKey(for: 3),
+                uuidKey: GammaPersistenceKey.uuidKey(for: "uuid-C")
+            )
+        ]))
+    }
+
+    // MARK: - Empty-input edges
+
+    /// No live displays and/or no legacy state must not crash and must yield no targets.
+    func testEmptyInputsProduceNoMigrationTargets() {
+        XCTAssertEqual(GammaPersistenceKey.migrationTargets(liveDisplays: [], legacyDisplayIDsWithSavedState: [501]), [])
+        XCTAssertEqual(GammaPersistenceKey.migrationTargets(liveDisplays: [(id: 1, uuid: "uuid-A")], legacyDisplayIDsWithSavedState: []), [])
+        XCTAssertEqual(GammaPersistenceKey.migrationTargets(liveDisplays: [], legacyDisplayIDsWithSavedState: []), [])
+    }
+}
+
+/// `MigrationTarget` needs `Hashable` only for the `Set` comparison in
+/// `testMultipleLiveDisplaysEachMigrateIndependently`, where migration order is not
+/// part of the contract; production code never needs `Set<MigrationTarget>`.
+extension GammaPersistenceKey.MigrationTarget: Hashable {}

--- a/project.yml
+++ b/project.yml
@@ -52,6 +52,7 @@ targets:
       - path: Crisp/Models/DisplayModeGeometry.swift
       - path: Crisp/Models/DDCServiceMatcher.swift
       - path: Crisp/Models/RefreshRateFormat.swift
+      - path: Crisp/Models/GammaPersistenceKey.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.crisp.tests


### PR DESCRIPTION
## What

On a dual-external monitor setup, `GammaService` persisted Color Temp / other image adjustments under `crisp.GammaService.savedAdjustment.<CGDirectDisplayID>`. macOS can reassign `CGDirectDisplayID` across a full reboot, so after restart the saved adjustment could land on the wrong physical display: A gets B's tint, B goes back to neutral.

This does the same thing the brightness-key selected-display persistence already does: key by `DisplayInfo.displayUUID` instead of the volatile ID.

## Changes

- `GammaService.saveState` / `loadSavedState` / `clearSavedState` / `reapplyIfNeeded` now take the `DisplayInfo` itself and persist/read under `GammaPersistenceKey.uuidKey(for: display.displayUUID)`, not the raw `CGDirectDisplayID`. `apply`, `reapply`, `hasActiveAdjustment`, `applyIdentity`, `resetSingleDisplay` stay keyed by `CGDirectDisplayID` since those only touch the in-memory, session-scoped `activeAdjustments` dict and the live CoreGraphics calls, which need the real id anyway.
- Added `GammaService.migrateLegacyStateIfNeeded(for:)`, called from `DisplayManager.refreshDisplays()` right after the display list is rebuilt (app launch, reconnect, wake), before anything reapplies a saved adjustment. For each live display, if its *current* id still has a legacy `crisp.GammaService.savedAdjustment.<id>` entry, that entry is copied to the display's UUID key and the legacy key is removed. It never overwrites an adjustment already saved under the UUID key, and it never touches a legacy key whose id has no live display right now, that display might just be disconnected, and guessing would repeat the exact bug this fixes.
- Extracted the key construction and the migration decision (which live displays have a matching legacy entry) into a pure `GammaPersistenceKey` enum (`Crisp/Models/GammaPersistenceKey.swift`), same pattern as `DDCServiceMatcher`/`DisplayModeGeometry`: no `UserDefaults` access inside it, so it's testable headlessly. Wired into the `CrispTests` target via `project.yml` sources (not `@testable import Crisp`, same reasoning as the existing pure-type tests). Added `CrispTests/GammaPersistenceKeyTests.swift` covering key construction and the migration mapping, including the dual-external "only the display with a matching legacy id migrates, to its own uuid" case and the "stale legacy entry with no live display is left alone" case.
- Presets still don't store gamma/Color Temp, that's the separate, already-documented gap the issue also mentions. Didn't touch it here.

## Migration behavior

- Runs once per display-list rebuild (`DisplayManager.refreshDisplays()`), so on every app launch, reconnect, and wake.
- Per live display: if `crisp.GammaService.savedAdjustment.<its current id>` exists, it gets copied to `crisp.GammaService.savedAdjustment.uuid.<its uuid>` (unless that UUID key already has a value) and the legacy key is deleted.
- A legacy key whose id doesn't belong to any currently connected display is left in `UserDefaults` untouched. It's orphaned but harmless, and there's no safe way to know which physical display it used to belong to.

## Verified locally

- `make compile` succeeds clean, no new warnings or errors from any of the changed files (checked the two pre-existing warnings in `GammaService.swift`/`DisplayManager.swift` predate this diff).
- `xcrun swiftc -parse` on the new pure type and its test file, both parse cleanly.

## Could not verify locally

- This machine only has the Command Line Tools, no full Xcode, so `make test` / `xcodebuild` don't run here (confirmed: `swiftc -typecheck` on any `CrispTests/*.swift` file, old or new, fails with "no such module XCTest", not specific to this change).
- No multi-monitor hardware here, so I couldn't reproduce the original bug or verify the actual reboot/reconnect behavior end to end. @cicae, you offered to test a build keyed by UUID, if you're up for it, that'd be the real verification this needs. I'd appreciate a check that Color Temp now survives a reboot with each display keeping its own value.

Fixes #32
