### PR TITLE
docs: note that presets do not store image adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Or download [`Crisp.dmg`](https://github.com/didriksg/Crisp/releases/latest/down
 - **Brightness everywhere**: controls the real backlight of external monitors (DDC), dims via software on monitors that don't support that, and can keep dimming below the hardware minimum. Smooth fades, and brightness keys that follow the pointer, target all displays, or a chosen subset
 - **Extra Brightness**: push XDR MacBook panels and HDR monitors past 100% by unlocking their HDR brightness reserve, up to the panel's full headroom (the feature BetterDisplay sells as brightness upscaling). One toggle per display, then the normal slider and brightness keys simply reach further. Sustained maximum brightness increases power draw, and real HDR video can look overblown while boosted
 - **Volume**: control the built-in speaker volume of external monitors over DDC, with a slider per display and the keyboard volume/mute keys mapped to the monitor when it's your audio output. Shows only for monitors that support it, and can be hidden entirely from Settings
-- **Presets**: save named display configurations (resolution, brightness, arrangement) with custom icons and colors, apply with one click, update in place
+- **Presets**: save named display configurations (resolution, brightness, arrangement) with custom icons and colors, apply with one click, update in place. Image adjustment (gamma, color temperature, contrast) is per-display and not stored in presets
 - **Display arrangement**: drag-to-arrange canvas, main display switching
 - **Disconnect displays**: turn physical displays off and back on from the menu, remembered across sleep/wake (Apple Silicon)
 - **System toggles**: Dark Mode, Night Shift, and True Tone, one click from the menu bar


### PR DESCRIPTION
Split out from #32 as #40. Presets store resolution, brightness, and arrangement, but not the Image Adjustment values (gamma, color temperature, contrast), and updating a preset does not record them either. That scope is intentional for now, but it surprises people, so the README's preset bullet now says so.

Skipped an in-app hint: it would add a localized string (en + zh-Hans) and extra text to a UI that deliberately stays minimal. Worth revisiting only if the confusion keeps showing up in issues.

Closes #40