### PR TITLE
fix: manual volume enable for monitors that never answer the DDC volume probe

### DIFF
--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -881,6 +881,16 @@
         }
       }
     },
+    "Force volume control for a monitor that doesn't report it. Crisp can set the volume but not read the current level." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "为不报告音量支持的显示器强制启用音量控制。Crisp 可以设置音量，但无法读取当前音量。"
+          }
+        }
+      }
+    },
     "Gain" : {
       "localizations" : {
         "zh-Hans" : {
@@ -1946,6 +1956,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "虚拟显示器"
+          }
+        }
+      }
+    },
+    "Volume Control" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音量控制"
           }
         }
       }

--- a/Crisp/Services/VolumeService.swift
+++ b/Crisp/Services/VolumeService.swift
@@ -31,6 +31,29 @@ final class VolumeService: ObservableObject {
         UserDefaults.standard.set(Array(rememberedCapable), forKey: capableKey)
     }
 
+    /// UUIDs the user forced volume-capable (issue #57). Some monitors (LG
+    /// 27UP850N over USB-C) never answer a 0x62 read but do accept 0x62
+    /// writes, so the probe can never prove support. Forced displays run
+    /// write-only with the assumed max of 100 (the pump's default).
+    private let forcedKey = "crisp.volumeForcedDisplays"
+    private lazy var forcedCapable: Set<String> =
+        Set(UserDefaults.standard.stringArray(forKey: forcedKey) ?? [])
+
+    func isForced(_ display: DisplayInfo) -> Bool {
+        forcedCapable.contains(display.displayUUID)
+    }
+
+    func setForced(_ on: Bool, for display: DisplayInfo) {
+        if on {
+            forcedCapable.insert(display.displayUUID)
+        } else {
+            forcedCapable.remove(display.displayUUID)
+        }
+        UserDefaults.standard.set(Array(forcedCapable), forKey: forcedKey)
+        // Un-forcing keeps the feature only if a real probe ever succeeded.
+        display.volumeSupported = on || rememberedCapable.contains(display.displayUUID)
+    }
+
     /// Drop per-display state for a disconnected display so a reused
     /// displayID cannot inherit it. rememberedCapable stays: it is UUID-keyed
     /// and deliberately permanent.
@@ -48,9 +71,10 @@ final class VolumeService: ObservableObject {
     /// next pass, and DDCService caches reads for 5s.
     func refreshVolume(for display: DisplayInfo) {
         guard !display.isBuiltin else { return }
-        // Seed from memory so a failed probe can't hide the feature; the read
-        // below still adopts the monitor's current level whenever it works.
-        if rememberedCapable.contains(display.displayUUID) {
+        // Seed from memory (or the user's force override) so a failed probe
+        // can't hide the feature; the read below still adopts the monitor's
+        // current level whenever it works.
+        if rememberedCapable.contains(display.displayUUID) || forcedCapable.contains(display.displayUUID) {
             display.volumeSupported = true
         }
         let id = display.displayID

--- a/Crisp/Views/DisplayDetailView.swift
+++ b/Crisp/Views/DisplayDetailView.swift
@@ -132,6 +132,10 @@ struct DetailTailBlock: View {
             // Disconnect this physical display (Apple Silicon only; hidden for the last screen)
             DisconnectDisplayRow(display: display)
 
+            // Manual volume enable for externals whose DDC volume probe never
+            // succeeded (issue #57); hidden once the probe confirms support.
+            VolumeOverrideView(display: display)
+
             // HDR: explicit per-display HDR mode toggle, shown only for
             // HDR-capable externals (built-in never offers this, matching
             // System Settings). Placed above Extra Brightness: cause before

--- a/Crisp/Views/VolumeOverrideView.swift
+++ b/Crisp/Views/VolumeOverrideView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// Per-display manual volume enable (issue #57). Some monitors (LG 27UP850N
+/// over USB-C) accept DDC volume writes but never answer the 0x62 probe read,
+/// so volumeSupported can never turn on by itself and the whole volume
+/// feature stays hidden. This row appears only for externals in that state
+/// and forces write-only volume for the display (persisted by UUID in
+/// VolumeService). Probe-confirmed monitors never show it.
+struct VolumeOverrideView: View {
+    @ObservedObject var display: DisplayInfo
+    @State private var isHovered = false
+
+    var body: some View {
+        if !display.isBuiltin,
+           !display.volumeSupported || VolumeService.shared.isForced(display) {
+            HStack {
+                MenuItemIcon(systemName: "speaker.wave.2.fill", color: .blue, active: display.volumeSupported)
+                Text("Volume Control")
+                    .font(.body)
+                Spacer()
+                Toggle("", isOn: Binding(
+                    get: { VolumeService.shared.isForced(display) },
+                    set: { VolumeService.shared.setForced($0, for: display) }
+                ))
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .controlSize(.small)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .menuRowHover(isHovered)
+            .onHover { isHovered = $0 }
+            .help("Force volume control for a monitor that doesn't report it. Crisp can set the volume but not read the current level.")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #57.

## Problem

On the LG 27UP850N-W over USB-C the volume slider never appears and the volume keys pass through, while BetterDisplay controls volume fine. The monitor accepts VCP 0x62 writes but seems to never return a valid 0x62 read reply, and Crisp gated the whole volume feature (slider, settings toggle, key routing) on one successful probe read. Brightness is unaffected because it never depended on reads.

## Fix

Adds a per-display "Volume Control" toggle in the expanded display detail, shown only for external displays whose volume probe never succeeded. Forcing it marks the display volume-capable (persisted by display UUID, same pattern as the remembered-capable set) and runs write-only volume with the assumed max of 100 that the write pump already defaults to. Monitors that answer the probe never show the row.

Known limitation: for forced displays the slider starts at 0 after launch since the monitor's current level cannot be read.

## Verification

`make check` passes (lint, tests, localization keys; new strings have zh-Hans translations). The broken-read hardware state cannot be reproduced locally, so on-monitor confirmation is pending from the reporter (test build offered in the issue).