### PR TITLE
In-app auto-updates via Sparkle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 build/
+vendor/
 *.xcodeproj/xcuserdata/
 *.xcodeproj/project.xcworkspace/xcuserdata/
 DerivedData/

--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -192,10 +192,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             self?.warmPanel()
         }
 
-        // Launch-time update check (self-throttled to one network call/hour);
-        // showPanel re-checks per open. Lived in MenuBarView's .task before
-        // the split-canvas migration.
-        Task { await UpdateService.shared.checkForUpdates() }
+        // Start Sparkle's background update scheduler; a found update surfaces
+        // as the panel's Update row (see UpdateService).
+        _ = UpdateService.shared
 
     }
 
@@ -870,11 +869,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
 
         PanelOpenGuard.openedAt = Date()
-        // Re-check for updates on open so a long-running instance surfaces a new
-        // release without a restart (the panel view mounts once, so its launch
-        // .task can't). checkForUpdates() self-throttles to one network call per
-        // hour, so opening the menu repeatedly costs nothing.
-        Task { await UpdateService.shared.checkForUpdates() }
 
         // Mirror changes made elsewhere while the panel stays open (the
         // click-time refresh above covered the open itself). Cancelled on

--- a/Crisp/Services/UpdateService.swift
+++ b/Crisp/Services/UpdateService.swift
@@ -1,92 +1,64 @@
-import Foundation
 import AppKit
+import Sparkle
 
