### PR TITLE
crispctl help: the full reference for people and agents

### DIFF
--- a/Crisp/Models/CrispControlModel.swift
+++ b/Crisp/Models/CrispControlModel.swift
@@ -112,14 +112,59 @@ enum CrispControlModel {
 }
 enum CrispControlCLIModel {
     static let usage = "usage: crispctl displays list | crispctl brightness get <display-id> | "
-        + "crispctl brightness set <display-id> <percent>"
+        + "crispctl brightness set <display-id> <percent> | crispctl help"
+
+    /// The full reference, for a person at a terminal and for an agent that reads it
+    /// before acting. Kept in the shared model so the app and the CLI cannot drift.
+    static let help = """
+        crispctl: control a running Crisp from the command line.
+
+        Crisp must be running on this Mac under the same user. crispctl talks to it
+        over a local Unix socket (mode 0600 in the per-user temp dir) and never
+        launches the app. Source builds only for now; the DMG and the Homebrew cask
+        do not ship crispctl.
+
+        Commands
+          crispctl displays list
+              Every online display: id, name, brightness (0-100), isBuiltin.
+          crispctl brightness get <display-id>
+              Current brightness of one display.
+          crispctl brightness set <display-id> <percent>
+              Set brightness, 0-100. Same path as the panel slider: hardware (DDC)
+              or software dimming as Crisp decided for that display, and it clears
+              the active preset. The reply means Crisp accepted the request, not
+              that the panel was read back; run brightness get to confirm.
+          crispctl help
+              This text. Also --help and -h.
+
+        Display ids
+          Runtime ids from displays list. They can change after an unplug or a
+          wake, so list first, then act.
+
+        Output
+          One JSON object per call. Success: {"ok":true,...}. Failure:
+          {"ok":false,"error":"..."}. Later versions may add fields; ignore
+          what you do not know. Crisp's own refusals come back on stdout,
+          crispctl's own errors (no socket, bad arguments) go to stderr.
+
+        Exit codes
+          0  ok
+          1  could not reach Crisp: not running, socket missing, another user,
+             or an unreadable reply
+          2  bad arguments
+          3  Crisp refused the request: unknown display, value out of range
+        """
 
     enum ParseResult: Equatable {
         case request(CrispControlRequest)
+        case help
         case failure
     }
     enum ResponseResult: Equatable { case success, serverFailure, invalid }
     static func parse(arguments: [String]) -> ParseResult {
+        if arguments.isEmpty || arguments == ["help"] || arguments == ["--help"] || arguments == ["-h"] {
+            return .help
+        }
         if arguments == ["displays", "list"] {
             return .request(.init(command: .list))
         }

--- a/CrispTests/CrispControlModelTests.swift
+++ b/CrispTests/CrispControlModelTests.swift
@@ -22,9 +22,21 @@ final class CrispControlModelTests: XCTestCase {
         }
     }
 
+    func testParserReturnsHelpForNoArgumentsAndHelpFlags() {
+        for arguments in [[], ["help"], ["--help"], ["-h"]] {
+            XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .help, "\(arguments)")
+        }
+        // The reference must name every command it documents, and the usage line must
+        // point at it, so a wrong invocation still leads to the full text.
+        for command in ["displays list", "brightness get", "brightness set", "crispctl help"] {
+            XCTAssertTrue(CrispControlCLIModel.help.contains(command), command)
+        }
+        XCTAssertTrue(CrispControlCLIModel.usage.contains("crispctl help"))
+    }
+
     func testParserRejectsInvalidArityIDsOptionsAndPercent() {
         let cases = [
-            [], ["displays"], ["displays", "list", "--json"],
+            ["help", "me"], ["displays"], ["displays", "list", "--json"],
             ["brightness", "get"], ["brightness", "get", "x"],
             ["brightness", "get", "4294967296"], ["brightness", "set", "42"],
             ["brightness", "set", "42", "nan"], ["brightness", "set", "42", "inf"],

--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ It supports exactly three commands:
 crispctl displays list
 crispctl brightness get <display-id>
 crispctl brightness set <display-id> <percent>
+crispctl help
 ```
+
+`crispctl help` is the full reference (output format, display ids, exit codes); point an agent at it before it does anything else.
 
 Crisp must already be running. Display selectors are numeric runtime IDs from `displays list`, and output is JSON by default. `brightness set` is a manual change like using the slider and clears the active preset. A successful request means the change was accepted and queued, not independently verified; it is not retried automatically.
 

--- a/Sources/crispctl/main.swift
+++ b/Sources/crispctl/main.swift
@@ -95,6 +95,9 @@ private func fail(_ message: String, code: Int32) -> Never {
 let request: CrispControlRequest
 switch CrispControlCLIModel.parse(arguments: Array(CommandLine.arguments.dropFirst())) {
 case let .request(value): request = value
+case .help:
+    print(CrispControlCLIModel.help)
+    Darwin.exit(EXIT_SUCCESS)
 case .failure: fail(CrispControlCLIModel.usage, code: 2)
 }
 do {


### PR DESCRIPTION
Follow-up to #75. `crispctl help`, `--help`, `-h`, and no arguments print a plain-text reference: what the tool is and needs, the three commands with what a set really means, the runtime display-id caveat, the JSON output contract, and the exit codes. The text sits in the shared CLI model next to the parser so it cannot drift from what the tool accepts; the usage line on bad arguments now points at it. README gets one line. Tested: lint, tests (new parser test), and the built tool against the running app.