### PR TITLE
chore: make toolchain comments machine-neutral

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,9 @@ jobs:
             exit 1
           fi
       # Lint, enforcing: the baseline is clean, so any violation (warning or
-      # error) fails via --strict. Locally run with SWIFTLINT_DISABLE_SOURCEKIT=1
-      # on CLT-only machines; the runner has full Xcode so SourceKit loads here.
+      # error) fails via --strict. Run locally with `swiftlint lint --strict`;
+      # without full Xcode, SWIFTLINT_DISABLE_SOURCEKIT=1 skips the
+      # SourceKit-backed rules, so CI stays the authoritative check.
       #
       # The macos-26 image ships no swiftlint, so install it explicitly (a
       # missing binary used to be swallowed as a silent no-op).
@@ -36,10 +37,11 @@ jobs:
         run: HOMEBREW_NO_AUTO_UPDATE=1 brew install swiftlint xcodegen
       - name: Lint (SwiftLint)
         run: swiftlint lint --strict --reporter github-actions-logging
-      # Unit tests. The dev machine is CLT-only and cannot run xcodebuild, so CI
-      # is the only place the suite actually executes; without this step the
-      # tests in CrispTests are dead weight (that is how the "-- Hz" bug and the
-      # untested doc-comment contract in DisplayMode survived to a release).
+      # Unit tests. Run locally with `make test` (needs full Xcode; the app
+      # itself builds with just the Command Line Tools). CI is the enforced
+      # gate: the suite was once never executed anywhere, which is how the
+      # "-- Hz" bug and the untested doc-comment contract in DisplayMode
+      # survived to a release.
       - name: Test
         run: make test
       # Every localization key the code uses must exist in the String Catalog.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,6 @@
-# SwiftLint config. Enforced in CI (see .github/workflows/ci.yml). Runs locally
-# too on Command Line Tools-only machines with SWIFTLINT_DISABLE_SOURCEKIT=1
-# (SourceKit-backed analyzer rules are skipped there; CI is the full check).
+# SwiftLint config. Enforced in CI (see .github/workflows/ci.yml); run locally
+# with `swiftlint lint --strict`. Without full Xcode, prefix
+# SWIFTLINT_DISABLE_SOURCEKIT=1 (skips the SourceKit-backed rules).
 
 disabled_rules:
   - todo                                     # `ponytail:` / TODO notes are intentional here


### PR DESCRIPTION
Comments in ci.yml and the .swiftlint.yml header described a specific dev machine's toolchain: "the dev machine is CLT-only", "CI is the only place the suite actually executes", "local runs need the SourceKit workaround". That framing means nothing to anyone else cloning the repo.

Rewritten to state only machine-independent facts: `make test` needs full Xcode (the app itself builds with just the Command Line Tools), `swiftlint lint --strict` runs anywhere (with a documented fallback for setups without full Xcode), and CI enforces both on every PR either way.

Requirement notes in the Makefile, dev.sh, README, and BUILDING.md were already machine-neutral and are untouched.