### PR TITLE
chore: add 'make check' local CI parity and clear mechanical warnings

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Runs the same checks CI enforces before every push. Opt in once with:
+#   git config core.hooksPath .githooks
+# Bypass for a single push with: git push --no-verify
+exec make check

--- a/Crisp/Services/BrightnessKeyService.swift
+++ b/Crisp/Services/BrightnessKeyService.swift
@@ -43,26 +43,26 @@ final class BrightnessKeyService: @unchecked Sendable {
     private var disabledAt: TimeInterval = 0
 
     // MARK: - NX Media Key Constants
-    // Marked nonisolated(unsafe) so they can be read from the nonisolated callback method.
-    // These are immutable compile-time constants so there is no data-race risk.
+    // Read from the nonisolated callback method; immutable Sendable `static let`s
+    // are implicitly nonisolated, so that is safe without any annotation.
 
     /// CGEventType raw value for NSSystemDefined / NX_SYSDEFINED events (media keys).
-    private nonisolated(unsafe) static let cgEventTypeSystemDefinedRaw: UInt32 = 14
+    private static let cgEventTypeSystemDefinedRaw: UInt32 = 14
     /// NX_SUBTYPE_AUX_CONTROL_BUTTONS, the subtype value for media/function keys.
-    private nonisolated(unsafe) static let nxSubtypeAuxControlButtons: Int16 = 8
+    private static let nxSubtypeAuxControlButtons: Int16 = 8
     /// NX_KEYTYPE_BRIGHTNESS_UP
-    private nonisolated(unsafe) static let nxKeytypeBrightnessUp: Int = 2
+    private static let nxKeytypeBrightnessUp: Int = 2
     /// NX_KEYTYPE_BRIGHTNESS_DOWN
-    private nonisolated(unsafe) static let nxKeytypeBrightnessDown: Int = 3
+    private static let nxKeytypeBrightnessDown: Int = 3
     /// NX_KEYTYPE_SOUND_UP / NX_KEYTYPE_SOUND_DOWN / NX_KEYTYPE_MUTE
-    private nonisolated(unsafe) static let nxKeytypeSoundUp: Int = 0
-    private nonisolated(unsafe) static let nxKeytypeSoundDown: Int = 1
-    private nonisolated(unsafe) static let nxKeytypeMute: Int = 7
+    private static let nxKeytypeSoundUp: Int = 0
+    private static let nxKeytypeSoundDown: Int = 1
+    private static let nxKeytypeMute: Int = 7
 
     /// Each key press moves brightness by 1/16 (≈ 6.25 %), matching macOS native behaviour.
-    private nonisolated(unsafe) static let brightnessStep: Double = 100.0 / 16.0
+    private static let brightnessStep: Double = 100.0 / 16.0
     /// Volume keys use the same 1/16 step as macOS's own volume control.
-    private nonisolated(unsafe) static let volumeStep: Double = 100.0 / 16.0
+    private static let volumeStep: Double = 100.0 / 16.0
 
     // MARK: - Start / Stop
 

--- a/Crisp/Services/DisplayManager.swift
+++ b/Crisp/Services/DisplayManager.swift
@@ -112,7 +112,7 @@ class DisplayManager: ObservableObject {
         }
 
         // Diff-based refresh: keep existing DisplayInfo objects (preserves @Published state)
-        var existingByID = Dictionary(uniqueKeysWithValues: displays.map { ($0.displayID, $0) })
+        let existingByID = Dictionary(uniqueKeysWithValues: displays.map { ($0.displayID, $0) })
 
         var updatedDisplays: [DisplayInfo] = []
         var addedDisplays: [DisplayInfo] = []

--- a/Crisp/Services/GammaService.swift
+++ b/Crisp/Services/GammaService.swift
@@ -156,7 +156,7 @@ final class GammaService: @unchecked Sendable {
     /// is restored, preventing a "flat" / uncalibrated appearance after reset.
     /// Prefer this over `restoreColorSync()` whenever only one display needs resetting.
     func resetSingleDisplay(_ displayID: CGDirectDisplayID) {
-        adjustmentsLock.withLock { activeAdjustments.removeValue(forKey: displayID) }
+        _ = adjustmentsLock.withLock { activeAdjustments.removeValue(forKey: displayID) }
         let size = 256
         var r = (0..<size).map { CGGammaValue($0) / CGGammaValue(size - 1) }
         var g = r; var b = r

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 #   make dev        compile, swap the binary into /Applications/Crisp.app, relaunch
 #   make compile    compile the binary only (./Crisp-bin), no swap — quick build check
 #   make test       generate the Xcode project and run unit tests
+#   make check      lint + tests, everything CI enforces: run before pushing
+#                   (auto-run on every push after: git config core.hooksPath .githooks)
 #
 # Distributable DMG:
 #   make build      signed universal (arm64 + x86_64) DMG via scripts/release.sh (dry run)
@@ -19,6 +21,12 @@
 # Single source of truth for the version: project.yml (used to tag the dry-run DMG).
 VERSION := $(shell grep -E '^[[:space:]]*MARKETING_VERSION:' project.yml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
 
+# Use Xcode.app's toolchain when installed, even if xcode-select still points at
+# the Command Line Tools: xcodebuild (test) and SwiftLint's SourceKit need it.
+ifneq (,$(wildcard /Applications/Xcode.app))
+export DEVELOPER_DIR ?= /Applications/Xcode.app/Contents/Developer
+endif
+
 # swiftc invocation kept in sync with dev.sh's compile step.
 SWIFT_SOURCES := Crisp/App/*.swift Crisp/Models/*.swift Crisp/Services/*.swift \
                  Crisp/Views/*.swift Crisp/Utilities/*.swift
@@ -28,13 +36,14 @@ SWIFTC_FLAGS := -O -swift-version 5 -strict-concurrency=minimal -parse-as-librar
                 -Xlinker -undefined -Xlinker dynamic_lookup
 
 .DEFAULT_GOAL := help
-.PHONY: help dev compile test build dmg release clean
+.PHONY: help dev compile test lint check build dmg release clean
 
 help:
 	@echo "Crisp — make targets:"
 	@echo "  make dev        compile + swap into /Applications/Crisp.app + relaunch (dev.sh)"
 	@echo "  make compile    compile ./Crisp-bin only, no swap (quick build check)"
 	@echo "  make test       generate the Xcode project and run unit tests"
+	@echo "  make check      lint + tests, everything CI enforces (run before pushing)"
 	@echo "  make build      signed universal DMG, no Xcode (scripts/release.sh v$(VERSION))"
 	@echo "  make dmg        DMG via Xcode (scripts/build-dmg.sh)"
 	@echo "  make release ARGS=\"vX.Y.Z notes.md --publish\"   full release (scripts/release.sh)"
@@ -53,6 +62,14 @@ test:
 	xcodebuild -quiet test -project Crisp.xcodeproj -scheme Crisp \
 		-destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO \
 		SWIFT_VERSION=5 SWIFT_STRICT_CONCURRENCY=minimal
+
+lint:
+	@command -v swiftlint >/dev/null || { echo "SwiftLint not installed: brew install swiftlint"; exit 1; }
+	swiftlint lint --strict --quiet
+
+# Everything CI enforces (lint + build + tests), locally.
+check: lint test
+	@echo "check passed: lint clean, tests green"
 
 build:
 	./scripts/release.sh v$(VERSION)

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -31,4 +31,15 @@ open /Applications/Crisp.app
 
 This is the fast dev loop: edit, compile, swap, relaunch, no Xcode involved.
 
+## Before opening a PR
+
+Run `make check`: it runs SwiftLint (strict) and the unit tests, the same
+checks CI enforces, so failures surface locally instead of on the PR. The test
+step needs full Xcode and `xcodegen` (`brew install swiftlint xcodegen`). To
+run it automatically on every push, opt in once:
+
+```sh
+git config core.hooksPath .githooks
+```
+
 The app icon is generated from vector code: `scripts/generate-icon.swift`.


### PR DESCRIPTION
Catching problems should not require pushing and waiting for CI. This adds the local loop:

- **`make check`**: SwiftLint (strict) + the unit tests, the same set CI enforces. Documented in BUILDING.md.
- **Optional pre-push hook**: `git config core.hooksPath .githooks` makes every push run `make check` first (`--no-verify` bypasses when needed).
- **Toolchain fallback**: the Makefile now uses /Applications/Xcode.app's toolchain when `xcode-select` points at the Command Line Tools, so `make test` and full-SourceKit lint work without a system-level switch.

Also clears the mechanical tier of compiler warnings (48 -> 36): nine redundant `nonisolated(unsafe)` annotations on immutable Sendable constants (implicitly nonisolated since SE-0434), one never-mutated `var`, one unused `withLock` result. The remaining 36 are strict-concurrency debt plus one deprecated API; those need per-site care and are deliberately not part of this change.

Verified: `make check` passes locally end to end (lint clean, 52/52 tests).