### PR TITLE
fix: label variable refresh rate modes on external displays

### DIFF
--- a/Crisp/Models/DisplayMode.swift
+++ b/Crisp/Models/DisplayMode.swift
@@ -19,6 +19,9 @@ struct DisplayMode: Identifiable, Equatable {
     let isHiDPI: Bool
     /// Whether this is the native (highest pixel resolution) mode
     let isNative: Bool
+    /// Whether this is the variable-refresh member of a duplicate mode pair
+    /// (see VariableRefreshModes); shown as "Variable (up to NHz)" like System Settings.
+    var isVariableRefresh: Bool = false
     /// Raw IODisplayModeID for CGConfigureDisplayWithDisplayMode (same as id)
     var ioDisplayModeID: Int32 { id }
 
@@ -52,6 +55,7 @@ struct DisplayMode: Identifiable, Equatable {
         }
 
         let maxPixelWidth = nativePixelWidth(from: rawModes)
+        let variableIDs = VariableRefreshModes.variableModeIDs(from: cgsModeRecords(for: displayID))
 
         var seen = Set<Int32>()
         var modes: [DisplayMode] = rawModes.compactMap { mode -> DisplayMode? in
@@ -73,7 +77,8 @@ struct DisplayMode: Identifiable, Equatable {
                 pixelHeight: ph,
                 refreshRate: refresh,
                 isHiDPI: pw > w,
-                isNative: pw >= maxPixelWidth
+                isNative: pw >= maxPixelWidth,
+                isVariableRefresh: variableIDs.contains(modeID)
             )
         }
 
@@ -86,15 +91,34 @@ struct DisplayMode: Identifiable, Equatable {
                                 pixelWidth: $0.pixelWidth, pixelHeight: $0.pixelHeight)
         })
         modes += cgsHiddenHiDPIModes(for: displayID, excludingIDs: knownIDs,
-                                     maxPixelWidth: maxPixelWidth, nativeAspect: nativeAR)
+                                     maxPixelWidth: maxPixelWidth, nativeAspect: nativeAR,
+                                     variableIDs: variableIDs)
 
         return modes.sorted { lhs, rhs in
             if lhs.width != rhs.width { return lhs.width > rhs.width }
             if lhs.height != rhs.height { return lhs.height > rhs.height }
             if lhs.refreshRate != rhs.refreshRate { return lhs.refreshRate > rhs.refreshRate }
+            // Variable above its same-rate fixed twin, matching System Settings.
+            if lhs.isVariableRefresh != rhs.isVariableRefresh { return lhs.isVariableRefresh }
             if lhs.isHiDPI != rhs.isHiDPI { return lhs.isHiDPI }
             return false
         }
+    }
+
+    /// The raw CGS mode table reduced to what the VRR detector needs.
+    private static func cgsModeRecords(for displayID: CGDirectDisplayID) -> [VRRModeRecord] {
+        var count: Int32 = 0
+        guard CGSGetNumberOfDisplayModes(displayID, &count) == .success, count > 0 else { return [] }
+        let length = Int32(MemoryLayout<CGSDisplayModeDescription>.size)
+        var out: [VRRModeRecord] = []
+        for i in 0..<count {
+            var d = CGSDisplayModeDescription()
+            guard CGSGetDisplayModeDescriptionOfLength(displayID, i, &d, length) == .success else { continue }
+            out.append(VRRModeRecord(id: Int32(bitPattern: d.modeNumber),
+                                     width: Int(d.width), height: Int(d.height),
+                                     freq: Int(d.freq), density: d.density, flags: d.flags))
+        }
+        return out
     }
 
     /// GPU-scaled HiDPI modes that `CGDisplayCopyAllDisplayModes` omits. When a scaled resolution
