### PR TITLE
Take F14/F15 as brightness keys (#69), managed switch for Keep Awake (#70)

### DIFF
--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -647,7 +647,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         blocks.append(toolshead)
         let toolsA = block("toolsA", isOpen: { state.showTools }) {
             VStack(alignment: .leading, spacing: 0) {
-                KeepAwakeRow()
+                if !KeepAwakeService.isDisabledByPolicy {
+                    KeepAwakeRow()
+                }
                 ExpandableRowStateful(icon: "display.2", iconActive: false,
                                       label: "Virtual Displays", state: state, key: \.showVirtualDisplays)
             }

--- a/Crisp/Services/BrightnessKeyService.swift
+++ b/Crisp/Services/BrightnessKeyService.swift
@@ -249,12 +249,15 @@ final class BrightnessKeyService: @unchecked Sendable {
         // still flows. Keycodes 144/145 are the brightness media keys. Mirrors MonitorControl's
         // dual-path capture, which is why it keeps working in clamshell where a SYSDEFINED-only tap
         // goes dead. (issue #21)
+        // Third-party keyboards in media-key mode (Logitech MX Keys via Logi Options+) send
+        // the brightness pair as F14/F15 (107/113) with no SYSDEFINED event at all; Apple's own
+        // full-size keyboard prints brightness on those two keys too. (issue #69)
         if type.rawValue == CGEventType.keyDown.rawValue {
             let kc = event.getIntegerValueField(.keyboardEventKeycode)
             switch kc {
-            case 144:
+            case 144, 113:
                 return routeBrightnessPress(up: true, event: event)
-            case 145:
+            case 145, 107:
                 return routeBrightnessPress(up: false, event: event)
             default:
                 return Unmanaged.passRetained(event)

--- a/Crisp/Services/KeepAwakeService.swift
+++ b/Crisp/Services/KeepAwakeService.swift
@@ -15,10 +15,20 @@ final class KeepAwakeService: ObservableObject {
     @Published private(set) var isActive = false
     private var assertionID: IOPMAssertionID = 0
 
+    /// True when an admin has switched Keep Awake off for this Mac: a configuration profile
+    /// for the `com.crisp.app` domain carrying `crisp.disableKeepAwake` = true. Managed
+    /// values land in UserDefaults on their own and outrank the user's own preferences, so
+    /// a `defaults write` cannot switch it back on. The Tools row is hidden rather than
+    /// greyed out; there is no room in the panel to explain who turned it off. (issue #70)
+    static var isDisabledByPolicy: Bool {
+        UserDefaults.standard.bool(forKey: "crisp.disableKeepAwake")
+    }
+
     /// Prevent display idle sleep (which also blocks system idle sleep) while `on`.
     func setActive(_ on: Bool) {
         guard on != isActive else { return }
         if on {
+            guard !Self.isDisabledByPolicy else { return }
             var id: IOPMAssertionID = 0
             let result = IOPMAssertionCreateWithName(
                 kIOPMAssertionTypePreventUserIdleDisplaySleep as CFString,

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Thank you to the people chipping in toward keeping Crisp signed and notarized:
 - **Administrator password** (one time, per monitor): needed only when you turn on smooth scaling, which installs a display override file into `/Library/Displays/Contents/Resources/Overrides` that macOS protects. Regular HiDPI scaling and everything else are password-free.
 - **Accessibility** (System Settings > Privacy & Security > Accessibility): needed only if you turn on Brightness Keys, which routes the keyboard brightness keys to other displays (follow the pointer, all connected, or a chosen subset). Without it, everything else still works; the keys just control the built-in display as usual.
 
+## Managed Macs
+
+To keep Keep Awake off on company Macs, push a configuration profile for the `com.crisp.app` domain with `crisp.disableKeepAwake` set to `true`. Crisp reads it at launch and leaves the row out of Tools. A managed value outranks the user's own preferences, so it cannot be switched back on with `defaults write`.
+
 ## Building
 
 ```sh


### PR DESCRIPTION
Two small ones from the tracker.

#69: Logitech MX Keys in media-key mode (Logi Options+) sends brightness as F14/F15, keycodes 107/113, with no SYSDEFINED event at all. The keyDown fallback in BrightnessKeyService only knew 144/145, so the keys did nothing over an external display. It now takes 107/113 too. Side effect: a real F14/F15 on a full-size keyboard now drives the display under the pointer as well, which is what Apple prints on those keys.

#70: a configuration profile for the `com.crisp.app` domain with `crisp.disableKeepAwake` set to true hides the Keep Awake row in Tools and makes KeepAwakeService refuse to take the power assertion. Managed values outrank user defaults, so `defaults write` cannot switch it back on. README gets a short Managed Macs section.

Tested on the dev build. #69: synthetic keycodes 113/107 through Crisp's tap, built-in display in allDisplays mode, 1/16 steps both ways, and the F15 bezel on the HP 27fw with the pointer there. #70: key set with `defaults write`, row gone, assertion refused. `make check` green.
