### PR TITLE
fix: apply smooth scaling immediately on single-display setups

### DIFF
--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -1628,6 +1628,16 @@
         }
       }
     },
+    "Saved. Unplug and replug the monitor cable, or restart your Mac, to apply." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保存。请拔掉并重新插入显示器连接线，或重启 Mac，以使更改生效。"
+          }
+        }
+      }
+    },
     "Saving…" : {
       "localizations" : {
         "zh-Hans" : {

--- a/Crisp/Services/DisplayManager.swift
+++ b/Crisp/Services/DisplayManager.swift
@@ -236,6 +236,10 @@ class DisplayManager: ObservableObject {
         // Keep the physical-disconnect list honest: drop any record whose display came back
         // online (re-plugged, or macOS re-enabled it).
         PhysicalDisplayToggleService.shared.reconcile()
+        // Runs on every refresh, but only ever does anything right after launch: a soft
+        // reconnect (smooth-scaling toggle) leaves a marker that only a mid-toggle app
+        // crash/force-quit would still find set, and it clears itself on first check.
+        Task { await PhysicalDisplayToggleService.shared.recoverStrandedSoftReconnect() }
         // A physical unplug bypasses disconnect()'s last-screen guard: internal disabled via
         // Crisp + external cable pulled = zero active displays, all black. Bring one back.
         PhysicalDisplayToggleService.shared.restoreIfNoActiveDisplay()

--- a/Crisp/Services/DisplayManager.swift
+++ b/Crisp/Services/DisplayManager.swift
@@ -236,9 +236,10 @@ class DisplayManager: ObservableObject {
         // Keep the physical-disconnect list honest: drop any record whose display came back
         // online (re-plugged, or macOS re-enabled it).
         PhysicalDisplayToggleService.shared.reconcile()
-        // Runs on every refresh, but only ever does anything right after launch: a soft
-        // reconnect (smooth-scaling toggle) leaves a marker that only a mid-toggle app
-        // crash/force-quit would still find set, and it clears itself on first check.
+        // Runs on every refresh, but is a cheap no-op unless a soft reconnect's dead-man
+        // marker is set (mid-toggle crash, or a re-enable that failed outright). The service
+        // skips it while a live soft reconnect is mid-blink, so this can't race the toggle's
+        // own retry loop even though the blink's reconfig events land here mid-toggle.
         Task { await PhysicalDisplayToggleService.shared.recoverStrandedSoftReconnect() }
         // A physical unplug bypasses disconnect()'s last-screen guard: internal disabled via
         // Crisp + external cable pulled = zero active displays, all black. Bring one back.

--- a/Crisp/Services/DisplayManager.swift
+++ b/Crisp/Services/DisplayManager.swift
@@ -238,8 +238,8 @@ class DisplayManager: ObservableObject {
         PhysicalDisplayToggleService.shared.reconcile()
         // Runs on every refresh, but is a cheap no-op unless a soft reconnect's dead-man
         // marker is set (mid-toggle crash, or a re-enable that failed outright). The service
-        // skips it while a live soft reconnect is mid-blink, so this can't race the toggle's
-        // own retry loop even though the blink's reconfig events land here mid-toggle.
+        // skips any display whose soft reconnect is still mid-blink, so this can't race a
+        // toggle's own retry loop even though the blink's reconfig events land here mid-toggle.
         Task { await PhysicalDisplayToggleService.shared.recoverStrandedSoftReconnect() }
         // A physical unplug bypasses disconnect()'s last-screen guard: internal disabled via
         // Crisp + external cable pulled = zero active displays, all black. Bring one back.

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -60,14 +60,37 @@ final class PhysicalDisplayToggleService: ObservableObject {
     @Published private(set) var disconnected: [DisconnectedDisplay] = []
 
     private let desiredKey = "crisp.PhysicalDisconnectedUUIDs"
-    /// Dead-man marker: the UUID of a display softReconnect is (or was, if the app died)
-    /// mid-toggle on. See softReconnect / recoverStrandedSoftReconnect.
+    /// Dead-man markers: the UUIDs of displays a softReconnect is (or was, if the app died)
+    /// mid-toggle on. A list, not a single slot: a manual smooth-scaling toggle and the
+    /// auto-HiDPI path (autoEnableHiDPIIfNeeded) can blink two different displays at once,
+    /// and each needs its own marker. See softReconnect / recoverStrandedSoftReconnect.
     private let softReconnectPendingKey = "crisp.PhysicalDisplayToggleService.softReconnectPending"
-    /// True while softReconnect is mid-blink. The marker above is legitimately set for that
-    /// whole window, and the blink's own removeFlag event fires refreshDisplays (and thus
-    /// recoverStrandedSoftReconnect) before the toggle finishes; this keeps the recovery
-    /// path from re-enabling the display out from under the retry loop.
-    private var softReconnectInFlight = false
+    /// UUIDs of displays whose softReconnect is mid-blink right now. Their markers above are
+    /// legitimately set for that whole window, and the blink's own removeFlag event fires
+    /// refreshDisplays (and thus recoverStrandedSoftReconnect) before the toggle finishes;
+    /// this keeps the recovery path and the sweep from re-enabling a display out from under
+    /// its own retry loop. Per-display, so concurrent blinks don't mask each other.
+    private var softReconnectInFlight: Set<String> = []
+
+    private func pendingSoftReconnectUUIDs() -> [String] {
+        UserDefaults.standard.stringArray(forKey: softReconnectPendingKey) ?? []
+    }
+
+    private func addPendingSoftReconnect(_ displayUUID: String) {
+        var pending = pendingSoftReconnectUUIDs()
+        guard !pending.contains(displayUUID) else { return }
+        pending.append(displayUUID)
+        UserDefaults.standard.set(pending, forKey: softReconnectPendingKey)
+    }
+
+    private func removePendingSoftReconnect(_ displayUUID: String) {
+        let pending = pendingSoftReconnectUUIDs().filter { $0 != displayUUID }
+        if pending.isEmpty {
+            UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
+        } else {
+            UserDefaults.standard.set(pending, forKey: softReconnectPendingKey)
+        }
+    }
 
     // MARK: - Support gate
 
@@ -206,33 +229,37 @@ final class PhysicalDisplayToggleService: ObservableObject {
     @discardableResult
     func softReconnect(_ display: DisplayInfo) async -> Bool {
         guard isSupported else { return false }
-        softReconnectInFlight = true
-        defer { softReconnectInFlight = false }
+        let blinkUUID = display.displayUUID
+        softReconnectInFlight.insert(blinkUUID)
+        defer { softReconnectInFlight.remove(blinkUUID) }
         let startID = display.displayID
         // Persist before disabling: if the app dies between here and a successful re-enable
         // below (crash, force-quit), the display would otherwise be stuck SLS-disabled with
         // nothing left to bring it back. recoverStrandedSoftReconnect checks this at the next
         // launch. Cleared as soon as re-enable succeeds, or immediately below if the disable
         // itself never happened.
-        UserDefaults.standard.set(display.displayUUID, forKey: softReconnectPendingKey)
+        addPendingSoftReconnect(blinkUUID)
         guard case .success = await setEnabled(false, displayID: startID) else {
-            UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
+            removePendingSoftReconnect(blinkUUID)
             return false
         }
         // Wait for the framebuffer to actually drop (removeFlag) before re-enabling;
         // the 0.9s ceiling matches the old fixed sleep if the event never comes.
         await ReconfigEvents.shared.next(for: startID, matching: .removeFlag, timeout: 0.9)
         for _ in 0..<3 {
-            let targetID = allDisplaysIncludingDisabled().first { uuid(for: $0) == display.displayUUID } ?? startID
+            let targetID = allDisplaysIncludingDisabled().first { uuid(for: $0) == blinkUUID } ?? startID
             if case .success = await setEnabled(true, displayID: targetID) {
-                UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
+                removePendingSoftReconnect(blinkUUID)
                 return true
             }
             try? await Task.sleep(nanoseconds: 300_000_000)
         }
         // The target never came back after three tries: don't leave any display our own
         // disable may have stranded off. The marker is left in place on purpose, so a
-        // relaunch retries the recovery too.
+        // relaunch retries the recovery too. Drop the in-flight claim first: this blink's
+        // retries are spent, and the sweep skips displays with a live claim, which would
+        // otherwise make it ignore the very display it's here to rescue.
+        softReconnectInFlight.remove(blinkUUID)
         await reenableUnintentionallyDisabled()
         return false
     }
@@ -268,7 +295,12 @@ final class PhysicalDisplayToggleService: ObservableObject {
         let onlineSet = onlineDisplayIDs()
         let intentionalUUIDs = Set(disconnected.map { $0.uuid })
         for id in allDisplaysIncludingDisabled() where !onlineSet.contains(id) {
-            guard !intentionalUUIDs.contains(uuid(for: id)) else { continue }
+            let displayUUID = uuid(for: id)
+            guard !intentionalUUIDs.contains(displayUUID) else { continue }
+            // A display mid-blink in a live softReconnect is off on purpose for ~1s; its own
+            // retry loop owns bringing it back, and racing it here would reintroduce the
+            // recovery-vs-toggle conflict this file just fixed, one display over.
+            guard !softReconnectInFlight.contains(displayUUID) else { continue }
             _ = await setEnabled(true, displayID: id)
         }
     }
@@ -300,45 +332,57 @@ final class PhysicalDisplayToggleService: ObservableObject {
         if disconnected.count != before { saveDesired() }
     }
 
-    /// Recovery for a softReconnect that never finished: if the app died (crash, force-quit)
-    /// between disabling the display and a successful re-enable, the marker softReconnect
-    /// left behind names exactly the stranded display. Called from
-    /// DisplayManager.refreshDisplays; a cheap no-op unless the marker is set, and skipped
-    /// while a live softReconnect is mid-blink (its own reconfig events fire refreshDisplays
-    /// before the toggle finishes, and its retry loop must not be raced). Mirrors
-    /// softReconnect's recovery ladder (3 re-enable tries, then the sweep), and clears the
-    /// marker only once the display is verifiably back online or gone entirely, so a
-    /// transient failure here leaves it set for the next refresh or launch to try again.
-    /// Only ever re-enables the ONE marked display directly, never any other disabled one
+    /// Guards against overlapping recovery runs from reconfiguration-callback bursts, same
+    /// as restoreInFlight below for restoreIfNoActiveDisplay.
+    private var strandedRecoveryInFlight = false
+
+    /// Recovery for softReconnects that never finished: if the app died (crash, force-quit)
+    /// between disabling a display and a successful re-enable, the markers softReconnect
+    /// left behind name exactly the stranded displays. Called from
+    /// DisplayManager.refreshDisplays; a cheap no-op unless a marker is set. Displays whose
+    /// softReconnect is live right now are skipped per-UUID (their reconfig events fire
+    /// refreshDisplays before the toggle finishes, and their retry loops must not be raced).
+    /// Mirrors softReconnect's recovery ladder (3 re-enable tries, then the sweep), and
+    /// clears each marker only once its display is verifiably back online or gone entirely,
+    /// so a transient failure here leaves it set for the next refresh or launch to try
+    /// again. Only ever re-enables marked displays directly, never any other disabled one
     /// (another app may have disabled those on purpose); the sweep it shares with
-    /// softReconnect stays scoped to displays outside the intentional `disconnected` set.
+    /// softReconnect stays scoped to displays outside the intentional `disconnected` set
+    /// and outside any live blink.
     func recoverStrandedSoftReconnect() async {
-        guard isSupported, !softReconnectInFlight,
-              let markedUUID = UserDefaults.standard.string(forKey: softReconnectPendingKey)
+        guard isSupported, !strandedRecoveryInFlight, !pendingSoftReconnectUUIDs().isEmpty
         else { return }
-        guard let targetID = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == markedUUID }) else {
-            // Display gone entirely (unplugged while stranded): a physical replug brings it
-            // back online by itself, so the marker has nothing left to do.
-            UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
-            return
-        }
-        if onlineDisplayIDs().contains(targetID) {
-            // Recovered normally (or a previous sweep already brought it back).
-            UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
-            return
-        }
-        for _ in 0..<3 {
-            if case .success = await setEnabled(true, displayID: targetID) {
-                UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
-                return
+        strandedRecoveryInFlight = true
+        defer { strandedRecoveryInFlight = false }
+        for markedUUID in pendingSoftReconnectUUIDs() {
+            // Re-checked per iteration: a blink can start for a marked display while an
+            // earlier iteration was awaiting.
+            guard !softReconnectInFlight.contains(markedUUID) else { continue }
+            guard let targetID = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == markedUUID }) else {
+                // Display gone entirely (unplugged while stranded): a physical replug brings
+                // it back online by itself, so the marker has nothing left to do.
+                removePendingSoftReconnect(markedUUID)
+                continue
             }
-            try? await Task.sleep(nanoseconds: 300_000_000)
-        }
-        await reenableUnintentionallyDisabled()
-        // Clear only if the sweep verifiably landed it; otherwise the marker stays set and
-        // the addFlag/refresh cadence (or the next launch) retries.
-        if onlineDisplayIDs().contains(targetID) {
-            UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
+            if onlineDisplayIDs().contains(targetID) {
+                // Recovered normally (or a previous sweep already brought it back).
+                removePendingSoftReconnect(markedUUID)
+                continue
+            }
+            var recovered = false
+            for _ in 0..<3 {
+                if case .success = await setEnabled(true, displayID: targetID) {
+                    recovered = true
+                    break
+                }
+                try? await Task.sleep(nanoseconds: 300_000_000)
+            }
+            if !recovered { await reenableUnintentionallyDisabled() }
+            // Clear only if the display verifiably came back; otherwise the marker stays set
+            // and the addFlag/refresh cadence (or the next launch) retries.
+            if recovered || onlineDisplayIDs().contains(targetID) {
+                removePendingSoftReconnect(markedUUID)
+            }
         }
     }
 

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -233,7 +233,19 @@ final class PhysicalDisplayToggleService: ObservableObject {
     func softReconnect(_ display: DisplayInfo) async -> Bool {
         guard isSupported else { return false }
         let blinkUUID = display.displayUUID
+        // Two callers can race on the same display (manual toggle + auto-HiDPI on a fresh
+        // connect): a second blink mid-blink would double-toggle the framebuffer and try to
+        // create a second sleep guard with the same fixed identity, which WindowServer
+        // rejects (see VirtualDisplayService.create). First one wins; the caller's settle
+        // re-read adopts whatever it produced.
+        guard !softReconnectInFlight.contains(blinkUUID) else { return false }
         let startID = display.displayID
+        // The re-enumeration can come back on macOS's default mode instead of the one the
+        // user was running (refresh-rate reset observed live on a 180Hz panel); capture the
+        // exact mode so a verified re-enable can restore it. Must be captured before the
+        // sleep guard below exists: the guard's arrival alone knocked this panel from 165Hz
+        // to 144Hz (observed live), so capturing after it memorizes the knocked-down mode.
+        let previousMode = CGDisplayCopyDisplayMode(startID)
         // A lid-closed portable sleeps the instant its sole active display goes away
         // (Clamshell Sleep; verified live: the blink's disable triggered it mid-toggle, the
         // wake left the display SLS-disabled behind a lying re-enable "success", and a
@@ -245,15 +257,15 @@ final class PhysicalDisplayToggleService: ObservableObject {
         // guaranteed mid-toggle sleep is how displays get stranded.
         var sleepGuard: CGVirtualDisplay?
         if Self.hasBattery && wouldLeaveNoActiveDisplay(startID) {
-            sleepGuard = await makeBlinkSleepGuard()
+            // Reuse a guard parked by a previous unresolved blink first: the fixed identity
+            // can't exist twice, so creating a fresh one alongside it would just fail.
+            sleepGuard = lingeringSleepGuard
+            lingeringSleepGuard = nil
+            if sleepGuard == nil { sleepGuard = await makeBlinkSleepGuard() }
             if sleepGuard == nil { return false }
         }
         // Held (released) at every exit below; releasing it is what removes the display.
         defer { withExtendedLifetime(sleepGuard) {} }
-        // The re-enumeration can come back on macOS's default mode instead of the one the
-        // user was running (refresh-rate reset observed live on a 180Hz panel); capture the
-        // exact mode now so a verified re-enable can restore it.
-        let previousMode = CGDisplayCopyDisplayMode(startID)
         softReconnectInFlight.insert(blinkUUID)
         defer { softReconnectInFlight.remove(blinkUUID) }
         // Persist before disabling: if the app dies between here and a verified re-enable
@@ -269,31 +281,71 @@ final class PhysicalDisplayToggleService: ObservableObject {
         // Wait for the framebuffer to actually drop (removeFlag) before re-enabling;
         // the 0.9s ceiling matches the old fixed sleep if the event never comes.
         await ReconfigEvents.shared.next(for: startID, matching: .removeFlag, timeout: 0.9)
+        var backOnline = false
         for _ in 0..<3 {
             let targetID = allDisplaysIncludingDisabled().first { uuid(for: $0) == blinkUUID } ?? startID
-            if case .success = await setEnabled(true, displayID: targetID),
-               await verifyBackOnline(uuid: blinkUUID) {
-                removePendingSoftReconnect(blinkUUID)
-                // Best effort: setting a mode whose timing no longer enumerates fails
-                // harmlessly (toggling smooth scaling OFF removes the dense mode the user
-                // may have been running), leaving macOS's fallback, same as pre-fix.
-                if let previousMode,
-                   let backID = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == blinkUUID }),
-                   CGDisplayCopyDisplayMode(backID)?.ioDisplayModeID != previousMode.ioDisplayModeID {
-                    CGDisplaySetDisplayMode(backID, previousMode, nil)
-                }
-                return true
-            }
+            // Fire the enable without awaiting its result. The result is untrustworthy in
+            // both directions (successes can lie, see verifyBackOnline; failures can mask a
+            // display already coming up), and CGCompleteDisplayConfiguration can block ~10s
+            // past the display's actual return while the link retrains after an override
+            // rebuild (observed live), which would hold the mode restore below hostage
+            // behind a blocked call and turn it into a second visible blink ~10s after the
+            // toggle. Enumeration is the only proof either way.
+            Task { _ = await setEnabled(true, displayID: targetID) }
+            // The verify window must outlast a display link handshake (2-4s): re-issuing
+            // enable while the display is mid-sync restarts the link and blinks it again.
+            if await verifyBackOnline(uuid: blinkUUID, timeout: 4.0) { backOnline = true; break }
             try? await Task.sleep(nanoseconds: 300_000_000)
         }
-        // The target never came back after three tries: don't leave any display our own
-        // disable may have stranded off. The marker is left in place on purpose, so a
-        // relaunch retries the recovery too. Drop the in-flight claim first: this blink's
-        // retries are spent, and the sweep skips displays with a live claim, which would
-        // otherwise make it ignore the very display it's here to rescue.
-        softReconnectInFlight.remove(blinkUUID)
-        await reenableUnintentionallyDisabled()
-        return false
+        if !backOnline {
+            // The target never came back under its own re-enables: don't leave any display
+            // our own disable may have stranded off. Drop the in-flight claim first: the
+            // sweep skips displays with a live claim, which would otherwise make it ignore
+            // the very display it's here to rescue.
+            softReconnectInFlight.remove(blinkUUID)
+            await reenableUnintentionallyDisabled()
+            // One longer last look before declaring failure: slow re-enumeration must land
+            // in the success epilogue below. Treating it as failure skips the mode restore
+            // (refresh-rate reset observed live) and parks the guard, whose later release
+            // reshuffles the windows a second time, seconds after the toggle.
+            backOnline = await verifyBackOnline(uuid: blinkUUID, timeout: 2.0)
+        }
+        guard backOnline else {
+            // Genuinely still down. The marker stays on purpose so refresh/relaunch keeps
+            // retrying, and the sleep guard is parked: releasing it now would hand a
+            // lid-closed portable straight to Clamshell Sleep with the display stranded,
+            // the exact state the guard exists to prevent. Recovery releases it once every
+            // marked display is resolved.
+            if sleepGuard != nil { lingeringSleepGuard = sleepGuard }
+            return false
+        }
+        removePendingSoftReconnect(blinkUUID)
+        if let previousMode,
+           let backID = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == blinkUUID }) {
+            // The blink re-reads override plists, which rebuilds the mode list and renumbers
+            // every mode ID (observed live: the same timing went 130 -> 683), so the captured
+            // object cannot be applied directly; re-find the equivalent mode in the fresh
+            // list by parameters. No match means the mode no longer enumerates (toggling
+            // smooth OFF removes the dense mode the user may have been running): macOS's
+            // fallback stands, same as pre-fix.
+            let options = [kCGDisplayShowDuplicateLowResolutionModes: true] as CFDictionary
+            let modes = CGDisplayCopyAllDisplayModes(backID, options) as? [CGDisplayMode] ?? []
+            if let target = modes.first(where: {
+                $0.width == previousMode.width && $0.height == previousMode.height
+                    && $0.pixelWidth == previousMode.pixelWidth
+                    && $0.pixelHeight == previousMode.pixelHeight
+                    && abs($0.refreshRate - previousMode.refreshRate) < 1
+            }) {
+                // A set issued while the link is still retraining can fail silently; verify
+                // it stuck and retry briefly instead of trusting one shot.
+                for _ in 0..<4 {
+                    if CGDisplayCopyDisplayMode(backID)?.ioDisplayModeID == target.ioDisplayModeID { break }
+                    _ = await ResolutionService.applyModeSync(target, on: backID)
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                }
+            }
+        }
+        return true
     }
 
     /// Runs SLSConfigureDisplayEnabled inside a CG configuration transaction.
@@ -347,12 +399,12 @@ final class PhysicalDisplayToggleService: ObservableObject {
         return Set(ids.prefix(Int(count)))
     }
 
-    /// True once the display with this UUID is back in the online list, polling up to ~1s.
-    /// A successful SLSConfigureDisplayEnabled transaction is NOT proof of recovery: around
-    /// sleep transitions it reports success while the display stays disabled (verified live
-    /// in clamshell). Only enumeration counts.
-    private func verifyBackOnline(uuid displayUUID: String) async -> Bool {
-        for _ in 0..<10 {
+    /// True once the display with this UUID is back in the online list, polling up to
+    /// `timeout` seconds. A successful SLSConfigureDisplayEnabled transaction is NOT proof
+    /// of recovery: around sleep transitions it reports success while the display stays
+    /// disabled (verified live in clamshell). Only enumeration counts.
+    private func verifyBackOnline(uuid displayUUID: String, timeout: TimeInterval = 1.0) async -> Bool {
+        for _ in 0..<max(Int(timeout * 10), 1) {
             if let id = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == displayUUID }),
                onlineDisplayIDs().contains(id) { return true }
             try? await Task.sleep(nanoseconds: 100_000_000)
@@ -428,6 +480,13 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// as restoreInFlight below for restoreIfNoActiveDisplay.
     private var strandedRecoveryInFlight = false
 
+    /// Sleep guard parked by a softReconnect whose display never verifiably returned (see
+    /// its retry-exhausted path): holding it keeps a lid-closed portable awake so the
+    /// marker/recovery cadence can keep retrying instead of the machine sleeping on a
+    /// stranded display. Released by recovery once every marked display is resolved, or
+    /// adopted by the next blink (the fixed identity can't be created twice).
+    private var lingeringSleepGuard: CGVirtualDisplay?
+
     /// Recovery for softReconnects that never finished: if the app died (crash, force-quit)
     /// between disabling a display and a successful re-enable, the markers softReconnect
     /// left behind name exactly the stranded displays. Called from
@@ -442,7 +501,10 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// softReconnect stays scoped to displays outside the intentional `disconnected` set
     /// and outside any live blink.
     func recoverStrandedSoftReconnect() async {
-        guard isSupported, !strandedRecoveryInFlight, !pendingSoftReconnectUUIDs().isEmpty
+        // Also runs while only a parked guard is left (markers resolved by another path,
+        // e.g. a later lid-open blink): the release at the bottom is its only way out.
+        guard isSupported, !strandedRecoveryInFlight,
+              !pendingSoftReconnectUUIDs().isEmpty || lingeringSleepGuard != nil
         else { return }
         strandedRecoveryInFlight = true
         defer { strandedRecoveryInFlight = false }
@@ -479,6 +541,12 @@ final class PhysicalDisplayToggleService: ObservableObject {
             if recovered || onlineDisplayIDs().contains(targetID) {
                 removePendingSoftReconnect(markedUUID)
             }
+        }
+        // A parked sleep guard has served its purpose once no marker remains unresolved:
+        // every marked display is back online or gone. Until then it stays, keeping a
+        // lid-closed portable awake for the next retry.
+        if lingeringSleepGuard != nil, pendingSoftReconnectUUIDs().isEmpty {
+            lingeringSleepGuard = nil
         }
     }
 

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -220,27 +220,40 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// failure can't strand a black screen. Unlike disconnect() it leaves the `disconnected` set
     /// untouched: this is a re-enumeration blip, not a user-visible disconnect.
     ///
-    /// Unlike disconnect(), this blinks even the sole active display on desktops: on a
-    /// single-display Mac mini refusing here just makes the override a silent no-op until
-    /// the next reboot or replug (issue #58), which is worse than a ~1s blank the retry loop
-    /// below is built to recover from. Two safety nets back that up: a dead-man marker in
-    /// case the app dies mid-toggle (recoverStrandedSoftReconnect), and a full
-    /// disabled-display sweep if every re-enable retry fails outright
-    /// (reenableUnintentionallyDisabled). Refuses (false) on Intel, on a portable whose sole
-    /// active display this is (Clamshell Sleep would fire mid-blink, see below), or if the
-    /// disable/verified re-enable never lands.
+    /// Unlike disconnect(), this blinks even the sole active display: refusing just makes
+    /// the override a silent no-op until the next reboot or replug (issue #58), which is
+    /// worse than a ~1s blank the retry loop below is built to recover from. On portables a
+    /// throwaway virtual display is held for the blink's duration so Clamshell Sleep never
+    /// fires mid-toggle (see makeBlinkSleepGuard). Two safety nets back the blink up: a
+    /// dead-man marker in case the app dies mid-toggle (recoverStrandedSoftReconnect), and a
+    /// full disabled-display sweep if every re-enable retry fails outright
+    /// (reenableUnintentionallyDisabled). Refuses (false) on Intel, when the portable sleep
+    /// guard can't be created, or if the disable/verified re-enable never lands.
     @discardableResult
     func softReconnect(_ display: DisplayInfo) async -> Bool {
         guard isSupported else { return false }
         let blinkUUID = display.displayUUID
         let startID = display.displayID
         // A lid-closed portable sleeps the instant its sole active display goes away
-        // (Clamshell Sleep; verified live: the blink's disable triggered it mid-toggle, and
-        // the wake left the display SLS-disabled with a lying re-enable "success"). So the
-        // sole-display blink is desktop-only: on a machine with a battery, refuse and let
-        // the caller show the replug hint instead. Lid-open laptops never hit this (the
-        // built-in keeps the count above one).
-        if wouldLeaveNoActiveDisplay(startID) && Self.hasBattery { return false }
+        // (Clamshell Sleep; verified live: the blink's disable triggered it mid-toggle, the
+        // wake left the display SLS-disabled behind a lying re-enable "success", and a
+        // PreventSystemSleep assertion does NOT stop it). A live virtual display keeps the
+        // display count above zero, which verifiably does prevent it (probed on the same
+        // hardware), so hold a throwaway one for the blink's duration. Lid-open laptops
+        // never get here (the built-in keeps the count above one); desktops need no guard
+        // (no clamshell rule). Refuse only if the guard can't be created: blinking into a
+        // guaranteed mid-toggle sleep is how displays get stranded.
+        var sleepGuard: CGVirtualDisplay?
+        if Self.hasBattery && wouldLeaveNoActiveDisplay(startID) {
+            sleepGuard = await makeBlinkSleepGuard()
+            if sleepGuard == nil { return false }
+        }
+        // Held (released) at every exit below; releasing it is what removes the display.
+        defer { withExtendedLifetime(sleepGuard) {} }
+        // The re-enumeration can come back on macOS's default mode instead of the one the
+        // user was running (refresh-rate reset observed live on a 180Hz panel); capture the
+        // exact mode now so a verified re-enable can restore it.
+        let previousMode = CGDisplayCopyDisplayMode(startID)
         softReconnectInFlight.insert(blinkUUID)
         defer { softReconnectInFlight.remove(blinkUUID) }
         // Persist before disabling: if the app dies between here and a verified re-enable
@@ -261,6 +274,14 @@ final class PhysicalDisplayToggleService: ObservableObject {
             if case .success = await setEnabled(true, displayID: targetID),
                await verifyBackOnline(uuid: blinkUUID) {
                 removePendingSoftReconnect(blinkUUID)
+                // Best effort: setting a mode whose timing no longer enumerates fails
+                // harmlessly (toggling smooth scaling OFF removes the dense mode the user
+                // may have been running), leaving macOS's fallback, same as pre-fix.
+                if let previousMode,
+                   let backID = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == blinkUUID }),
+                   CGDisplayCopyDisplayMode(backID)?.ioDisplayModeID != previousMode.ioDisplayModeID {
+                    CGDisplaySetDisplayMode(backID, previousMode, nil)
+                }
                 return true
             }
             try? await Task.sleep(nanoseconds: 300_000_000)
@@ -348,6 +369,43 @@ final class PhysicalDisplayToggleService: ObservableObject {
         IOObjectRelease(service)
         return true
     }()
+
+    /// Throwaway virtual display held while blinking a portable's sole active display, so
+    /// Clamshell Sleep never sees a zero-display moment (see softReconnect). Registered but
+    /// deliberately minimal: 1080p, no HiDPI ladder. Stamped with the shared virtual vendor
+    /// ID so DisplayManager filters it from the UI like any managed virtual display, and
+    /// with a FIXED product/serial so macOS keys its per-display settings (including the
+    /// "what to show" choice) on a stable identity instead of re-prompting every blink.
+    /// Returns nil unless the display verifiably comes online; a registered-but-offline
+    /// guard protects nothing.
+    private func makeBlinkSleepGuard() async -> CGVirtualDisplay? {
+        let w = 1920, h = 1080
+        let ppi = 110.0
+        let descriptor = CGVirtualDisplayDescriptor()
+        descriptor.sizeInMillimeters = CGSize(width: Double(w) / ppi * 25.4,
+                                              height: Double(h) / ppi * 25.4)
+        descriptor.maxPixelsWide = UInt32(w)
+        descriptor.maxPixelsHigh = UInt32(h)
+        descriptor.name = "Crisp Blink Guard"
+        descriptor.vendorID = VirtualDisplayService.crispVirtualVendorID
+        descriptor.productID = 0xB11C
+        descriptor.serialNum = 0xB11C
+        // DO NOT set queue or color primaries (see VirtualDisplayService.create).
+        guard let vd = CGVirtualDisplay(descriptor: descriptor) else { return nil }
+        let settings = CGVirtualDisplaySettings()
+        settings.hiDPI = false
+        let mode: CGVirtualDisplayMode = CGVirtualDisplayMode(width: UInt(w), height: UInt(h), refreshRate: 60.0)
+        settings.modes = [mode]
+        let applied: Bool = await CGHelpers.runWithTimeout(seconds: 10, fallback: false) {
+            vd.apply(settings)
+        }
+        guard applied, vd.displayID != kCGNullDirectDisplay else { return nil }
+        for _ in 0..<20 {
+            if onlineDisplayIDs().contains(vd.displayID) { return vd }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        return nil
+    }
 
     // MARK: - Reconcile / Wake restore
 

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -60,6 +60,9 @@ final class PhysicalDisplayToggleService: ObservableObject {
     @Published private(set) var disconnected: [DisconnectedDisplay] = []
 
     private let desiredKey = "crisp.PhysicalDisconnectedUUIDs"
+    /// Dead-man marker: the UUID of a display softReconnect is (or was, if the app died)
+    /// mid-toggle on. See softReconnect / recoverStrandedSoftReconnect.
+    private let softReconnectPendingKey = "crisp.PhysicalDisplayToggleService.softReconnectPending"
 
     // MARK: - Support gate
 
@@ -186,22 +189,44 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// time via this toggle). The screen blanks ~1s. Re-resolves the ID by UUID before
     /// re-enabling since the disconnect can reassign it, and retries the re-enable so a transient
     /// failure can't strand a black screen. Unlike disconnect() it leaves the `disconnected` set
-    /// untouched: this is a re-enumeration blip, not a user-visible disconnect. Refuses (false)
-    /// if it would leave no active display, or on Intel.
+    /// untouched: this is a re-enumeration blip, not a user-visible disconnect.
+    ///
+    /// Unlike disconnect(), this blinks even the sole active display: on a single-display
+    /// machine refusing here just makes the override a silent no-op until the next reboot or
+    /// replug (issue #58), which is worse than a ~1s blank the retry loop below is built to
+    /// recover from. Two safety nets back that up: a dead-man marker in case the app dies
+    /// mid-toggle (recoverStrandedSoftReconnect), and a full disabled-display sweep if every
+    /// re-enable retry fails outright (reenableUnintentionallyDisabled). Refuses (false) only
+    /// on Intel, or if the disable/re-enable itself never lands.
     @discardableResult
     func softReconnect(_ display: DisplayInfo) async -> Bool {
         guard isSupported else { return false }
         let startID = display.displayID
-        guard !wouldLeaveNoActiveDisplay(startID) else { return false }
-        guard case .success = await setEnabled(false, displayID: startID) else { return false }
+        // Persist before disabling: if the app dies between here and a successful re-enable
+        // below (crash, force-quit), the display would otherwise be stuck SLS-disabled with
+        // nothing left to bring it back. recoverStrandedSoftReconnect checks this at the next
+        // launch. Cleared as soon as re-enable succeeds, or immediately below if the disable
+        // itself never happened.
+        UserDefaults.standard.set(display.displayUUID, forKey: softReconnectPendingKey)
+        guard case .success = await setEnabled(false, displayID: startID) else {
+            UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
+            return false
+        }
         // Wait for the framebuffer to actually drop (removeFlag) before re-enabling;
         // the 0.9s ceiling matches the old fixed sleep if the event never comes.
         await ReconfigEvents.shared.next(for: startID, matching: .removeFlag, timeout: 0.9)
         for _ in 0..<3 {
             let targetID = allDisplaysIncludingDisabled().first { uuid(for: $0) == display.displayUUID } ?? startID
-            if case .success = await setEnabled(true, displayID: targetID) { return true }
+            if case .success = await setEnabled(true, displayID: targetID) {
+                UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
+                return true
+            }
             try? await Task.sleep(nanoseconds: 300_000_000)
         }
+        // The target never came back after three tries: don't leave any display our own
+        // disable may have stranded off. The marker is left in place on purpose, so a
+        // relaunch retries the recovery too.
+        await reenableUnintentionallyDisabled()
         return false
     }
 
@@ -228,6 +253,23 @@ final class PhysicalDisplayToggleService: ObservableObject {
         }
     }
 
+    /// Safety net for softReconnect's re-enable retries all failing: sweeps every SLS-disabled
+    /// display that isn't one we disconnected on purpose (`disconnected`), so a transient
+    /// re-enable failure can never leave a screen stuck black. Other apps (Lunar and friends)
+    /// disable displays intentionally; those are left alone.
+    private func reenableUnintentionallyDisabled() async {
+        var onlineCount: UInt32 = 0
+        CGGetOnlineDisplayList(0, nil, &onlineCount)
+        var onlineIDs = [CGDirectDisplayID](repeating: 0, count: Int(onlineCount))
+        CGGetOnlineDisplayList(onlineCount, &onlineIDs, &onlineCount)
+        let onlineSet = Set(onlineIDs.prefix(Int(onlineCount)))
+        let intentionalUUIDs = Set(disconnected.map { $0.uuid })
+        for id in allDisplaysIncludingDisabled() where !onlineSet.contains(id) {
+            guard !intentionalUUIDs.contains(uuid(for: id)) else { continue }
+            _ = await setEnabled(true, displayID: id)
+        }
+    }
+
     // MARK: - Reconcile / Wake restore
 
     /// Drops records for displays that are back online (e.g. physically re-plugged, or macOS
@@ -243,6 +285,31 @@ final class PhysicalDisplayToggleService: ObservableObject {
         let before = disconnected.count
         disconnected.removeAll { onlineUUIDs.contains($0.uuid) }
         if disconnected.count != before { saveDesired() }
+    }
+
+    /// Startup recovery for a softReconnect that never finished: if the app died (crash,
+    /// force-quit) between disabling the display and its re-enable retry loop, the marker
+    /// softReconnect left behind names exactly the stranded display. Called from
+    /// DisplayManager.refreshDisplays (its very first run, at app launch, alongside
+    /// reconcile()); a no-op once the marker is gone. Only ever touches the ONE marked
+    /// display, never any other disabled one (another app may have disabled those on purpose).
+    func recoverStrandedSoftReconnect() async {
+        guard isSupported,
+              let markedUUID = UserDefaults.standard.string(forKey: softReconnectPendingKey)
+        else { return }
+        // The marker's job ends here either way: a stale UUID (display gone, or already
+        // recovered) should not keep getting rechecked on every future launch.
+        defer { UserDefaults.standard.removeObject(forKey: softReconnectPendingKey) }
+        guard let targetID = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == markedUUID })
+        else { return }
+        var onlineCount: UInt32 = 0
+        CGGetOnlineDisplayList(0, nil, &onlineCount)
+        var onlineIDs = [CGDirectDisplayID](repeating: 0, count: Int(onlineCount))
+        CGGetOnlineDisplayList(onlineCount, &onlineIDs, &onlineCount)
+        // Already online: recovered normally (or the retry-exhausted sweep in softReconnect
+        // already brought it back); nothing to do.
+        guard !onlineIDs.prefix(Int(onlineCount)).contains(targetID) else { return }
+        _ = await setEnabled(true, displayID: targetID)
     }
 
     /// Guards against overlapping restore attempts from reconfiguration-callback bursts.

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreGraphics
 import ColorSync
+import IOKit
 
 /// Disconnects / reconnects REAL (physical) displays on the fly, the way BetterDisplay's
 /// "Disconnect Display" works. This is fundamentally different from VirtualDisplayService:
@@ -219,25 +220,34 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// failure can't strand a black screen. Unlike disconnect() it leaves the `disconnected` set
     /// untouched: this is a re-enumeration blip, not a user-visible disconnect.
     ///
-    /// Unlike disconnect(), this blinks even the sole active display: on a single-display
-    /// machine refusing here just makes the override a silent no-op until the next reboot or
-    /// replug (issue #58), which is worse than a ~1s blank the retry loop below is built to
-    /// recover from. Two safety nets back that up: a dead-man marker in case the app dies
-    /// mid-toggle (recoverStrandedSoftReconnect), and a full disabled-display sweep if every
-    /// re-enable retry fails outright (reenableUnintentionallyDisabled). Refuses (false) only
-    /// on Intel, or if the disable/re-enable itself never lands.
+    /// Unlike disconnect(), this blinks even the sole active display on desktops: on a
+    /// single-display Mac mini refusing here just makes the override a silent no-op until
+    /// the next reboot or replug (issue #58), which is worse than a ~1s blank the retry loop
+    /// below is built to recover from. Two safety nets back that up: a dead-man marker in
+    /// case the app dies mid-toggle (recoverStrandedSoftReconnect), and a full
+    /// disabled-display sweep if every re-enable retry fails outright
+    /// (reenableUnintentionallyDisabled). Refuses (false) on Intel, on a portable whose sole
+    /// active display this is (Clamshell Sleep would fire mid-blink, see below), or if the
+    /// disable/verified re-enable never lands.
     @discardableResult
     func softReconnect(_ display: DisplayInfo) async -> Bool {
         guard isSupported else { return false }
         let blinkUUID = display.displayUUID
+        let startID = display.displayID
+        // A lid-closed portable sleeps the instant its sole active display goes away
+        // (Clamshell Sleep; verified live: the blink's disable triggered it mid-toggle, and
+        // the wake left the display SLS-disabled with a lying re-enable "success"). So the
+        // sole-display blink is desktop-only: on a machine with a battery, refuse and let
+        // the caller show the replug hint instead. Lid-open laptops never hit this (the
+        // built-in keeps the count above one).
+        if wouldLeaveNoActiveDisplay(startID) && Self.hasBattery { return false }
         softReconnectInFlight.insert(blinkUUID)
         defer { softReconnectInFlight.remove(blinkUUID) }
-        let startID = display.displayID
-        // Persist before disabling: if the app dies between here and a successful re-enable
+        // Persist before disabling: if the app dies between here and a verified re-enable
         // below (crash, force-quit), the display would otherwise be stuck SLS-disabled with
         // nothing left to bring it back. recoverStrandedSoftReconnect checks this at the next
-        // launch. Cleared as soon as re-enable succeeds, or immediately below if the disable
-        // itself never happened.
+        // launch. Cleared as soon as the display is verifiably back online, or immediately
+        // below if the disable itself never happened.
         addPendingSoftReconnect(blinkUUID)
         guard case .success = await setEnabled(false, displayID: startID) else {
             removePendingSoftReconnect(blinkUUID)
@@ -248,7 +258,8 @@ final class PhysicalDisplayToggleService: ObservableObject {
         await ReconfigEvents.shared.next(for: startID, matching: .removeFlag, timeout: 0.9)
         for _ in 0..<3 {
             let targetID = allDisplaysIncludingDisabled().first { uuid(for: $0) == blinkUUID } ?? startID
-            if case .success = await setEnabled(true, displayID: targetID) {
+            if case .success = await setEnabled(true, displayID: targetID),
+               await verifyBackOnline(uuid: blinkUUID) {
                 removePendingSoftReconnect(blinkUUID)
                 return true
             }
@@ -315,6 +326,29 @@ final class PhysicalDisplayToggleService: ObservableObject {
         return Set(ids.prefix(Int(count)))
     }
 
+    /// True once the display with this UUID is back in the online list, polling up to ~1s.
+    /// A successful SLSConfigureDisplayEnabled transaction is NOT proof of recovery: around
+    /// sleep transitions it reports success while the display stays disabled (verified live
+    /// in clamshell). Only enumeration counts.
+    private func verifyBackOnline(uuid displayUUID: String) async -> Bool {
+        for _ in 0..<10 {
+            if let id = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == displayUUID }),
+               onlineDisplayIDs().contains(id) { return true }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        return false
+    }
+
+    /// Portables enforce Clamshell Sleep the moment no display is active; desktops don't.
+    /// Battery presence is the lid-independent laptop test (the built-in panel can vanish
+    /// from the display lists entirely while the lid is closed, so it can't be the signal).
+    private static let hasBattery: Bool = {
+        let service = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("AppleSmartBattery"))
+        guard service != 0 else { return false }
+        IOObjectRelease(service)
+        return true
+    }()
+
     // MARK: - Reconcile / Wake restore
 
     /// Drops records for displays that are back online (e.g. physically re-plugged, or macOS
@@ -371,7 +405,11 @@ final class PhysicalDisplayToggleService: ObservableObject {
             }
             var recovered = false
             for _ in 0..<3 {
-                if case .success = await setEnabled(true, displayID: targetID) {
+                // The API result alone is never trusted (see verifyBackOnline): a lying
+                // "success" here is exactly how a clamshell-sleep interruption erased the
+                // marker while the display stayed disabled.
+                if case .success = await setEnabled(true, displayID: targetID),
+                   await verifyBackOnline(uuid: markedUUID) {
                     recovered = true
                     break
                 }

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -63,6 +63,11 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// Dead-man marker: the UUID of a display softReconnect is (or was, if the app died)
     /// mid-toggle on. See softReconnect / recoverStrandedSoftReconnect.
     private let softReconnectPendingKey = "crisp.PhysicalDisplayToggleService.softReconnectPending"
+    /// True while softReconnect is mid-blink. The marker above is legitimately set for that
+    /// whole window, and the blink's own removeFlag event fires refreshDisplays (and thus
+    /// recoverStrandedSoftReconnect) before the toggle finishes; this keeps the recovery
+    /// path from re-enabling the display out from under the retry loop.
+    private var softReconnectInFlight = false
 
     // MARK: - Support gate
 
@@ -201,6 +206,8 @@ final class PhysicalDisplayToggleService: ObservableObject {
     @discardableResult
     func softReconnect(_ display: DisplayInfo) async -> Bool {
         guard isSupported else { return false }
+        softReconnectInFlight = true
+        defer { softReconnectInFlight = false }
         let startID = display.displayID
         // Persist before disabling: if the app dies between here and a successful re-enable
         // below (crash, force-quit), the display would otherwise be stuck SLS-disabled with
@@ -258,16 +265,22 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// re-enable failure can never leave a screen stuck black. Other apps (Lunar and friends)
     /// disable displays intentionally; those are left alone.
     private func reenableUnintentionallyDisabled() async {
-        var onlineCount: UInt32 = 0
-        CGGetOnlineDisplayList(0, nil, &onlineCount)
-        var onlineIDs = [CGDirectDisplayID](repeating: 0, count: Int(onlineCount))
-        CGGetOnlineDisplayList(onlineCount, &onlineIDs, &onlineCount)
-        let onlineSet = Set(onlineIDs.prefix(Int(onlineCount)))
+        let onlineSet = onlineDisplayIDs()
         let intentionalUUIDs = Set(disconnected.map { $0.uuid })
         for id in allDisplaysIncludingDisabled() where !onlineSet.contains(id) {
             guard !intentionalUUIDs.contains(uuid(for: id)) else { continue }
             _ = await setEnabled(true, displayID: id)
         }
+    }
+
+    /// Display IDs currently online. SLS-disabled displays are omitted here (see
+    /// allDisplaysIncludingDisabled), so "online" doubles as the enabled check.
+    private func onlineDisplayIDs() -> Set<CGDirectDisplayID> {
+        var count: UInt32 = 0
+        CGGetOnlineDisplayList(0, nil, &count)
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        CGGetOnlineDisplayList(count, &ids, &count)
+        return Set(ids.prefix(Int(count)))
     }
 
     // MARK: - Reconcile / Wake restore
@@ -287,29 +300,46 @@ final class PhysicalDisplayToggleService: ObservableObject {
         if disconnected.count != before { saveDesired() }
     }
 
-    /// Startup recovery for a softReconnect that never finished: if the app died (crash,
-    /// force-quit) between disabling the display and its re-enable retry loop, the marker
-    /// softReconnect left behind names exactly the stranded display. Called from
-    /// DisplayManager.refreshDisplays (its very first run, at app launch, alongside
-    /// reconcile()); a no-op once the marker is gone. Only ever touches the ONE marked
-    /// display, never any other disabled one (another app may have disabled those on purpose).
+    /// Recovery for a softReconnect that never finished: if the app died (crash, force-quit)
+    /// between disabling the display and a successful re-enable, the marker softReconnect
+    /// left behind names exactly the stranded display. Called from
+    /// DisplayManager.refreshDisplays; a cheap no-op unless the marker is set, and skipped
+    /// while a live softReconnect is mid-blink (its own reconfig events fire refreshDisplays
+    /// before the toggle finishes, and its retry loop must not be raced). Mirrors
+    /// softReconnect's recovery ladder (3 re-enable tries, then the sweep), and clears the
+    /// marker only once the display is verifiably back online or gone entirely, so a
+    /// transient failure here leaves it set for the next refresh or launch to try again.
+    /// Only ever re-enables the ONE marked display directly, never any other disabled one
+    /// (another app may have disabled those on purpose); the sweep it shares with
+    /// softReconnect stays scoped to displays outside the intentional `disconnected` set.
     func recoverStrandedSoftReconnect() async {
-        guard isSupported,
+        guard isSupported, !softReconnectInFlight,
               let markedUUID = UserDefaults.standard.string(forKey: softReconnectPendingKey)
         else { return }
-        // The marker's job ends here either way: a stale UUID (display gone, or already
-        // recovered) should not keep getting rechecked on every future launch.
-        defer { UserDefaults.standard.removeObject(forKey: softReconnectPendingKey) }
-        guard let targetID = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == markedUUID })
-        else { return }
-        var onlineCount: UInt32 = 0
-        CGGetOnlineDisplayList(0, nil, &onlineCount)
-        var onlineIDs = [CGDirectDisplayID](repeating: 0, count: Int(onlineCount))
-        CGGetOnlineDisplayList(onlineCount, &onlineIDs, &onlineCount)
-        // Already online: recovered normally (or the retry-exhausted sweep in softReconnect
-        // already brought it back); nothing to do.
-        guard !onlineIDs.prefix(Int(onlineCount)).contains(targetID) else { return }
-        _ = await setEnabled(true, displayID: targetID)
+        guard let targetID = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == markedUUID }) else {
+            // Display gone entirely (unplugged while stranded): a physical replug brings it
+            // back online by itself, so the marker has nothing left to do.
+            UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
+            return
+        }
+        if onlineDisplayIDs().contains(targetID) {
+            // Recovered normally (or a previous sweep already brought it back).
+            UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
+            return
+        }
+        for _ in 0..<3 {
+            if case .success = await setEnabled(true, displayID: targetID) {
+                UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
+                return
+            }
+            try? await Task.sleep(nanoseconds: 300_000_000)
+        }
+        await reenableUnintentionallyDisabled()
+        // Clear only if the sweep verifiably landed it; otherwise the marker stays set and
+        // the addFlag/refresh cadence (or the next launch) retries.
+        if onlineDisplayIDs().contains(targetID) {
+            UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
+        }
     }
 
     /// Guards against overlapping restore attempts from reconfiguration-callback bursts.

--- a/Crisp/Views/DisplayModeListView.swift
+++ b/Crisp/Views/DisplayModeListView.swift
@@ -463,12 +463,15 @@ final class DisplayModeController: ObservableObject {
                 try? await Task.sleep(nanoseconds: 800_000_000)  // let refreshModes land
                 smoothOn = smoothModesPresent
                 refreshSmoothWouldPrompt()
-                if !reconnected {
-                    // Single-active-display machines refuse the blink (and a normal reconnect
-                    // can still fail outright): the switch above already snapped back to
-                    // ground truth, which would otherwise look like the toggle silently did
-                    // nothing. It didn't: the plist write landed, it just needs a real
-                    // reconnect (or reboot) to be read.
+                if !reconnected && smoothOn != on {
+                    // The blink was refused (Intel) or failed, and the re-read never happened:
+                    // the switch above snapped back to ground truth, which would otherwise look
+                    // like the toggle silently did nothing. It didn't: the plist write landed,
+                    // it just needs a real reconnect (or reboot) to be read. The ground-truth
+                    // check matters: when softReconnect returns false but its retry-exhausted
+                    // sweep completed the blink anyway, the modes DID re-enumerate, a hint
+                    // would be wrong, and that path also rebuilt this controller so a hint set
+                    // here could never render (the rebuilt row reads the fresh controller).
                     withAnimation {
                         reconnectHint = String(
                             localized: "Saved. Unplug and replug the monitor cable, or restart your Mac, to apply.")

--- a/Crisp/Views/DisplayModeListView.swift
+++ b/Crisp/Views/DisplayModeListView.swift
@@ -24,6 +24,13 @@ final class DisplayModeController: ObservableObject {
     @Published var pendingResolutionID: String?
     @Published var pendingRefreshID: Int32?
     @Published var errorMessage: String?
+    /// Set when a smooth-scaling toggle's soft-reconnect couldn't happen (e.g. this is the
+    /// only active display and macOS refused to blink it, or the re-enable retries all
+    /// failed). The plist write itself still landed on disk; this tells the user how to make
+    /// it take effect instead of the switch just silently snapping back. Unlike errorMessage
+    /// this does NOT auto-clear after a few seconds: "go replug the cable" isn't something to
+    /// blink-and-miss, so it stays put while the section is open.
+    @Published var reconnectHint: String?
     @Published var sliderIndex: Double = 0
     @Published var smoothBusy: Bool = false
     @Published var smoothOn: Bool = false
@@ -407,12 +414,16 @@ final class DisplayModeController: ObservableObject {
 
     /// Flips the dense HiDPI ladder on or off. ON writes the override, OFF removes it; both then
     /// soft-reconnect (screen blanks ~1s) so macOS re-enumerates in software rather than on a
-    /// physical reconnect, and both touch /Library/Displays so both show one admin prompt.
-    /// Optimistic: the knob moves now, a settle re-read adopts whatever actually enumerated.
+    /// physical reconnect, and both touch /Library/Displays so both show one admin prompt. When
+    /// the soft-reconnect itself can't complete (e.g. a re-enable that never lands), the write
+    /// already landed on disk; reconnectHint tells the user how to make it take effect instead
+    /// of the switch just silently snapping back (issue #58). Optimistic: the knob moves now,
+    /// a settle re-read adopts whatever actually enumerated.
     func userToggleSmooth(_ on: Bool) {
         guard !smoothBusy, PanelOpenGuard.allowsActivation else { return }
         smoothOn = on   // optimistic; the re-enumeration below confirms it
         smoothBusy = true
+        reconnectHint = nil   // fresh attempt: any hint from a previous one is now moot
         // Panel-space dims: the override plist is rotation-blind (see panelNativeResolution).
         let (nativeW, nativeH) = display.panelNativeResolution
         // Capture now, while the display is still connected and its UUID resolves; the
@@ -447,11 +458,22 @@ final class DisplayModeController: ObservableObject {
                 defer { PanelOpenGuard.suppressAutoDismiss = false }
                 // Re-read the override change in software (screen blanks ~1s) instead of
                 // asking for a physical reconnect.
-                await PhysicalDisplayToggleService.shared.softReconnect(display)
+                let reconnected = await PhysicalDisplayToggleService.shared.softReconnect(display)
                 HiDPIService.shared.refreshModes(for: display)
                 try? await Task.sleep(nanoseconds: 800_000_000)  // let refreshModes land
                 smoothOn = smoothModesPresent
                 refreshSmoothWouldPrompt()
+                if !reconnected {
+                    // Single-active-display machines refuse the blink (and a normal reconnect
+                    // can still fail outright): the switch above already snapped back to
+                    // ground truth, which would otherwise look like the toggle silently did
+                    // nothing. It didn't: the plist write landed, it just needs a real
+                    // reconnect (or reboot) to be read.
+                    withAnimation {
+                        reconnectHint = String(
+                            localized: "Saved. Unplug and replug the monitor cable, or restart your Mac, to apply.")
+                    }
+                }
                 // The blank/auth prompt can steal key focus, greying the switch; re-key the panel.
                 if let panel = NSApp.windows.first(where: { $0 is MenuPanel }), panel.isVisible {
                     panel.makeKey()
@@ -720,7 +742,8 @@ struct RefreshListBlock: View {
 }
 
 /// Trailing rows of the mode section: the smooth-scaling switch (externals
-/// only), the transient switch-failure message, and the section divider.
+/// only), the transient switch-failure message, the apply-it-yourself reconnect
+/// hint, and the section divider.
 struct ModeTailBlock: View {
     @ObservedObject var controller: DisplayModeController
     private var display: DisplayInfo { controller.display }
@@ -741,6 +764,23 @@ struct ModeTailBlock: View {
                     Text(msg)
                         .font(.caption2)
                         .foregroundColor(.red)
+                    Spacer()
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .transition(.opacity)
+            }
+
+            // Informational, not an error (the plist write already succeeded): neutral
+            // styling, and unlike errorMessage it does not auto-clear on a timer.
+            if let hint = controller.reconnectHint {
+                HStack(spacing: 6) {
+                    Image(systemName: "info.circle")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    Text(hint)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
                     Spacer()
                 }
                 .padding(.horizontal, 12)

--- a/Crisp/Views/DisplayModeListView.swift
+++ b/Crisp/Views/DisplayModeListView.swift
@@ -464,7 +464,8 @@ final class DisplayModeController: ObservableObject {
                 smoothOn = smoothModesPresent
                 refreshSmoothWouldPrompt()
                 if !reconnected && smoothOn != on {
-                    // The blink was refused (Intel) or failed, and the re-read never happened:
+                    // The blink was refused (Intel, or a portable's sleep guard failed to
+                    // create) or never landed, and the re-read never happened:
                     // the switch above snapped back to ground truth, which would otherwise look
                     // like the toggle silently did nothing. It didn't: the plist write landed,
                     // it just needs a real reconnect (or reboot) to be read. The ground-truth


### PR DESCRIPTION
## What & why
Fixes #58 (diagnosed in #54). On single-active-display machines (Mac mini with one monitor, clamshell with one external), the Smooth scaling toggle wrote the override plist but `softReconnect` silently refused to blink the only display, so nothing re-enumerated and the switch snapped back with no explanation. The change then applied by surprise on the next reboot or replug.

Two layers:
1. **Honest fallback**: `userToggleSmooth` no longer discards `softReconnect`'s result. When the blink is refused or fails, a neutral persistent hint explains that the change is saved and needs a cable replug or restart. New string localized in en + zh-Hans.
2. **Blink allowed on a single display, with a safety net**: the `wouldLeaveNoActiveDisplay` refusal is removed from `softReconnect` only (kept for user-initiated disconnects). A dead-man marker (display UUID in UserDefaults) is set before the disable and cleared after a successful re-enable; startup recovery re-enables only that marked display if a crash stranded it. If all 3 re-enable retries fail, every unintentionally disabled display (not in the intentional `disconnected` set) is re-enabled as a last resort, and the layer-1 hint still shows.

Review question: the retry-exhausted fallback sweeps all unintentionally disabled displays, while startup recovery touches only the marked one. Intentional asymmetry per the fix plan, but worth a second look.

## How tested
`make check` passes (swiftlint --strict, xcodebuild test with warnings-as-errors, localization key completeness). NOT yet verified on real single-display hardware: the blink/re-enable path on a sole active display needs a live test (Mac mini, or MacBook in clamshell with one external).

## Checklist
- [x] Builds locally
- [x] Added `Localizable.xcstrings` entries for the new user-facing string (en + zh-Hans)
- [ ] Screenshot of the new hint row pending live testing