@@ -109,7 +133,8 @@ struct DisplayMode: Identifiable, Equatable {
     private static func cgsHiddenHiDPIModes(for displayID: CGDirectDisplayID,
                                             excludingIDs known: Set<Int32>,
                                             maxPixelWidth: Int,
-                                            nativeAspect: Double) -> [DisplayMode] {
+                                            nativeAspect: Double,
+                                            variableIDs: Set<Int32>) -> [DisplayMode] {
         var count: Int32 = 0
         guard CGSGetNumberOfDisplayModes(displayID, &count) == .success, count > 0 else { return [] }
         let length = Int32(MemoryLayout<CGSDisplayModeDescription>.size)
@@ -131,7 +156,8 @@ struct DisplayMode: Identifiable, Equatable {
             out.append(DisplayMode(id: id, width: w, height: h,
                                    pixelWidth: pw, pixelHeight: ph,
                                    refreshRate: Double(d.freq),
-                                   isHiDPI: pw > w, isNative: pw >= maxPixelWidth))
+                                   isHiDPI: pw > w, isNative: pw >= maxPixelWidth,
+                                   isVariableRefresh: variableIDs.contains(id)))
         }
         return out
     }
@@ -150,6 +176,7 @@ struct DisplayMode: Identifiable, Equatable {
         let ph = mode.pixelHeight
         let refresh = mode.refreshRate
         let modeID = mode.ioDisplayModeID
+        let variableIDs = VariableRefreshModes.variableModeIDs(from: cgsModeRecords(for: displayID))
 
         return DisplayMode(
             id: modeID,
@@ -159,7 +186,8 @@ struct DisplayMode: Identifiable, Equatable {
             pixelHeight: ph,
             refreshRate: refresh,
             isHiDPI: pw > w,
-            isNative: pw >= maxPixelWidth
+            isNative: pw >= maxPixelWidth,
+            isVariableRefresh: variableIDs.contains(modeID)
         )
     }
 }

--- a/Crisp/Models/VariableRefreshModes.swift
+++ b/Crisp/Models/VariableRefreshModes.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// One raw CGS mode table row, reduced to the fields the VRR detector needs
+/// (`CGSDisplayModeDescription`: modeNumber, flags at offset 4, logical size,
+/// freq, backing density).
+struct VRRModeRecord: Equatable {
+    let id: Int32
+    let width: Int
+    let height: Int
+    let freq: Int
+    let density: Float
+    let flags: UInt32
+}
+
+/// Detects the variable-refresh member of duplicate mode pairs (issue #31).
+///
+/// On a VRR-capable external, macOS's mode table carries two otherwise identical
+/// usable entries for each rate inside the panel's adaptive range: one fixed, one
+/// variable. Nothing in the public API tells them apart per mode, so Crisp showed
+/// confusing duplicate rows ("165Hz, 165Hz"). Verified against real hardware
+/// (AOC Q27G3XMN 48-180Hz panel, macOS 26, live NSScreen refresh-range checks at
+/// 180 native, 180 scaled, and 60 HiDPI):
+///   - the variable twin always enumerates with the LOWER modeNumber;
+///   - at native resolution the fixed twin additionally carries the IOKit
+///     safe|default flag bits (0x2|0x4), and those bits are static (they do not
+///     follow the user's selection);
+///   - non-VRR panels (a DELL U2412M and the built-in ProMotion panel) expose no
+///     usable duplicate pairs at all, so this cannot false-positive there.
+enum VariableRefreshModes {
+    /// Mode macOS deems unusable for the desktop GUI (matches isUsableForDesktopGUI == false).
+    static let unusableFlag: UInt32 = 0x4000_0000
+    /// kDisplayModeDefaultFlag: the display's default (EDID-preferred) timing.
+    static let defaultFlag: UInt32 = 0x0000_0004
+
+    /// IDs of the variable member of every usable exact-duplicate pair
+    /// (same logical size, same rate, same backing density).
+    static func variableModeIDs(from records: [VRRModeRecord]) -> Set<Int32> {
+        var groups: [String: [VRRModeRecord]] = [:]
+        for record in records where record.flags & unusableFlag == 0 {
+            let key = "\(record.width)x\(record.height)@\(record.freq)@\(String(format: "%.2f", record.density))"
+            groups[key, default: []].append(record)
+        }
+        var variable = Set<Int32>()
+        // ponytail: only exact pairs are classified; >2 identical usable modes was
+        // never observed on real hardware, guess nothing there.
+        for pair in groups.values where pair.count == 2 {
+            let defaulted = pair.filter { $0.flags & defaultFlag != 0 }
+            if defaulted.count == 1 {
+                // The default-flagged twin is the fixed one (EDID-preferred timing).
+                variable.insert(pair.first { $0.flags & defaultFlag == 0 }!.id)
+            } else {
+                // Scaled pairs are byte-identical in flags; the variable twin
+                // consistently enumerates first.
+                variable.insert(pair.min { $0.id < $1.id }!.id)
+            }
+        }
+        return variable
+    }
+}

