### PR TITLE
perf: eliminate idle wakeups, event-driven display waits, stale-state pruning

### DIFF
--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -48,6 +48,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// rectangle) on every reopen. Hidden = alpha 0 + click-through instead,
     /// so track shown-ness ourselves; isVisible stays true.
     private var isPanelShown = false
+    /// Mirrors external state changes (Control Center, brightness keys, other
+    /// apps) into the sliders while the panel is open. Started by showPanel,
+    /// cancelled by closePanel: nothing polls while the panel is hidden;
+    /// showPanel's click-time refresh covers state that drifted while closed.
+    private var externalStatePollTask: Task<Void, Never>?
 
     /// Called after wake-from-sleep; wired in setupStartupBehavior.
     var onWake: (() -> Void)?
@@ -192,14 +197,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // the split-canvas migration.
         Task { await UpdateService.shared.checkForUpdates() }
 
-        // Mirror changes made elsewhere (Control Center, brightness keys,
-        // other apps) while the panel is visible. Poll forever but only touch
-        // hardware when shown.
-        Task { [weak self] in
-            while !Task.isCancelled {
-                self?.pollExternalState()
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-            }
+    }
+
+    /// One-shot re-sync of everything that can drift while the panel is closed
+    /// (Night Shift/True Tone via Control Center, DDC brightness changed by the
+    /// monitor's own buttons or another app). All reads run off the main
+    /// thread; called at the click in showPanel.
+    private func refreshExternalState() {
+        CoreBrightnessService.shared.refresh()
+        for display in displayManager.displays {
+            Task { await BrightnessService.shared.refreshBrightness(for: display) }
         }
     }
 
@@ -479,6 +486,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         p.ignoresMouseEvents = true
         p.orderFrontRegardless()
         canvas.prePaint()
+        // Warm-up done, panel hidden: no vsync ticks until the first open.
+        canvas.parkSpring()
     }
 
     /// Displays that get their own section, in panel order (screen the panel
@@ -798,10 +807,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         warmPanel()
         guard let p = panel else { return }
 
+        // Kick the refresh of everything that can drift while the panel is
+        // closed NOW, at the click: the reads run off the main thread and land
+        // during the fade-in, so the sliders are correct by the time the panel
+        // is readable instead of visibly jumping shortly after it opened.
+        refreshExternalState()
+
         // Native menus appear at full size with all content visible at once;
         // only size changes AFTER opening animate.
         positionPanel(p)
         canvas.retargetLinkIfNeeded()
+        canvas.wakeSpring()
         // The display order can differ per open (panel-screen-first sort);
         // rebuild happens hidden, before the fade.
         rebuildBlocksIfNeeded()
@@ -859,11 +875,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // .task can't). checkForUpdates() self-throttles to one network call per
         // hour, so opening the menu repeatedly costs nothing.
         Task { await UpdateService.shared.checkForUpdates() }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