-/// Checks for new releases on GitHub and surfaces the latest version info.
-@MainActor
-final class UpdateService: ObservableObject, @unchecked Sendable {
+/// Bridges Sparkle's updater to the panel UI. Scheduled checks run in the
+/// background (SUEnableAutomaticChecks in Info.plist, daily by default); a
+/// found update surfaces as the panel's Update row via the gentle-reminders
+/// delegate instead of a focus-stealing alert, which matters for a
+/// menu-bar-only (LSUIElement) app. Clicking the row hands off to Sparkle's
+/// standard download/install/relaunch UI.
+final class UpdateService: NSObject, ObservableObject {
     static let shared = UpdateService()
-
-    // Set these when the repo is published. Placeholder values disable the update check.
-    private let repoOwner = "didriksg"
-    private let repoName  = "Crisp"
 
     // Current app bundle version (CFBundleShortVersionString)
     let currentVersion: String = {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
     }()
 
-    @Published var latestVersion: String? = nil
-    @Published var releaseURL: URL? = nil
-    @Published var isChecking: Bool = false
     @Published var hasUpdate: Bool = false
-    @Published var lastCheckDate: Date? = nil
+    @Published var latestVersion: String? = nil
 
-    private init() {}
+    // lazy so `self` can be the user-driver delegate; touched in init so the
+    // updater (and its check scheduler) starts at launch, not on first access.
+    private lazy var updaterController = SPUStandardUpdaterController(
+        startingUpdater: true, updaterDelegate: nil, userDriverDelegate: self)
 
-    // MARK: - Check for Updates
-
-    func checkForUpdates() async {
-        guard !repoOwner.isEmpty, repoOwner != "OWNER", !repoName.isEmpty else {
-            // Repo not yet configured, silently skip update check
-            return
-        }
-        if let last = lastCheckDate, Date().timeIntervalSince(last) < 3600 { return }
-        guard !isChecking else { return }
-        isChecking = true
-        defer { isChecking = false }
-
-        let urlString = "https://api.github.com/repos/\(repoOwner)/\(repoName)/releases/latest"
-        guard let url = URL(string: urlString) else { return }
-
-        do {
-            var request = URLRequest(url: url)
-            request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-            request.timeoutInterval = 10
-            let (data, response) = try await URLSession.shared.data(for: request)
-            guard (response as? HTTPURLResponse)?.statusCode == 200 else {
-                // Repo may not exist yet; silently ignore
-                lastCheckDate = Date()
-                return
-            }
-            let json: [String: Any]?
-            do {
-                json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-            } catch {
-                lastCheckDate = Date()
-                return
-            }
-            if let tag = json?["tag_name"] as? String {
-                let clean = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
-                latestVersion = clean
-                releaseURL = (json?["html_url"] as? String).flatMap { URL(string: $0) }
-                hasUpdate = isNewerVersion(clean, than: currentVersion)
-            }
-            lastCheckDate = Date()
-        } catch {
-            // Network unavailable or repo doesn't exist, silently ignore
-            lastCheckDate = Date()
-        }
+    private override init() {
+        super.init()
+        _ = updaterController
     }
 
-    // MARK: - Version Comparison
+    // MARK: - Install
 
-    private func isNewerVersion(_ remote: String, than local: String) -> Bool {
-        let remoteComponents = remote.split(separator: ".").compactMap { Int($0) }
-        let localComponents  = local.split(separator: ".").compactMap { Int($0) }
-        let length = max(remoteComponents.count, localComponents.count)
-        for i in 0..<length {
-            let r = i < remoteComponents.count ? remoteComponents[i] : 0
-            let l = i < localComponents.count  ? localComponents[i]  : 0
-            if r > l { return true }
-            if r < l { return false }
-        }
-        return false
+    /// Update-row action: a user-initiated check brings up Sparkle's update UI
+    /// in immediate focus and runs the download/install/relaunch flow.
+    func installUpdate() {
+        updaterController.checkForUpdates(nil)
+    }
+}
+
+// Sparkle's standard user driver calls these on the main thread.
+extension UpdateService: SPUStandardUserDriverDelegate {
+
+    /// Opt in to handling scheduled-update presentation ourselves; without
+    /// this a dockless app gets Sparkle's focus-stealing default UI plus a
+    /// log warning.
+    var supportsGentleScheduledUpdateReminders: Bool { true }
+
+    func standardUserDriverShouldHandleShowingScheduledUpdate(
+        _ update: SUAppcastItem, andInImmediateFocus immediateFocus: Bool
+    ) -> Bool {
+        // Never let a scheduled check pop UI; the panel's Update row is the
+        // reminder. (User-initiated checks still show Sparkle's UI directly.)
+        false
     }
 
-    // MARK: - Open Release Page
-
-    func openReleasePage() {
-        guard let url = releaseURL else { return }
-        NSWorkspace.shared.open(url)
+    func standardUserDriverWillHandleShowingUpdate(
+        _ handleShowingUpdate: Bool, forUpdate update: SUAppcastItem, state: SPUUserUpdateState
+    ) {
+        latestVersion = update.displayVersionString
+        hasUpdate = true
+        // Not cleared on session end: a dismissed update is still pending, and
+        // an installed one relaunches the app anyway.
     }
 }

--- a/Crisp/Services/UpdateService.swift
+++ b/Crisp/Services/UpdateService.swift
@@ -31,8 +31,12 @@ final class UpdateService: NSObject, ObservableObject {
     // MARK: - Install
 
     /// Update-row action: a user-initiated check brings up Sparkle's update UI
-    /// in immediate focus and runs the download/install/relaunch flow.
+    /// and runs the download/install/relaunch flow. The panel is a
+    /// non-activating NSPanel, so the app isn't active when the row is
+    /// clicked; without an explicit activate, macOS 14's cooperative
+    /// activation leaves Sparkle's window behind the frontmost app.
     func installUpdate() {
+        NSApp.activate()
         updaterController.checkForUpdates(nil)
     }
 }

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -281,10 +281,6 @@ struct UpdateRow: View {
             Text("v\(version)")
                 .font(.caption)
                 .foregroundColor(.secondary)
-            Image(systemName: "arrow.up.forward")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .accessibilityHidden(true)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 5)

--- a/Crisp/Views/PanelBlocks.swift
+++ b/Crisp/Views/PanelBlocks.swift
@@ -186,7 +186,7 @@ struct UpdateBlockView: View {
 
     var body: some View {
         if updateService.hasUpdate, let ver = updateService.latestVersion {
-            UpdateRow(version: ver) { updateService.openReleasePage() }
+            UpdateRow(version: ver) { updateService.installUpdate() }
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,17 @@ SWIFT_SOURCES := Crisp/App/*.swift Crisp/Models/*.swift Crisp/Services/*.swift \
 SWIFTC_FLAGS := -O -swift-version 5 -strict-concurrency=minimal -parse-as-library \
                 -import-objc-header Crisp/Crisp-Bridging-Header.h \
                 -framework AppKit -framework SwiftUI -framework IOKit -framework CoreAudio \
+                -F vendor/Sparkle -framework Sparkle \
+                -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
                 -Xlinker -undefined -Xlinker dynamic_lookup
 
 .DEFAULT_GOAL := help
-.PHONY: help dev compile test lint loc-check check build dmg release clean
+.PHONY: help dev compile test lint loc-check check build dmg release clean vendor
+
+# Sparkle framework, pinned + cached in vendor/ (needed to compile and to
+# generate the Xcode project's framework reference).
+vendor:
+	@./scripts/fetch-sparkle.sh
 
 help:
 	@echo "Crisp — make targets:"
@@ -52,7 +59,7 @@ help:
 dev:
 	./dev.sh
 
-compile:
+compile: vendor
 	@echo "==> Compiling Crisp $(VERSION) -> ./Crisp-bin"
 	swiftc $(SWIFTC_FLAGS) $(SWIFT_SOURCES) -o Crisp-bin
 	@echo "Done. ./Crisp-bin built (not swapped into the app; use 'make dev' for that)."
@@ -60,7 +67,7 @@ compile:
 # Warnings are errors here (the baseline is zero, issue #47), so a PR that
 # introduces one fails make check and CI. `make compile` stays permissive for
 # mid-iteration builds.
-test:
+test: vendor
 	xcodegen generate
 	xcodebuild -quiet test -project Crisp.xcodeproj -scheme Crisp \
 		-destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO \
@@ -73,7 +80,7 @@ lint:
 
 # Same check as CI's "Check localization keys" step: every key the code uses
 # must exist in the String Catalog (missing keys silently fall back to English).
-loc-check:
+loc-check: vendor
 	xcodegen generate
 	xcodebuild -quiet -exportLocalizations -project Crisp.xcodeproj \
 		-localizationPath build/loc CODE_SIGNING_ALLOWED=NO \

--- a/dev.sh
+++ b/dev.sh
@@ -23,10 +23,14 @@ fi
 VERSION=$(grep -E '^[[:space:]]*MARKETING_VERSION:' project.yml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
 BUILD=$(grep -E '^[[:space:]]*CURRENT_PROJECT_VERSION:' project.yml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
 
+./scripts/fetch-sparkle.sh
+
 echo "==> Compiling Crisp $VERSION ($BUILD)..."
 swiftc -O -swift-version 5 -strict-concurrency=minimal -parse-as-library \
     -import-objc-header Crisp/Crisp-Bridging-Header.h \
     -framework AppKit -framework SwiftUI -framework IOKit -framework CoreAudio \
+    -F vendor/Sparkle -framework Sparkle \
+    -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
     -Xlinker -undefined -Xlinker dynamic_lookup \
     Crisp/App/*.swift Crisp/Models/*.swift Crisp/Services/*.swift \
     Crisp/Views/*.swift Crisp/Utilities/*.swift \
@@ -36,10 +40,30 @@ echo "==> Swapping into ${APP}..."
 pkill -x Crisp 2>/dev/null || true
 sleep 1
 cp Crisp-bin "$APP/Contents/MacOS/Crisp"
+# The binary links Sparkle at @rpath, so the target bundle needs the framework
+# too (an install from a pre-Sparkle release won't have it). Refresh it on
+# every swap so vendor/ and the bundle can't drift; the re-sign below restores
+# the seal broken by the XPCServices strip.
+rm -rf "$APP/Contents/Frameworks/Sparkle.framework"
+mkdir -p "$APP/Contents/Frameworks"
+cp -R vendor/Sparkle/Sparkle.framework "$APP/Contents/Frameworks/"
+rm -rf "$APP/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices" \
+       "$APP/Contents/Frameworks/Sparkle.framework/XPCServices"
 # Keep the installed bundle's reported version in step with project.yml,
 # since the binary swap doesn't regenerate Info.plist.
 /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $VERSION" "$APP/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD" "$APP/Contents/Info.plist"
+# Sparkle keys, absent when swapping into a pre-Sparkle install: without them
+# the updater logs errors and prompts for check permission on second launch.
+PLIST="$APP/Contents/Info.plist"
+for key in SUFeedURL SUPublicEDKey SUEnableAutomaticChecks SUVerifyUpdateBeforeExtraction SURequireSignedFeed; do
+    /usr/libexec/PlistBuddy -c "Delete :$key" "$PLIST" 2>/dev/null || true
+done
+/usr/libexec/PlistBuddy -c "Add :SUFeedURL string https://didriksg.github.io/Crisp/appcast.xml" "$PLIST"
+/usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string 3UT7wZoXDzrAhwCMVS3DoPt2lcya9H/cvlyXliuPuhM=" "$PLIST"
+/usr/libexec/PlistBuddy -c "Add :SUEnableAutomaticChecks bool true" "$PLIST"
+/usr/libexec/PlistBuddy -c "Add :SUVerifyUpdateBeforeExtraction bool true" "$PLIST"
+/usr/libexec/PlistBuddy -c "Add :SURequireSignedFeed bool true" "$PLIST"
 xattr -cr "$APP"
 # Sign with a stable self-signed identity when one exists, so macOS keeps the
 # Accessibility grant across rebuilds. Ad-hoc signing changes the code hash every
@@ -53,11 +77,14 @@ SIGN_ID="${CRISP_SIGN_ID:-Crisp Dev}"
 # requirement so TCC keeps the grant across rebuilds).
 if security find-identity -p codesigning 2>/dev/null | grep -qF "$SIGN_ID"; then
     echo "==> Signing with identity: $SIGN_ID"
-    codesign --force -s "$SIGN_ID" --entitlements Crisp/Crisp.entitlements "$APP"
 else
     echo "==> Signing ad hoc ($SIGN_ID not found; Accessibility will reset each build)"
-    codesign --force -s - --entitlements Crisp/Crisp.entitlements "$APP"
+    SIGN_ID="-"
 fi
+# Framework first (its seal broke when XPCServices got stripped), then the app,
+# no --deep. Autoupdate/Updater.app inside keep Sparkle's own valid signatures.
+codesign --force -s "$SIGN_ID" "$APP/Contents/Frameworks/Sparkle.framework"
+codesign --force -s "$SIGN_ID" --entitlements Crisp/Crisp.entitlements "$APP"
 
 echo "==> Launching..."
 open "$APP"

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -9,9 +9,12 @@ full DMG with `./scripts/release.sh vX.Y.Z` (no Xcode needed). But for the fast
 dev loop, the binary alone compiles with just the Command Line Tools:
 
 ```sh
+./scripts/fetch-sparkle.sh   # once: vendors the Sparkle updater framework
 swiftc -O -swift-version 5 -strict-concurrency=minimal -parse-as-library \
   -import-objc-header Crisp/Crisp-Bridging-Header.h \
   -framework AppKit -framework SwiftUI -framework IOKit \
+  -F vendor/Sparkle -framework Sparkle \
+  -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
   -Xlinker -undefined -Xlinker dynamic_lookup \
   Crisp/App/*.swift Crisp/Models/*.swift Crisp/Services/*.swift \
   Crisp/Views/*.swift Crisp/Utilities/*.swift \
@@ -19,7 +22,8 @@ swiftc -O -swift-version 5 -strict-concurrency=minimal -parse-as-library \
 ```
 
 To run it, swap the binary into an existing Crisp.app install and re-sign ad
-hoc:
+hoc (the install must contain `Contents/Frameworks/Sparkle.framework`; installs
+of a pre-Sparkle release don't, so use `./dev.sh`, which copies it in):
 
 ```sh
 pkill -x Crisp

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,51 @@
+# Releasing
+
+Normal flow is unchanged: `./scripts/release.sh vX.Y.Z notes.md --publish`
+(see the script header for setup). The Sparkle auto-update chain adds the
+steps below.
+
+## Every release
+
+After `--publish` finishes, commit and push `docs/appcast.xml` together with
+the `project.yml` version bump. In-app updates go live only when GitHub Pages
+serves the new appcast; until then installed apps simply keep waiting (they
+never break, they just see no update).
+
+## First Sparkle release only (delete this section afterwards)
+
+Add `auto_updates true` to `Casks/crisp.rb` in `didriksg/homebrew-tap`. The
+release script only bumps `version` and `sha256`; the stanza is a one-time
+manual edit. It tells `brew upgrade` the app updates itself, and since
+Homebrew 6 brew reconciles against the on-disk version instead of
+reinstalling.
+
+## The signing key
+
+Updates are EdDSA-signed. The private key lives in the maintainer's login
+Keychain (created once with `./vendor/Sparkle/bin/generate_keys`); the public
+half is pinned in `scripts/release.sh` as `SUPublicEDKey`. A backup of the
+private key is stored in Bitwarden.
+
+- Lost key: no future updates can be signed. Restore from Bitwarden with
+  `generate_keys -f <file>`.
+- Leaked key: treat like a leaked Developer ID key; an attacker who also
+  gains GitHub access could ship signed updates. Rotation is painful (old
+  installs pin the old public key), so custody beats rotation.
+- Never commit or log the private key. `generate_appcast`/`sign_update` read
+  it from the Keychain automatically at publish time.
+
+## Testing an update locally (no publish)
+
+Build the "old" and "new" versions with two dry runs, serve a signed feed
+from localhost, and let the old build update itself:
+
+1. `./scripts/release.sh v9.9.8`, copy `build/Crisp.app` somewhere writable,
+   point its `SUFeedURL` at `http://localhost:8765/appcast.xml` with
+   PlistBuddy and re-sign ad hoc.
+2. `./scripts/release.sh v9.9.9`, put `Crisp.dmg` in a feed dir, run
+   `./vendor/Sparkle/bin/generate_appcast --download-url-prefix
+   http://localhost:8765/ -o <feeddir>/appcast.xml <feeddir>`, then
+   `python3 -m http.server 8765` in the feed dir.
+3. Quit the installed Crisp first (single-instance lock), launch the test
+   copy, and use the panel's Update row. Delete the `SU*` keys from
+   `defaults read com.crisp.app` afterwards.

--- a/project.yml
+++ b/project.yml
@@ -18,6 +18,10 @@ targets:
       - path: Crisp
         excludes:
           - "**/*.md"
+    dependencies:
+      # Prebuilt Sparkle, fetched by scripts/fetch-sparkle.sh (make vendor).
+      - framework: vendor/Sparkle/Sparkle.framework
+        embed: true
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.crisp.app
@@ -41,6 +45,8 @@ targets:
         # loaded in-process via AppKit, so mark just these two symbols as
         # resolved-at-runtime instead of hard-linking a private framework path.
         OTHER_LDFLAGS: "-Wl,-U,_SLSConfigureDisplayEnabled -Wl,-U,_SLSGetDisplayList"
+        FRAMEWORK_SEARCH_PATHS: "vendor/Sparkle"
+        LD_RUNPATH_SEARCH_PATHS: "@executable_path/../Frameworks"
         GENERATE_INFOPLIST_FILE: YES
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
   CrispTests:

--- a/scripts/fetch-sparkle.sh
+++ b/scripts/fetch-sparkle.sh
@@ -7,11 +7,14 @@ set -euo pipefail
 
 SPARKLE_VERSION="2.9.5"
 SPARKLE_SHA256="015336b601493e05c237964954bff6191370003d94edefe663724c88840d73cc"
+# Bump the -pN suffix when the post-extract patching below changes, so cached
+# vendor/ dirs refresh.
+SPARKLE_PATCH_REV="${SPARKLE_VERSION}-p1"
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/vendor/Sparkle"
 
-if [ -f "$DEST/.version" ] && [ "$(cat "$DEST/.version")" = "$SPARKLE_VERSION" ]; then
+if [ -f "$DEST/.version" ] && [ "$(cat "$DEST/.version")" = "$SPARKLE_PATCH_REV" ]; then
     exit 0
 fi
 
@@ -26,5 +29,15 @@ rm -rf "$DEST"
 mkdir -p "$DEST"
 # Only the framework and CLI tools; the archive's test app and dSYMs stay out.
 tar -xJf "$TMP/sparkle.tar.xz" -C "$DEST" "./Sparkle.framework" "./bin"
-echo "$SPARKLE_VERSION" > "$DEST/.version"
-echo "==> Sparkle $SPARKLE_VERSION ready in vendor/Sparkle"
+
+# House style: no em-dashes in user-facing text. Sparkle's English update
+# alert uses them ("... is now available—you have ..."); swap for the
+# semicolon Sparkle already uses elsewhere in the same strings. Editing the
+# framework is fine: every build path re-signs it anyway (XPCServices strip).
+STRINGS="$DEST/Sparkle.framework/Versions/B/Resources/Base.lproj/Sparkle.strings"
+plutil -convert xml1 "$STRINGS"
+sed -i '' 's/—/; /g' "$STRINGS"
+plutil -convert binary1 "$STRINGS"
+
+echo "$SPARKLE_PATCH_REV" > "$DEST/.version"
+echo "==> Sparkle ${SPARKLE_VERSION} ready in vendor/Sparkle"

--- a/scripts/fetch-sparkle.sh
+++ b/scripts/fetch-sparkle.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Fetches the prebuilt Sparkle updater framework + CLI tools into vendor/Sparkle/
+# (gitignored). Pinned by version and sha256 so every build path (release.sh,
+# dev.sh, Makefile, CI) links the exact same binary. Idempotent: no-op when the
+# pinned version is already in place.
+set -euo pipefail
+
+SPARKLE_VERSION="2.9.5"
+SPARKLE_SHA256="015336b601493e05c237964954bff6191370003d94edefe663724c88840d73cc"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$ROOT/vendor/Sparkle"
+
+if [ -f "$DEST/.version" ] && [ "$(cat "$DEST/.version")" = "$SPARKLE_VERSION" ]; then
+    exit 0
+fi
+
+echo "==> Fetching Sparkle ${SPARKLE_VERSION}…"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+curl -fsSL -o "$TMP/sparkle.tar.xz" \
+    "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-$SPARKLE_VERSION.tar.xz"
+echo "$SPARKLE_SHA256  $TMP/sparkle.tar.xz" | shasum -a 256 -c - >/dev/null
+
+rm -rf "$DEST"
+mkdir -p "$DEST"
+# Only the framework and CLI tools; the archive's test app and dSYMs stay out.
+tar -xJf "$TMP/sparkle.tar.xz" -C "$DEST" "./Sparkle.framework" "./bin"
+echo "$SPARKLE_VERSION" > "$DEST/.version"
+echo "==> Sparkle $SPARKLE_VERSION ready in vendor/Sparkle"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -37,16 +37,30 @@ fi
 
 rm -rf "$BUILD"; mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
 
+"$ROOT/scripts/fetch-sparkle.sh"
+
 echo "==> Compiling universal binary (arm64 + x86_64)…"
 SRC=$(find Crisp -name '*.swift')
 for a in arm64 x86_64; do
   swiftc -O -parse-as-library -target "$a-apple-macos14.0" \
     -import-objc-header Crisp/Crisp-Bridging-Header.h \
+    -F "$ROOT/vendor/Sparkle" -framework Sparkle \
+    -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
     -Xlinker -U -Xlinker _SLSConfigureDisplayEnabled \
     -Xlinker -U -Xlinker _SLSGetDisplayList \
     $SRC -o "$BUILD/Crisp-$a"
 done
 lipo -create "$BUILD/Crisp-arm64" "$BUILD/Crisp-x86_64" -output "$APP/Contents/MacOS/Crisp"
+
+echo "==> Embedding Sparkle.framework…"
+mkdir -p "$APP/Contents/Frameworks"
+cp -R "$ROOT/vendor/Sparkle/Sparkle.framework" "$APP/Contents/Frameworks/"
+# Crisp is not sandboxed, so Sparkle's XPC services are dead weight; Sparkle's
+# docs recommend deleting them (the dir and the top-level symlink to it, which
+# would otherwise dangle). Stripping breaks the framework's signature seal,
+# which is fine: the signing step below re-signs the framework either way.
+rm -rf "$APP/Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices" \
+       "$APP/Contents/Frameworks/Sparkle.framework/XPCServices"
 
 echo "==> Building app icon from asset catalog…"
 ICONSET="$BUILD/AppIcon.iconset"; mkdir -p "$ICONSET"
@@ -92,6 +106,11 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 	<key>LSUIElement</key><true/>
 	<key>NSHumanReadableCopyright</key><string>Crisp - Free &amp; Open Source</string>
 	<key>NSAppleEventsUsageDescription</key><string>Crisp uses System Events to switch Dark Mode with the system's animated transition.</string>
+	<key>SUFeedURL</key><string>https://didriksg.github.io/Crisp/appcast.xml</string>
+	<key>SUPublicEDKey</key><string>3UT7wZoXDzrAhwCMVS3DoPt2lcya9H/cvlyXliuPuhM=</string>
+	<key>SUEnableAutomaticChecks</key><true/>
+	<key>SUVerifyUpdateBeforeExtraction</key><true/>
+	<key>SURequireSignedFeed</key><true/>
 	<key>CFBundleSupportedPlatforms</key><array><string>MacOSX</string></array>
 </dict>
 </plist>
@@ -101,14 +120,25 @@ PLIST
 # else ad-hoc so dry runs and contributor/CI builds still work without a cert. A
 # notarizable build needs the hardened runtime (--options runtime) and a secure
 # timestamp; ad-hoc gets neither and can't be notarized anyway. (b00d.0)
+# Sparkle's nested executables get signed individually, inside-out, then the app
+# WITHOUT --deep: --deep would stamp the app's entitlements onto nested code and
+# Sparkle's docs explicitly warn against it.
 xattr -cr "$APP"
+SPARKLE_FW="$APP/Contents/Frameworks/Sparkle.framework"
+SPARKLE_NESTED=("$SPARKLE_FW/Versions/B/Autoupdate" "$SPARKLE_FW/Versions/B/Updater.app" "$SPARKLE_FW")
 if [ -n "${CRISP_SIGN_ID:-}" ]; then
   echo "==> Signing (Developer ID: $CRISP_SIGN_ID, hardened runtime)…"
-  codesign --force --deep --options runtime --timestamp \
+  for item in "${SPARKLE_NESTED[@]}"; do
+    codesign --force --options runtime --timestamp --sign "$CRISP_SIGN_ID" "$item"
+  done
+  codesign --force --options runtime --timestamp \
     --entitlements Crisp/Crisp.entitlements --sign "$CRISP_SIGN_ID" "$APP"
 else
   echo "==> Signing (ad-hoc — set CRISP_SIGN_ID for a notarizable build)…"
-  codesign --force --deep --sign - --entitlements Crisp/Crisp.entitlements "$APP"
+  for item in "${SPARKLE_NESTED[@]}"; do
+    codesign --force --sign - "$item"
+  done
+  codesign --force --sign - --entitlements Crisp/Crisp.entitlements "$APP"
 fi
 codesign --verify --deep --strict "$APP"
 
@@ -152,6 +182,20 @@ sed -i '' "s/MARKETING_VERSION: \"[^\"]*\"/MARKETING_VERSION: \"${VERSION}\"/" p
 echo "==> Creating GitHub release ${TAG}…"
 gh release create "$TAG" --title "Crisp ${TAG}" --notes-file "$NOTES" "$DMG"
 
+# Sparkle reads docs/appcast.xml via GitHub Pages. generate_appcast signs the
+# DMG with the EdDSA key from the login Keychain (created once with
+# ./vendor/Sparkle/bin/generate_keys) and points the enclosure at the release
+# asset uploaded above.
+# ponytail: single-entry appcast, latest release only; old installs only ever
+# need the newest version. Embed HTML release notes here if ever wanted.
+echo "==> Generating Sparkle appcast…"
+APPCAST_STAGE="$BUILD/appcast"; mkdir -p "$APPCAST_STAGE"
+cp "$DMG" "$APPCAST_STAGE/Crisp.dmg"
+"$ROOT/vendor/Sparkle/bin/generate_appcast" \
+  --download-url-prefix "https://github.com/didriksg/Crisp/releases/download/${TAG}/" \
+  --link "https://github.com/didriksg/Crisp/releases" \
+  -o "$ROOT/docs/appcast.xml" "$APPCAST_STAGE"
+
 echo "==> Bumping Homebrew tap…"
 SHA_FILE=$(gh api "repos/$TAP_REPO/contents/$TAP_CASK" --jq '.sha')
 gh api "repos/$TAP_REPO/contents/$TAP_CASK" --jq '.content' | base64 -d \
@@ -163,3 +207,5 @@ gh api -X PUT "repos/$TAP_REPO/contents/$TAP_CASK" \
   -f sha="$SHA_FILE" --jq '.commit.sha' >/dev/null
 
 echo "==> Released ${TAG} and updated the tap."
+echo "==> ACTION REQUIRED: commit and push docs/appcast.xml (+ project.yml bump)."
+echo "    In-app updates go live only once GitHub Pages serves the new appcast."


### PR DESCRIPTION
Closes #56.

The Update row in the panel now downloads, verifies, and installs releases in place (one click, relaunch included) instead of opening the GitHub release page. Checks run daily in the background; a found update surfaces through the existing panel row via Sparkle's gentle-reminders API, so the menu-bar app never steals focus.

## How

- `UpdateService` wraps `SPUStandardUpdaterController`; the hand-rolled GitHub API poller is gone. Same published surface, so the view diff is minimal.
- Sparkle 2.9.5 is vendored prebuilt via `scripts/fetch-sparkle.sh` (sha256-pinned, gitignored `vendor/`). XPC services are stripped since the app is not sandboxed.
- `release.sh` links and embeds the framework, signs inside-out (Sparkle forbids `codesign --deep`), and on `--publish` writes an EdDSA-signed single-entry appcast to `docs/appcast.xml`, served by the existing GitHub Pages.
- Homebrew stays first-class: the tap cask gets `auto_updates true` at the next release; since Homebrew 6, `brew upgrade` reconciles against the on-disk version instead of reinstalling over a self-updated app.

## Security model

Publishing a GitHub release is not enough to feed installs an update. Every shipped app pins the EdDSA public key (`SUPublicEDKey`); the appcast itself must be signed (`SURequireSignedFeed`) and signatures are checked before extraction (`SUVerifyUpdateBeforeExtraction`). The private key lives only in the maintainer's Keychain, with an offline backup. An attacker with full control of the repo, releases, Pages, or the network can at worst delay updates, never inject code.

## Verified

- `make check` green (lint, tests, localization keys); dry-run DMG builds universal and passes `codesign --verify --strict`.
- Full update cycle exercised locally against a signed localhost feed, twice: headless (silent install mode, 9.9.8 to 9.9.9) and by hand through the panel UI (gentle reminder row, focused dialog, install and relaunch).
- The live test caught and fixed a real bug: the panel is a non-activating NSPanel, so Sparkle's window opened unfocused behind other apps until the row action activates the app explicitly.

## Notes

- Release-day steps (tap stanza, appcast push) are in `docs/RELEASING.md`.
- Existing installs do one last manual download to get onto this version; everything after is in-app.