--- a/Crisp/Models/VariableRefreshRange.swift
+++ b/Crisp/Models/VariableRefreshRange.swift
@@ -1,0 +1,51 @@
+import Foundation
+import IOKit
+import CoreGraphics
+
+/// Reads a panel's adaptive-sync floor from the IORegistry so the variable-refresh
+/// row can show the full range like System Settings ("Variable (48-180Hz)").
+///
+/// The DCP display pipe (Apple Silicon) publishes per-timing `TimingElements` on its
+/// `IOMobileFramebufferShim` node, each carrying `Minimum`/`MaximumVariableRefreshRate`
+/// in 16.16 fixed point. The node's `EDID UUID` is EDID-derived, not the CG display
+/// UUID: its first 8 hex digits are the panel's vendor and product ids (verified:
+/// 10AC7BA0-... for a DELL U2412M, 05E326B3-... for an AOC Q27G3XMN), so the node is
+/// matched on `CGDisplayVendorNumber`/`CGDisplayModelNumber`. Two identical panels
+/// share a floor, so prefix ambiguity is harmless. Returns nil when the registry does
+/// not expose a range (no VRR timings, or a non-DCP framebuffer), in which case the
+/// caller falls back to the "Variable (up to NHz)" wording.
+enum VariableRefreshRange {
+    static func minimumRate(vendorNumber: UInt32, modelNumber: UInt32) -> Int? {
+        // The UUID keeps the EDID's raw byte order: vendor big-endian, product
+        // little-endian (CG's modelNumber is the decoded value, so swap it back).
+        let prefix = String(format: "%04X%02X%02X",
+                            vendorNumber & 0xFFFF, modelNumber & 0xFF, (modelNumber >> 8) & 0xFF)
+        var iterator = io_iterator_t()
+        guard IOServiceGetMatchingServices(kIOMainPortDefault,
+                                           IOServiceMatching("IOMobileFramebufferShim"),
+                                           &iterator) == KERN_SUCCESS else { return nil }
+        defer { IOObjectRelease(iterator) }
+
+        var service = IOIteratorNext(iterator)
+        while service != 0 {
+            defer { service = IOIteratorNext(iterator) }
+            defer { IOObjectRelease(service) }
+            guard let edid = IORegistryEntryCreateCFProperty(service, "EDID UUID" as CFString,
+                                                             kCFAllocatorDefault, 0)?
+                    .takeRetainedValue() as? String,
+                  edid.replacingOccurrences(of: "-", with: "").uppercased().hasPrefix(prefix),
+                  let timings = IORegistryEntryCreateCFProperty(service, "TimingElements" as CFString,
+                                                                kCFAllocatorDefault, 0)?
+                    .takeRetainedValue() as? [[String: Any]]
+            else { continue }
+            let floors = timings.compactMap { timing -> Int? in
+                guard let maxRate = timing["MaximumVariableRefreshRate"] as? Int, maxRate > 0,
+                      let minRate = timing["MinimumVariableRefreshRate"] as? Int, minRate > 0
+                else { return nil }
+                return minRate / 65536
+            }
+            return floors.min()
+        }
+        return nil
+    }
+}

--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -1422,6 +1422,26 @@
         }
       }
     },