-            guard let self, self.isPanelShown else { return }
-            CoreBrightnessService.shared.refresh()
-            for display in self.displayManager.displays {
-                Task { await BrightnessService.shared.refreshBrightness(for: display) }
+
+        // Mirror changes made elsewhere while the panel stays open (the
+        // click-time refresh above covered the open itself). Cancelled on
+        // close: a hidden panel needs no heartbeat.
+        if externalStatePollTask == nil {
+            externalStatePollTask = Task { [weak self] in
+                while !Task.isCancelled {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    self?.pollExternalState()
+                }
             }
         }
 
@@ -907,6 +928,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         guard let p = panel, isPanelShown else { return }
         isPanelShown = false
         statusItem?.button?.highlight(false)
+        canvas.parkSpring()
+        externalStatePollTask?.cancel()
+        externalStatePollTask = nil
         // Hide with a quick fade, like native menus; never order out (see
         // isPanelShown comment). Click-through is immediate.
         p.ignoresMouseEvents = true

--- a/Crisp/App/PanelCanvas.swift
+++ b/Crisp/App/PanelCanvas.swift
@@ -116,6 +116,15 @@ final class FrameSpring: NSObject {
         velocity = 0
     }
 
+    var isAnimating: Bool { active }
+
+    /// Park/unpark the vsync tick while the panel is hidden. Pausing (not
+    /// invalidating) keeps the never-create-on-demand rule: the link object
+    /// survives, so resuming at open has it hot long before the first toggle.
+    func setPaused(_ paused: Bool) {
+        link?.isPaused = paused
+    }
+
     @objc private func tick(_ l: CADisplayLink) {
         let now = CACurrentMediaTime()
         let gap = (now - lastTick) * 1000
@@ -707,6 +716,19 @@ final class PanelCanvas {
         spring.retarget(view: v)
         linkScreen = screen
         PanelCanvas.log.log("link fps=\(screen.maximumFramesPerSecond)")
+    }
+
+    /// Stop the vsync wakeups while the panel is hidden: idle ticks are no-ops,
+    /// but 60-165 process wakeups per second all day are not free. Snap any
+    /// in-flight animation first so a paused link cannot strand onSettle's
+    /// cleanup (unmuting, window tighten).
+    func parkSpring() {
+        if spring.isAnimating { snapToTargets() }
+        spring.setPaused(true)
+    }
+
+    func wakeSpring() {
+        spring.setPaused(false)
     }
 
     /// Warm-up pre-paint: draw every block once while the panel is invisible

--- a/Crisp/Services/BrightnessBoostService.swift
+++ b/Crisp/Services/BrightnessBoostService.swift
@@ -355,6 +355,18 @@ final class BrightnessBoostService {
         EDROverlayManager.shared.removeAll()
     }
 
+    /// Drop all per-display state for a disconnected display so a reused
+    /// displayID cannot inherit it (same hazard as BrightnessService's
+    /// invalidateDDCState; DisplayManager calls both from its removed loop).
+    func invalidate(for displayID: CGDirectDisplayID) {
+        maxAnimators[displayID]?.cancel()
+        maxAnimators.removeValue(forKey: displayID)
+        headroomLossSince.removeValue(forKey: displayID)
+        hdrRequestGeneration.removeValue(forKey: displayID)
+        collapsingDisplays.remove(displayID)
+        hdrSupportCache.removeValue(forKey: displayID)
+    }
+
     @objc private func screenParametersChanged() {
         // DisplayIDs can be reassigned across a reconfiguration; drop the
         // capability cache before anything re-reads it.
@@ -411,9 +423,13 @@ final class BrightnessBoostService {
         }
         // Wait on the live collapse set, not the isEnabled flag: a collapse
         // started moments earlier from the Extra Brightness row has already
-        // cleared the flag but is still animating this display.
-        while collapsingDisplays.contains(displayID) {
+        // cleared the flag but is still animating this display. Capped at 2s
+        // (the collapse runs 0.35s): an animator cancelled without its final
+        // tick would otherwise leave the marker set and spin this forever.
+        var waited = 0
+        while collapsingDisplays.contains(displayID), waited < 40 {
             try? await Task.sleep(nanoseconds: 50_000_000)
+            waited += 1
         }
         // Brief settle so the collapse's last brightness write lands
         // before the mode switch.

--- a/Crisp/Services/BrightnessBoostService.swift
+++ b/Crisp/Services/BrightnessBoostService.swift
@@ -49,6 +49,11 @@ final class BrightnessBoostService {
     /// once nothing is boosted.
     private var headroomPollTask: Task<Void, Never>?
 
+    /// Pending post-reconfiguration reconcile. One at a time: a connect or
+    /// disconnect storm posts didChangeScreenParametersNotification many
+    /// times, and each reapplyAll is a full DDC/gamma/overlay pass.
+    private var reapplyAfterReconfigTask: Task<Void, Never>?
+
     /// When an enabled external first reported potentialHeadroom at or below
     /// hdrReadyThreshold: HDR capability disappeared out from under it (user
     /// turned HDR off, or a HiDPI mode switch dropped HDR advertisement).
@@ -354,10 +359,13 @@ final class BrightnessBoostService {
         // DisplayIDs can be reassigned across a reconfiguration; drop the
         // capability cache before anything re-reads it.
         hdrSupportCache.removeAll()
-        // Reconcile after connect/disconnect storms settle (mirrors the panel's
-        // own debounce; mid-reconfig geometry and headroom reads are garbage).
-        Task { @MainActor in
+        // Reconcile ONCE after connect/disconnect storms settle (mirrors the
+        // panel's own debounce; mid-reconfig geometry and headroom reads are
+        // garbage): cancel any reconcile a previous notification scheduled.
+        reapplyAfterReconfigTask?.cancel()
+        reapplyAfterReconfigTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
+            guard !Task.isCancelled else { return }
             self.reapplyAll()
         }
     }

--- a/Crisp/Services/BrightnessService.swift
+++ b/Crisp/Services/BrightnessService.swift
@@ -692,8 +692,9 @@ final class BrightnessService: @unchecked Sendable {
         ddcAvailableLock.withLock { ddcAvailable[displayID] }
     }
 
-    /// Clears DDC availability and max brightness cache for a disconnected display.
+    /// Clears all per-display state for a disconnected display.
     /// Call this when a display is removed so stale state cannot pollute a reconnect.
+    @MainActor
     func invalidateDDCState(for displayID: CGDirectDisplayID) {
         ddcAvailableLock.withLock {
             ddcAvailable.removeValue(forKey: displayID)
@@ -702,6 +703,21 @@ final class BrightnessService: @unchecked Sendable {
             // display's software-dimming routing would stick to whatever
             // display inherits its ID next.
             hdrDimmedDisplays.remove(displayID)
+        }
+        // Same ID-reuse hazard for the rest: reapplySoftwareBrightnessIfNeeded
+        // reads the in-memory factor first, so a display inheriting this ID
+        // would silently get the departed display's dimming factor.
+        animators[displayID]?.cancel()
+        animators.removeValue(forKey: displayID)
+        softwareBrightnessLock.withLock {
+            _ = softwareBrightnessFactors.removeValue(forKey: displayID)
+        }
+        ddcPumpLock.withLock {
+            pendingDDCPercent.removeValue(forKey: displayID)
+            ddcFailStreak.removeValue(forKey: displayID)
+            lastDDCWriteInstant.removeValue(forKey: displayID)
+            // ddcPumpActive stays: the pump owns it and removes itself once it
+            // sees no pending value.
         }
     }
 

--- a/Crisp/Services/BrightnessService.swift
+++ b/Crisp/Services/BrightnessService.swift
@@ -2,6 +2,8 @@ import Foundation
 import IOKit
 import IOKit.graphics
 import CoreGraphics
+// For CGDisplayCreateUUIDFromDisplayID (ApplicationServices, not CoreGraphics).
+import AppKit
 
 @_silgen_name("CGDisplayIOServicePort")
 private func CGDisplayIOServicePort(_ display: CGDirectDisplayID) -> io_service_t
@@ -189,8 +191,46 @@ final class BrightnessService: @unchecked Sendable {
     private var softwareBrightnessFactors: [CGDirectDisplayID: Double] = [:]
     private let softwareBrightnessLock = NSLock()
 
+    /// UUID-keyed like GammaPersistenceKey (issue #32): displayIDs are reused
+    /// across reconnects and reboots, so the old raw-ID key could hand this
+    /// display's dimming factor to a different physical display later.
     private func softBrightnessKey(for displayID: CGDirectDisplayID) -> String {
+        if let uuid = Self.displayUUIDString(for: displayID) {
+            return "crisp.softBrightness.uuid.\(uuid)"
+        }
+        // UUID lookup failed (display just went offline): legacy raw-ID key.
+        return Self.legacySoftBrightnessKey(for: displayID)
+    }
+
+    private static func legacySoftBrightnessKey(for displayID: CGDirectDisplayID) -> String {
         "crisp.softBrightness_\(displayID)"
+    }
+
+    /// Same primary path as DisplayInfo.displayUUID (CG UUID of an online
+    /// display), so both produce identical key strings.
+    private static func displayUUIDString(for displayID: CGDirectDisplayID) -> String? {
+        guard let cfUUID = CGDisplayCreateUUIDFromDisplayID(displayID) else { return nil }
+        return CFUUIDCreateString(nil, cfUUID.takeRetainedValue()) as String?
+    }
+
+    /// Moves any legacy, displayID-keyed software-brightness factor onto the
+    /// stable UUID key, for every display currently online. Same rules as
+    /// GammaService.migrateLegacyStateIfNeeded: repeated calls are no-ops, an
+    /// existing UUID entry is never overwritten, and a legacy key with no live
+    /// display is left alone (guessing which physical display it belonged to
+    /// is exactly the bug being fixed).
+    @MainActor
+    func migrateLegacySoftBrightnessIfNeeded(for displays: [DisplayInfo]) {
+        let defaults = UserDefaults.standard
+        for display in displays {
+            let legacyKey = Self.legacySoftBrightnessKey(for: display.displayID)
+            guard defaults.object(forKey: legacyKey) != nil else { continue }
+            let uuidKey = "crisp.softBrightness.uuid.\(display.displayUUID)"
+            if defaults.object(forKey: uuidKey) == nil {
+                defaults.set(defaults.double(forKey: legacyKey), forKey: uuidKey)
+            }
+            defaults.removeObject(forKey: legacyKey)
+        }
     }
 
     private func saveSoftwareBrightness(factor: Double, for displayID: CGDirectDisplayID) {

--- a/Crisp/Services/DisplayManager.swift
+++ b/Crisp/Services/DisplayManager.swift
@@ -109,6 +109,7 @@ class DisplayManager: ObservableObject {
         removedIDs.forEach {
             DDCService.shared.clearCache(for: $0)
             BrightnessService.shared.invalidateDDCState(for: $0)
+            GammaService.shared.invalidate(for: $0)
         }
 
         // Diff-based refresh: keep existing DisplayInfo objects (preserves @Published state)

--- a/Crisp/Services/DisplayManager.swift
+++ b/Crisp/Services/DisplayManager.swift
@@ -22,6 +22,7 @@ private func displayReconfigCallback(
     guard !flags.contains(.beginConfigurationFlag) else { return }
 
     Task { @MainActor in
+        ReconfigEvents.shared.resolve(displayID: displayID, flags: flags)
         if flags.isDisjoint(with: [.addFlag, .removeFlag, .movedFlag]) {
             // Mode or main-display change: refresh mode info for existing displays only.
             manager.refreshExistingDisplayModes()
@@ -29,6 +30,53 @@ private func displayReconfigCallback(
             // Add/remove/move: rebuild so display bounds (arrangement) are current;
             // refreshExistingDisplayModes doesn't re-read bounds.
             manager.refreshDisplays()
+        }
+    }
+}
+
+/// Awaitable one-shot bridge over the CG reconfiguration callback: suspend
+/// until `displayID` posts a completed event matching `flags`, or the timeout
+/// elapses (returns false). Replaces blind sleeps and polls for "the display
+/// left the online list" / "the mode change landed". Events are not replayed,
+/// so callers must check their condition right before awaiting; on a MainActor
+/// caller that check-then-await is race-free (the resolving callback also runs
+/// on the main actor), elsewhere the timeout bounds the miss at the old
+/// fixed-sleep cost.
+@MainActor
+final class ReconfigEvents {
+    static let shared = ReconfigEvents()
+    private init() {}
+
+    private struct Waiter {
+        let displayID: CGDirectDisplayID
+        let flags: CGDisplayChangeSummaryFlags
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+    private var waiters: [UUID: Waiter] = [:]
+
+    /// Called from the reconfiguration callback for completed changes only.
+    func resolve(displayID: CGDirectDisplayID, flags: CGDisplayChangeSummaryFlags) {
+        for (token, waiter) in waiters
+        where waiter.displayID == displayID && !flags.isDisjoint(with: waiter.flags) {
+            waiters.removeValue(forKey: token)
+            waiter.continuation.resume(returning: true)
+        }
+    }
+
+    @discardableResult
+    func next(
+        for displayID: CGDirectDisplayID,
+        matching flags: CGDisplayChangeSummaryFlags,
+        timeout: TimeInterval
+    ) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let token = UUID()
+            waiters[token] = Waiter(displayID: displayID, flags: flags, continuation: continuation)
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                guard let waiter = self?.waiters.removeValue(forKey: token) else { return }
+                waiter.continuation.resume(returning: false)
+            }
         }
     }
 }
@@ -110,6 +158,8 @@ class DisplayManager: ObservableObject {
             DDCService.shared.clearCache(for: $0)
             BrightnessService.shared.invalidateDDCState(for: $0)
             GammaService.shared.invalidate(for: $0)
+            BrightnessBoostService.shared.invalidate(for: $0)
+            VolumeService.shared.invalidate(for: $0)
         }
 
         // Diff-based refresh: keep existing DisplayInfo objects (preserves @Published state)
@@ -135,6 +185,7 @@ class DisplayManager: ObservableObject {
         // Reconcile any legacy CGDirectDisplayID-keyed gamma adjustment onto the stable
         // UUID key before anything below reapplies a saved adjustment (issue #32).
         GammaService.shared.migrateLegacyStateIfNeeded(for: updatedDisplays)
+        BrightnessService.shared.migrateLegacySoftBrightnessIfNeeded(for: updatedDisplays)
 
         // Only load details / refresh brightness for newly appeared displays
         for display in addedDisplays {

--- a/Crisp/Services/GammaService.swift
+++ b/Crisp/Services/GammaService.swift
@@ -139,6 +139,15 @@ final class GammaService: @unchecked Sendable {
             0.0, 1.0, 1.0)
     }
 
+    /// Drop the in-memory adjustment for a disconnected display. Display IDs
+    /// are reused, so a stale entry would otherwise be pushed onto whatever
+    /// display inherits the ID next (refreshDisplays reapplies unconditionally
+    /// for kept displays). The UUID-keyed persisted copy stays untouched;
+    /// reapplyIfNeeded restores it when the same physical display returns.
+    func invalidate(for displayID: CGDirectDisplayID) {
+        _ = adjustmentsLock.withLock { activeAdjustments.removeValue(forKey: displayID) }
+    }
+
     /// Restore all online displays to identity gamma (per-display, avoids global reset).
     func restoreColorSync() {
         adjustmentsLock.withLock { activeAdjustments.removeAll() }

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -194,7 +194,9 @@ final class PhysicalDisplayToggleService: ObservableObject {
         let startID = display.displayID
         guard !wouldLeaveNoActiveDisplay(startID) else { return false }
         guard case .success = await setEnabled(false, displayID: startID) else { return false }
-        try? await Task.sleep(nanoseconds: 900_000_000)  // let the framebuffer drop before re-enabling
+        // Wait for the framebuffer to actually drop (removeFlag) before re-enabling;
+        // the 0.9s ceiling matches the old fixed sleep if the event never comes.
+        await ReconfigEvents.shared.next(for: startID, matching: .removeFlag, timeout: 0.9)
         for _ in 0..<3 {
             let targetID = allDisplaysIncludingDisabled().first { uuid(for: $0) == display.displayUUID } ?? startID
             if case .success = await setEnabled(true, displayID: targetID) { return true }

--- a/Crisp/Services/ResolutionService.swift
+++ b/Crisp/Services/ResolutionService.swift
@@ -237,7 +237,7 @@ final class ResolutionService: @unchecked Sendable {
     /// id segfaults in checkCapacity() on macOS 26. It must run inside a real
     /// CGBegin/CGCompleteDisplayConfiguration transaction (verified against BetterDisplay on Tahoe).
     private func cgsFallback(modeID: UInt32, on displayID: CGDirectDisplayID) async -> Bool {
-        return await Task.detached(priority: .userInitiated) {
+        let committed = await Task.detached(priority: .userInitiated) {
             var config: CGDisplayConfigRef?
             guard CGBeginDisplayConfiguration(&config) == .success, let cfg = config else {
                 return false
@@ -249,12 +249,16 @@ final class ResolutionService: @unchecked Sendable {
                 return false
             }
 
-            let complete = CGCompleteDisplayConfiguration(cfg, .forSession)
-            // Wait for the mode change to propagate, then verify the active mode actually changed.
-            try? await Task.sleep(nanoseconds: 100_000_000)  // 100ms
-            let newModeID = CGDisplayCopyDisplayMode(displayID)?.ioDisplayModeID
-            let success = complete == .success && newModeID == Int32(bitPattern: modeID)
-            return success
+            return CGCompleteDisplayConfiguration(cfg, .forSession) == .success
         }.value
+        guard committed else { return false }
+        // The commit propagates async. Fast path: already active. Otherwise wait
+        // for the mode-change event instead of a blind 100ms sleep (0.5s ceiling
+        // also covers panels the old flat sleep verified too early on), then
+        // verify the active mode actually changed.
+        let target = Int32(bitPattern: modeID)
+        if CGDisplayCopyDisplayMode(displayID)?.ioDisplayModeID == target { return true }
+        await ReconfigEvents.shared.next(for: displayID, matching: .setModeFlag, timeout: 0.5)
+        return CGDisplayCopyDisplayMode(displayID)?.ioDisplayModeID == target
     }
 }

--- a/Crisp/Services/VirtualDisplayService.swift
+++ b/Crisp/Services/VirtualDisplayService.swift
@@ -192,7 +192,11 @@ final class VirtualDisplayService: ObservableObject, @unchecked Sendable {
     private func applyNativeResolution(_ displayID: CGDirectDisplayID, width: Int, height: Int) async {
         let options = [kCGDisplayShowDuplicateLowResolutionModes as String: true] as CFDictionary
         for attempt in 0..<5 {
-            if attempt > 0 { try? await Task.sleep(nanoseconds: 300_000_000) }
+            // Between attempts, wake on the mode-change event instead of a blind
+            // 300ms sleep; same per-attempt ceiling when no event comes.
+            if attempt > 0 {
+                await ReconfigEvents.shared.next(for: displayID, matching: .setModeFlag, timeout: 0.3)
+            }
             // Native 1x means point size == pixel size == the target resolution.
             if let cur = CGDisplayCopyDisplayMode(displayID),
                cur.width == width, cur.pixelWidth == width { return }
@@ -277,18 +281,17 @@ final class VirtualDisplayService: ObservableObject, @unchecked Sendable {
         return true
     }
 
-    /// Waits (bounded, ~1.5s ceiling) for a torn-down virtual display to leave the
+    /// Waits (bounded, 1.5s ceiling) for a torn-down virtual display to leave the
     /// online display list. CGVirtualDisplay teardown is async: dropping the strong
-    /// reference starts it, but WindowServer finishes on its own time.
+    /// reference starts it, but WindowServer finishes on its own time. Event-driven:
+    /// the check-then-await is race-free on the main actor (see ReconfigEvents).
     private func waitForDisplayOffline(_ displayID: CGDirectDisplayID) async {
-        for _ in 0..<30 {
-            var count: UInt32 = 0
-            CGGetOnlineDisplayList(0, nil, &count)
-            var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
-            CGGetOnlineDisplayList(count, &ids, &count)
-            if !ids.contains(displayID) { return }
-            try? await Task.sleep(nanoseconds: 50_000_000)
-        }
+        var count: UInt32 = 0
+        CGGetOnlineDisplayList(0, nil, &count)
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        CGGetOnlineDisplayList(count, &ids, &count)
+        guard ids.contains(displayID) else { return }
+        await ReconfigEvents.shared.next(for: displayID, matching: .removeFlag, timeout: 1.5)
     }
 
     // MARK: - Persistence

--- a/Crisp/Services/VolumeService.swift
+++ b/Crisp/Services/VolumeService.swift
@@ -31,6 +31,14 @@ final class VolumeService: ObservableObject {
         UserDefaults.standard.set(Array(rememberedCapable), forKey: capableKey)
     }
 
+    /// Drop per-display state for a disconnected display so a reused
+    /// displayID cannot inherit it. rememberedCapable stays: it is UUID-keyed
+    /// and deliberately permanent.
+    func invalidate(for displayID: CGDirectDisplayID) {
+        ddcMax.removeValue(forKey: displayID)
+        preMuteVolume.removeValue(forKey: displayID)
+    }
+
     // MARK: - Probe
 
     /// Reads VCP 0x62 once. Success marks the display volume-capable (the

--- a/Crisp/Views/DisplayModeListView.swift
+++ b/Crisp/Views/DisplayModeListView.swift
@@ -231,15 +231,11 @@ final class DisplayModeController: ObservableObject {
                 success = await ResolutionService.shared.setDisplayMode(mode, for: displayID)
             }
             if success {
-                try? await Task.sleep(nanoseconds: 300_000_000)
-                let refreshedMode = await Task.detached(priority: .userInitiated) {
-                    DisplayMode.currentMode(for: displayID)
-                }.value
-                if let rm = refreshedMode, rm.width == mode.width && rm.height == mode.height {
-                    display.currentDisplayMode = rm
-                } else {
-                    display.currentDisplayMode = mode
-                }
+                // Optimistic: the reconfiguration callback's setModeFlag branch
+                // re-reads the authoritative mode into display.currentDisplayMode
+                // moments later (refreshExistingDisplayModes); this only moves the
+                // checkmark instantly instead of after a 300ms re-read.
+                display.currentDisplayMode = mode
                 errorMessage = nil
             } else {
                 withAnimation {

--- a/docs/panel-resize.md
+++ b/docs/panel-resize.md
@@ -89,7 +89,11 @@ Every rule, with the observation that forced it:
    callback arrived 65.9ms late, rendering as freeze-then-24pt-step even with
    gap clamping. The link is created once at panel warm-up; idle ticks are
    no-ops. It IS recreated when the panel opens on a different screen (a link
-   latched to a 120Hz screen feeds a 165Hz screen unevenly).
+   latched to a 120Hz screen feeds a 165Hz screen unevenly). While the panel
+   is hidden the link is PAUSED (not invalidated): the object survives, and
+   unpausing at showPanel (in-flight animations only start on a later user
+   toggle) gives it the same warm-up window the recreate-at-open path relies
+   on, without paying vsync wakeups all day for a closed panel.
 3. **Advance the spring by wall time clamped to a 21ms catch-up window.**
    Frame-paced time (one refresh period per tick) ran at HALF speed through
    sustained lower-rate stretches and snapped to full speed on recovery, which


### PR DESCRIPTION
## Summary

Performance round from a full audit of CPU usage, unnecessary work, and per-display state lifetime. The app was already lean while in use, so the wins concentrate on idle cost, operation latency, and latent ID-reuse bugs.

### Idle cost (panel closed) to ~zero
- The panel spring's `CADisplayLink` is now paused while the panel is hidden (parked at warm-up and close, woken at open). It fired every vsync (60-165Hz) for the whole session; idle ticks were no-ops but the wakeups were not free. The never-create-on-demand rule from `docs/panel-resize.md` still holds: the link object survives, and waking at open gives the same warm-up window the recreate-at-open path relies on (doc updated).
- The 1s external-state poll now runs only while the panel is shown (started in `showPanel`, cancelled in `closePanel`). It previously ran from launch to quit and no-op'd behind a visibility guard.
- Measured with the panel closed: 2 idle wakeups per 10s and 0.0% CPU, versus a mechanism-guaranteed 60-165 wakeups/sec plus 1/sec on main.

### Native feel at open, without background polling
The state refresh (Night Shift/True Tone, DDC brightness) now kicks at the click, at the top of `showPanel`, instead of 0.25s after the panel is visible. The reads run off the main thread and land during the fade-in, so sliders are correct when the panel is readable instead of visibly jumping afterward.

### Event-driven display waits (new `ReconfigEvents`)
A small awaitable one-shot bridge over the existing `CGDisplayRegisterReconfigurationCallback`: suspend until a display posts a completed event matching a flag, with the old sleep duration kept as the timeout ceiling. Replaces:
- `softReconnect`'s fixed 900ms framebuffer-drop wait (re-enable now starts when `.removeFlag` lands, up to ~0.8s faster per smooth-scaling toggle)
- virtual display teardown's 30x50ms online-list poll (`.removeFlag`)
- the virtual display default-mode retry's blind 300ms sleeps (`.setModeFlag`)
- the CGS private-API fallback's flat 100ms wait-then-verify (`.setModeFlag`; the flat sleep could also verify too early on slow panels and report a false failure)
- `DisplayModeListView`'s 300ms sleep + re-read after a mode switch (optimistic set; the callback's `.setModeFlag` refresh writes the authoritative mode)

### Stale per-display state pruned on disconnect (ID-reuse bugs)
macOS reuses `CGDirectDisplayID`s, and several dicts keyed by raw ID were never pruned, so a new display could inherit a departed monitor's state:
- `BrightnessService.invalidateDDCState` now also clears the animator, in-memory software dimming factor, and the DDC pump dicts
- software-brightness persistence is now UUID-keyed like gamma (issue #32 pattern), with the same migrate-only-live-displays legacy migration
- `GammaService`, `BrightnessBoostService`, and `VolumeService` prune their per-display state from the same `removedIDs` loop
- `BrightnessBoostService.screenParametersChanged` debounces `reapplyAll` (one reconcile per replug storm instead of one full DDC/gamma/overlay pass per notification), and `setHDRPreference`'s collapse wait is bounded at 2s

## Test plan
- `make check` green (lint, tests with warnings-as-errors, localization keys)
- Manual on real hardware via `make dev`: panel open/close and section resize feel on a 165Hz screen, slider correctness at open after external changes, smooth-scaling toggle, resolution switches including HiDPI variants, display replug with software dimming and gamma restore, idle wakeups sampled via `top`