### PR TITLE
Resolve all strict-concurrency warnings and enforce warnings-as-errors

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,4 +2,10 @@
 # Runs the same checks CI enforces before every push. Opt in once with:
 #   git config core.hooksPath .githooks
 # Bypass for a single push with: git push --no-verify
-exec make check
+# Skip delete-only pushes (local sha is all zeros): nothing new to check.
+while read -r _ local_sha _ _; do
+	case "$local_sha" in
+	*[!0]*) exec make check ;;
+	esac
+done
+exit 0

--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -117,7 +117,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.onWake?()
+            // Delivered on `queue: .main`, so the main actor is current.
+            MainActor.assumeIsolated { self?.onWake?() }
         }
 
         setupStartupBehavior()
@@ -916,8 +917,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }, completionHandler: { [weak self] in
             // Hidden now: tell the content to collapse its tool/nav sections so the
             // next open is fresh. Skip if the panel was reopened during the fade.
-            guard let self, !self.isPanelShown else { return }
-            NotificationCenter.default.post(name: .crispPanelDidClose, object: nil)
+            // Animation completion runs on the main thread.
+            MainActor.assumeIsolated {
+                guard let self, !self.isPanelShown else { return }
+                NotificationCenter.default.post(name: .crispPanelDidClose, object: nil)
+            }
         })
         if let monitor = clickMonitor {
             NSEvent.removeMonitor(monitor)

--- a/Crisp/App/PanelCanvas.swift
+++ b/Crisp/App/PanelCanvas.swift
@@ -208,7 +208,7 @@ final class PanelBlock {
 /// keeps window frame + block frames consistent every tick.
 @MainActor
 final class PanelCanvas {
-    static let log = Logger(subsystem: "com.crisp.app", category: "panelcanvas")
+    nonisolated static let log = Logger(subsystem: "com.crisp.app", category: "panelcanvas")
     /// For the spring's tick log sub-timings (single instance in practice).
     static weak var shared: PanelCanvas?
 

--- a/Crisp/Services/BrightnessKeyService.swift
+++ b/Crisp/Services/BrightnessKeyService.swift
@@ -43,26 +43,26 @@ final class BrightnessKeyService: @unchecked Sendable {
     private var disabledAt: TimeInterval = 0
 
     // MARK: - NX Media Key Constants
-    // Read from the nonisolated callback method; immutable Sendable `static let`s
-    // are implicitly nonisolated, so that is safe without any annotation.
+    // `nonisolated` (immutable Sendable constants) so the nonisolated tap
+    // callback can read them without hopping to the main actor.
 
     /// CGEventType raw value for NSSystemDefined / NX_SYSDEFINED events (media keys).
-    private static let cgEventTypeSystemDefinedRaw: UInt32 = 14
+    private nonisolated static let cgEventTypeSystemDefinedRaw: UInt32 = 14
     /// NX_SUBTYPE_AUX_CONTROL_BUTTONS, the subtype value for media/function keys.
-    private static let nxSubtypeAuxControlButtons: Int16 = 8
+    private nonisolated static let nxSubtypeAuxControlButtons: Int16 = 8
     /// NX_KEYTYPE_BRIGHTNESS_UP
-    private static let nxKeytypeBrightnessUp: Int = 2
+    private nonisolated static let nxKeytypeBrightnessUp: Int = 2
     /// NX_KEYTYPE_BRIGHTNESS_DOWN
-    private static let nxKeytypeBrightnessDown: Int = 3
+    private nonisolated static let nxKeytypeBrightnessDown: Int = 3
     /// NX_KEYTYPE_SOUND_UP / NX_KEYTYPE_SOUND_DOWN / NX_KEYTYPE_MUTE
-    private static let nxKeytypeSoundUp: Int = 0
-    private static let nxKeytypeSoundDown: Int = 1
-    private static let nxKeytypeMute: Int = 7
+    private nonisolated static let nxKeytypeSoundUp: Int = 0
+    private nonisolated static let nxKeytypeSoundDown: Int = 1
+    private nonisolated static let nxKeytypeMute: Int = 7
 
     /// Each key press moves brightness by 1/16 (≈ 6.25 %), matching macOS native behaviour.
-    private static let brightnessStep: Double = 100.0 / 16.0
+    private nonisolated static let brightnessStep: Double = 100.0 / 16.0
     /// Volume keys use the same 1/16 step as macOS's own volume control.
-    private static let volumeStep: Double = 100.0 / 16.0
+    private nonisolated static let volumeStep: Double = 100.0 / 16.0
 
     // MARK: - Start / Stop
 
@@ -140,8 +140,11 @@ final class BrightnessKeyService: @unchecked Sendable {
         // lands. The activation observer just makes it feel instant when the user clicks back in.
         if pollTimer == nil {
             pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] timer in
-                guard let self else { timer.invalidate(); return }
-                self.armIfSettled()
+                // Scheduled from the main actor, so it fires on the main run loop.
+                MainActor.assumeIsolated {
+                    guard let self else { timer.invalidate(); return }
+                    self.armIfSettled()
+                }
             }
         }
         if activationObserver == nil {
@@ -190,11 +193,14 @@ final class BrightnessKeyService: @unchecked Sendable {
         // ponytail: 0.5s poll, well inside the ~1s WindowServer tap-timeout; AXIsProcessTrusted()
         // is a cheap TCC lookup so 2x/sec while armed is negligible.
         trustWatchdog = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] timer in
-            guard let self else { timer.invalidate(); return }
-            guard self.eventTap != nil, !AXIsProcessTrusted() else { return }
-            self.disabledAt = ProcessInfo.processInfo.systemUptime
-            self.stop()
-            self.retryUntilArmed()
+            // Scheduled from the main actor, so it fires on the main run loop.
+            MainActor.assumeIsolated {
+                guard let self else { timer.invalidate(); return }
+                guard self.eventTap != nil, !AXIsProcessTrusted() else { return }
+                self.disabledAt = ProcessInfo.processInfo.systemUptime
+                self.stop()
+                self.retryUntilArmed()
+            }
         }
     }
 

--- a/Crisp/Services/ColorProfileService.swift
+++ b/Crisp/Services/ColorProfileService.swift
@@ -187,7 +187,7 @@ final class ColorProfileService: @unchecked Sendable {
     func colorModeDescription(for displayID: CGDirectDisplayID) -> String {
         guard let mode = CGDisplayCopyDisplayMode(displayID) else { return "Unknown" }
         let encoding: String
-        if let cfEnc = mode.pixelEncoding { encoding = cfEnc as String } else { encoding = "" }
+        if let cfEnc = (mode as DisplayModePixelEncoding).pixelEncoding { encoding = cfEnc as String } else { encoding = "" }
         let bpc = bitsPerChannel(from: encoding)
         let source = CGDisplayIsBuiltin(displayID) != 0 ? "Internal" : "External"
         return "\(source) (\(bpc)-bit)"
@@ -285,3 +285,12 @@ final class ColorProfileService: @unchecked Sendable {
         )
     }
 }
+
+/// `CGDisplayMode.pixelEncoding` is deprecated (macOS 10.11, "No longer
+/// supported") but still returns real data and is the only source for the
+/// panel's bits-per-channel. Reading it through this protocol witness
+/// acknowledges the deprecation once instead of warning at every call site.
+private protocol DisplayModePixelEncoding {
+    var pixelEncoding: CFString? { get }
+}
+extension CGDisplayMode: DisplayModePixelEncoding {}

--- a/Crisp/Services/CoreBrightnessService.swift
+++ b/Crisp/Services/CoreBrightnessService.swift
@@ -80,12 +80,14 @@ final class CoreBrightnessService: ObservableObject {
     /// The reads are XPC round-trips, so they run off the main thread to keep
     /// panel opening snappy; results publish back on main.
     func refresh() {
-        let blueClient = blueLightClient
-        let ttClient = trueToneClient
+        // The CoreBrightness XPC client objects are safe to message from any
+        // thread, but NSObject is not Sendable; box them across the hop.
+        let blueBox = UncheckedSendable(value: blueLightClient)
+        let ttBox = UncheckedSendable(value: trueToneClient)
         let ttAvailable = trueToneAvailable
         DispatchQueue.global(qos: .userInitiated).async {
             var nightShift: Bool?
-            if let c = blueClient {
+            if let c = blueBox.value {
                 var buf = [UInt8](repeating: 0, count: 64)
                 let sel = NSSelectorFromString("getBlueLightStatus:")
                 if c.responds(to: sel) {
@@ -98,7 +100,7 @@ final class CoreBrightnessService: ObservableObject {
                 }
             }
             var trueTone: Bool?
-            if let c = ttClient, ttAvailable {
+            if let c = ttBox.value, ttAvailable {
                 trueTone = Self.boolCall(c, "enabled")
             }
             let dark = _SLSGetAppearanceTheme?()
@@ -177,3 +179,8 @@ final class CoreBrightnessService: ObservableObject {
         unsafeBitCast(obj.method(for: sel), to: Fn.self)(obj, sel, v)
     }
 }
+
+/// Carries a value across a `@Sendable` boundary the compiler cannot verify.
+/// Only for objects that are documented or observed thread-safe to message
+/// (here: the CoreBrightness XPC client objects).
+private struct UncheckedSendable<T>: @unchecked Sendable { let value: T }

--- a/Crisp/Services/EDROverlayManager.swift
+++ b/Crisp/Services/EDROverlayManager.swift
@@ -137,7 +137,8 @@ final class EDROverlayManager {
         // long as the overlay exists (matches BrightIntosh's MTKView-driven
         // approach; ours stays a CAMetalLayer + Timer to keep the diff small).
         let timer = Timer(timeInterval: 0.2, repeats: true) { [weak self] _ in
-            self?.render(for: displayID)
+            // Added to RunLoop.main below, so it fires on the main run loop.
+            MainActor.assumeIsolated { self?.render(for: displayID) }
         }
         RunLoop.main.add(timer, forMode: .common)
         overlays[displayID]?.timer = timer

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,15 @@ compile:
 	swiftc $(SWIFTC_FLAGS) $(SWIFT_SOURCES) -o Crisp-bin
 	@echo "Done. ./Crisp-bin built (not swapped into the app; use 'make dev' for that)."
 
+# Warnings are errors here (the baseline is zero, issue #47), so a PR that
+# introduces one fails make check and CI. `make compile` stays permissive for
+# mid-iteration builds.
 test:
 	xcodegen generate
 	xcodebuild -quiet test -project Crisp.xcodeproj -scheme Crisp \
 		-destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO \
-		SWIFT_VERSION=5 SWIFT_STRICT_CONCURRENCY=minimal
+		SWIFT_VERSION=5 SWIFT_STRICT_CONCURRENCY=minimal \
+		SWIFT_TREAT_WARNINGS_AS_ERRORS=YES
 
 lint:
 	@command -v swiftlint >/dev/null || { echo "SwiftLint not installed: brew install swiftlint"; exit 1; }


### PR DESCRIPTION
Closes #47.

The build is now warning-free under both toolpaths (swiftc via `make compile`, xcodebuild via `make test`), and `make test` sets `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES`, so a PR that introduces any warning fails `make check` locally and CI remotely, the same treatment lint got in #42.

How each class of warning was resolved:

- **Main-runloop callbacks touching main-actor state** (poll and watchdog timers in BrightnessKeyService, the wake observer and panel-fade completion in AppDelegate, the 5fps overlay timer in EDROverlayManager): wrapped in `MainActor.assumeIsolated`. Every one of these provably runs on the main run loop (timers scheduled from the main actor, `queue: .main` observers, animation completion), and `assumeIsolated` asserts that instead of assuming it silently. Same pattern the event-tap callback already used.
- **Immutable constants read from nonisolated contexts** (the NX media-key constants, PanelCanvas's `Logger`): explicit `nonisolated static let`. Immutable Sendable values, safe from any context.
- **CoreBrightness XPC clients captured in a `@Sendable` background hop**: carried in a small `@unchecked Sendable` box with the thread-safety rationale documented at the type.
- **Deprecated `CGDisplayMode.pixelEncoding`**: read through a private protocol witness, acknowledging the deprecation once; it remains the only source for bits-per-channel and still returns real data.

Also: the pre-push hook now skips delete-only pushes (it pointlessly ran the full check when deleting a remote branch).

Verified: `make check` green end to end with enforcement active (lint clean, 52/52 tests, localization keys complete), zero warnings from both compilers.