+    "Variable (%@-%@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可变（%@-%@）"
+          }
+        }
+      }
+    },
+    "Variable (up to %@)" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可变（最高 %@）"
+          }
+        }
+      }
+    },
     "Virtual Display" : {
       "localizations" : {
         "zh-Hans" : {

--- a/Crisp/Views/DisplayModeListView.swift
+++ b/Crisp/Views/DisplayModeListView.swift
@@ -31,6 +31,9 @@ final class DisplayModeController: ObservableObject {
     private var isSwitching: Bool = false
     private var cachedGroups: [ResolutionGroup]?
     private var cachedSliderModes: [DisplayMode]?
+    /// Panel's adaptive-sync floor (48 on a 48-180Hz panel), for the Variable row label.
+    private lazy var vrrMinimumRate: Int? = VariableRefreshRange.minimumRate(
+        vendorNumber: display.vendorNumber, modelNumber: display.modelNumber)
     private var displayRelay: AnyCancellable?
 
     init(display: DisplayInfo, displayManager: DisplayManager) {
@@ -93,8 +96,21 @@ final class DisplayModeController: ObservableObject {
         let lodpiSizes = Set(base.filter { !$0.isHiDPI }.map { "\($0.width)x\($0.height)" })
 
         let mapped = grouped.map { (_, modes) -> ResolutionGroup in
-            let sorted = modes.sorted { $0.refreshRate > $1.refreshRate }
-            let w = sorted[0].width, h = sorted[0].height, hidpi = sorted[0].isHiDPI
+            let sorted = modes.sorted {
+                if $0.refreshRate != $1.refreshRate { return $0.refreshRate > $1.refreshRate }
+                // Variable above its same-rate fixed twin, matching System Settings.
+                return $0.isVariableRefresh && !$1.isVariableRefresh
+            }
+            // One Variable row per size, like System Settings: macOS mints a variable
+            // twin for every rate inside the panel's adaptive range, but only the top
+            // one is a meaningful choice; the lesser twins would just render as
+            // duplicate Hz rows. Keep whatever is current, as everywhere else.
+            let maxVariableRate = sorted.lazy.filter { $0.isVariableRefresh }.map { $0.refreshRate }.max()
+            let visible = sorted.filter {
+                !$0.isVariableRefresh || $0.refreshRate == maxVariableRate
+                    || $0.id == currentMode?.id
+            }
+            let w = visible[0].width, h = visible[0].height, hidpi = visible[0].isHiDPI
             let isDefault = !display.isBuiltin && !hidpi && w == nativeW && h == nativeH
             let isLowResolution = !hidpi && !isDefault && hiDPISizes.contains("\(w)x\(h)")
             return ResolutionGroup(
@@ -103,7 +119,7 @@ final class DisplayModeController: ObservableObject {
                 isHiDPI: hidpi,
                 isDefault: isDefault,
                 isLowResolution: isLowResolution,
-                modes: sorted
+                modes: visible
             )
         }
 
@@ -165,9 +181,20 @@ final class DisplayModeController: ObservableObject {
     }
 
     /// Refresh-rate label, matching System Settings: the built-in's 120Hz variable-refresh
-    /// mode reads "ProMotion" rather than a fixed number; everything else is its Hz string.
+    /// mode reads "ProMotion" rather than a fixed number, an external VRR twin reads
+    /// "Variable (up to NHz)", and everything else is its Hz string.
     func refreshLabel(_ mode: DisplayMode) -> String {
         if display.isBuiltin && Int(mode.refreshRate.rounded()) >= 120 { return "ProMotion" }
+        if mode.isVariableRefresh {
+            // Full range like System Settings ("Variable (48-180Hz)") when the registry
+            // exposes the adaptive-sync floor; "up to" wording otherwise.
+            if let minRate = vrrMinimumRate {
+                return String(format: NSLocalizedString("Variable (%@-%@)", comment: "External VRR refresh-rate row, full range"),
+                              String(minRate), mode.refreshRateString)
+            }
+            return String(format: NSLocalizedString("Variable (up to %@)", comment: "External VRR refresh-rate row"),
+                          mode.refreshRateString)
+        }
         return mode.refreshRateString
     }
 

--- a/CrispTests/VariableRefreshModesTests.swift
+++ b/CrispTests/VariableRefreshModesTests.swift
@@ -19,7 +19,7 @@ final class VariableRefreshModesTests: XCTestCase {
     func testDefaultFlaggedTwinIsFixed() {
         let ids = VariableRefreshModes.variableModeIDs(from: [
             record(680, 2560, 1440, freq: 180, flags: 0x0200_0001),
-            record(681, 2560, 1440, freq: 180, flags: 0x0200_0007),
+            record(681, 2560, 1440, freq: 180, flags: 0x0200_0007)
         ])
         XCTAssertEqual(ids, [680])
     }
@@ -29,7 +29,7 @@ final class VariableRefreshModesTests: XCTestCase {
     func testFlagRuleBeatsOrderRule() {
         let ids = VariableRefreshModes.variableModeIDs(from: [
             record(680, 2560, 1440, freq: 180, flags: 0x0200_0007),
-            record(681, 2560, 1440, freq: 180, flags: 0x0200_0001),
+            record(681, 2560, 1440, freq: 180, flags: 0x0200_0001)
         ])
         XCTAssertEqual(ids, [681])
     }
@@ -39,7 +39,7 @@ final class VariableRefreshModesTests: XCTestCase {
     func testFlagIdenticalPairFallsBackToLowerID() {
         let ids = VariableRefreshModes.variableModeIDs(from: [
             record(387, 1920, 1080, freq: 180),
-            record(386, 1920, 1080, freq: 180),
+            record(386, 1920, 1080, freq: 180)
         ])
         XCTAssertEqual(ids, [386])
     }
@@ -49,7 +49,7 @@ final class VariableRefreshModesTests: XCTestCase {
     func testDifferentDensityIsNotAPair() {
         let ids = VariableRefreshModes.variableModeIDs(from: [
             record(686, 2560, 1440, freq: 60, density: 1.0),
-            record(727, 2560, 1440, freq: 60, density: 2.0),
+            record(727, 2560, 1440, freq: 60, density: 2.0)
         ])
         XCTAssertEqual(ids, [])
     }
@@ -59,7 +59,7 @@ final class VariableRefreshModesTests: XCTestCase {
     func testUnusableModesAreIgnored() {
         let ids = VariableRefreshModes.variableModeIDs(from: [
             record(731, 400, 300, freq: 180, density: 2.0, flags: 0x4000_0000),
-            record(732, 400, 300, freq: 180, density: 2.0, flags: 0x4000_0000),
+            record(732, 400, 300, freq: 180, density: 2.0, flags: 0x4000_0000)
         ])
         XCTAssertEqual(ids, [])
     }
@@ -70,7 +70,7 @@ final class VariableRefreshModesTests: XCTestCase {
         let ids = VariableRefreshModes.variableModeIDs(from: [
             record(1, 1920, 1200, freq: 60),
             record(2, 1920, 1200, freq: 50),
-            record(3, 1600, 1200, freq: 60),
+            record(3, 1600, 1200, freq: 60)
         ])
         XCTAssertEqual(ids, [])
     }
@@ -81,7 +81,7 @@ final class VariableRefreshModesTests: XCTestCase {
         let ids = VariableRefreshModes.variableModeIDs(from: [
             record(1, 800, 600, freq: 120),
             record(2, 800, 600, freq: 120),
-            record(3, 800, 600, freq: 120),
+            record(3, 800, 600, freq: 120)
         ])
         XCTAssertEqual(ids, [])
     }
@@ -93,7 +93,7 @@ final class VariableRefreshModesTests: XCTestCase {
             record(680, 2560, 1440, freq: 180, flags: 0x0200_0001),
             record(681, 2560, 1440, freq: 180, flags: 0x0200_0007),
             record(727, 2560, 1440, freq: 60, density: 2.0),
-            record(728, 2560, 1440, freq: 60, density: 2.0),
+            record(728, 2560, 1440, freq: 60, density: 2.0)
         ])
         XCTAssertEqual(ids, [680, 727])
     }

--- a/CrispTests/VariableRefreshModesTests.swift
+++ b/CrispTests/VariableRefreshModesTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+/// Headless tests for the VRR duplicate-pair detector (issue #31).
+///
+/// `VariableRefreshModes` is compiled directly into this test target (see `project.yml`
+/// sources, same route as `DisplayModeGeometry`). The fixtures mirror the mode tables
+/// observed on real hardware: an AOC Q27G3XMN VRR panel (duplicate usable pairs per
+/// rate, variable twin first, fixed native twin flagged safe|default) and a DELL
+/// U2412M / built-in ProMotion panel (no usable duplicate pairs at all).
+final class VariableRefreshModesTests: XCTestCase {
+
+    private func record(_ id: Int32, _ w: Int, _ h: Int, freq: Int, density: Float = 1.0,
+                        flags: UInt32 = 0x1) -> VRRModeRecord {
+        VRRModeRecord(id: id, width: w, height: h, freq: freq, density: density, flags: flags)
+    }
+
+    /// The native 180Hz pair from the AOC: fixed twin carries safe|default (0x7),
+    /// so the flag rule picks the other member regardless of ordering.
+    func testDefaultFlaggedTwinIsFixed() {
+        let ids = VariableRefreshModes.variableModeIDs(from: [
+            record(680, 2560, 1440, freq: 180, flags: 0x0200_0001),
+            record(681, 2560, 1440, freq: 180, flags: 0x0200_0007),
+        ])
+        XCTAssertEqual(ids, [680])
+    }
+
+    /// Flags beat enumeration order: if the default-flagged (fixed) twin enumerates
+    /// FIRST, the variable one is still the unflagged member, not the lower id.
+    func testFlagRuleBeatsOrderRule() {
+        let ids = VariableRefreshModes.variableModeIDs(from: [
+            record(680, 2560, 1440, freq: 180, flags: 0x0200_0007),
+            record(681, 2560, 1440, freq: 180, flags: 0x0200_0001),
+        ])
+        XCTAssertEqual(ids, [681])
+    }
+
+    /// Scaled pairs are flag-identical (0x1/0x1); the variable twin is the lower id
+    /// (verified live: 386 variable / 387 fixed, 727 variable / 728 fixed).
+    func testFlagIdenticalPairFallsBackToLowerID() {
+        let ids = VariableRefreshModes.variableModeIDs(from: [
+            record(387, 1920, 1080, freq: 180),
+            record(386, 1920, 1080, freq: 180),
+        ])
+        XCTAssertEqual(ids, [386])
+    }
+
+    /// Same size and rate at different densities is NOT a pair: a 2560x1440@60 1x mode
+    /// and a 2560x1440@60 HiDPI mode are different resolutions to the user.
+    func testDifferentDensityIsNotAPair() {
+        let ids = VariableRefreshModes.variableModeIDs(from: [
+            record(686, 2560, 1440, freq: 60, density: 1.0),
+            record(727, 2560, 1440, freq: 60, density: 2.0),
+        ])
+        XCTAssertEqual(ids, [])
+    }
+
+    /// Unusable (0x40000000-flagged) modes never form pairs: the AOC lists many
+    /// byte-identical hidden encoding variants that must not trigger detection.
+    func testUnusableModesAreIgnored() {
+        let ids = VariableRefreshModes.variableModeIDs(from: [
+            record(731, 400, 300, freq: 180, density: 2.0, flags: 0x4000_0000),
+            record(732, 400, 300, freq: 180, density: 2.0, flags: 0x4000_0000),
+        ])
+        XCTAssertEqual(ids, [])
+    }
+
+    /// Singletons (every rate on a fixed-rate panel) produce nothing: the DELL U2412M
+    /// and built-in ProMotion tables have zero usable duplicates.
+    func testFixedRatePanelProducesNothing() {
+        let ids = VariableRefreshModes.variableModeIDs(from: [
+            record(1, 1920, 1200, freq: 60),
+            record(2, 1920, 1200, freq: 50),
+            record(3, 1600, 1200, freq: 60),
+        ])
+        XCTAssertEqual(ids, [])
+    }
+
+    /// Three-or-more identical usable modes were never observed on hardware; the
+    /// detector classifies nothing there rather than guessing.
+    func testTripleGroupIsSkipped() {
+        let ids = VariableRefreshModes.variableModeIDs(from: [
+            record(1, 800, 600, freq: 120),
+            record(2, 800, 600, freq: 120),
+            record(3, 800, 600, freq: 120),
+        ])
+        XCTAssertEqual(ids, [])
+    }
+
+    /// Multiple pairs across rates each resolve independently (the AOC pairs every
+    /// rate inside its 48-180 adaptive range).
+    func testEveryRatePairResolvesIndependently() {
+        let ids = VariableRefreshModes.variableModeIDs(from: [
+            record(680, 2560, 1440, freq: 180, flags: 0x0200_0001),
+            record(681, 2560, 1440, freq: 180, flags: 0x0200_0007),
+            record(727, 2560, 1440, freq: 60, density: 2.0),
+            record(728, 2560, 1440, freq: 60, density: 2.0),
+        ])
+        XCTAssertEqual(ids, [680, 727])
+    }
+
+    func testEmptyInputProducesNothing() {
+        XCTAssertEqual(VariableRefreshModes.variableModeIDs(from: []), [])
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -53,6 +53,7 @@ targets:
       - path: Crisp/Models/DDCServiceMatcher.swift
       - path: Crisp/Models/RefreshRateFormat.swift
       - path: Crisp/Models/GammaPersistenceKey.swift
+      - path: Crisp/Models/VariableRefreshModes.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.crisp.tests


### PR DESCRIPTION
Fixes #31.

On a VRR external, macOS's mode table carries two otherwise identical usable entries per rate inside the panel's adaptive range, one fixed and one variable, and nothing public tells them apart per mode. Crisp rendered them as duplicate Hz rows (the two 165Hz entries in the issue). This PR detects the variable twin and labels it like System Settings.

**Detection** (`VariableRefreshModes`, pure and unit-tested): group usable raw CGS modes by size + rate + backing density; in each exact pair, the twin without `kDisplayModeDefaultFlag` is the variable one, falling back to the lower mode number when flags tie (scaled pairs are flag-identical). Verified on real hardware (AOC Q27G3XMN, 48-180Hz adaptive range) with live NSScreen refresh-range checks after actually switching into both members of three different pairs: 180Hz native, 180Hz scaled, 60Hz HiDPI. The variable twin enumerated first in all three, and the flag bits stayed put when the active mode changed, so they are a stable property of the table, not selection state.

**Label**: the variable twin reads "Variable (48-180Hz)" like System Settings. The adaptive floor comes from the IORegistry (`IOMobileFramebufferShim` timing elements, matched by the panel's vendor/product id, which the node's `EDID UUID` embeds in raw EDID byte order); when the registry exposes no range (e.g. non-DCP framebuffers) the label falls back to "Variable (up to 180Hz)". Both strings localized (en + zh-Hans).

**List shape**: macOS mints a variable twin for every rate in the range (verified: even the 60Hz HiDPI pair runs 48-60 variable), but System Settings shows a single Variable row, so Crisp keeps only the family's top variable twin and sorts it above its fixed sibling. Everything else is untouched.

**False-positive controls**: a fixed-rate DELL U2412M and the built-in ProMotion panel both expose zero usable duplicate pairs, so non-VRR displays and the existing ProMotion label are unaffected.

**Verified**: `make compile` clean; 9 headless XCTests for the detector (fixtures taken from the real mode tables); the shipped detector run end-to-end against three live displays classified all seven live-confirmed mode ids correctly; dev build tested in the real UI on all three displays.

The groundwork probe from #39 (`scripts/vrr-probe.swift`) is what made the reverse-engineering possible; monitors with different VRR behavior can be diagnosed with it if reports come in.