### PR TITLE
crispctl: add display metadata

### DIFF
--- a/Crisp/Models/CrispControlModel.swift
+++ b/Crisp/Models/CrispControlModel.swift
@@ -4,11 +4,46 @@ enum CrispControlSocket {
     static let path = FileManager.default.temporaryDirectory
         .appendingPathComponent("crispctl.sock").path
 }
+struct CrispControlResolution: Codable, Equatable {
+    let logicalWidth: Int
+    let logicalHeight: Int
+    let pixelWidth: Int
+    let pixelHeight: Int
+    let refreshRate: Double
+    let isHiDPI: Bool
+}
+enum CrispControlBrightnessBackend: String, Codable, Equatable {
+    case builtin
+    case ddc
+    case software
+    case unknown
+}
 struct CrispControlDisplay: Codable, Equatable {
     let id: UInt32
     let name: String
     let brightness: Double
     let isBuiltin: Bool
+    let uuid: String?
+    let resolution: CrispControlResolution?
+    let brightnessBackend: CrispControlBrightnessBackend?
+
+    init(
+        id: UInt32,
+        name: String,
+        brightness: Double,
+        isBuiltin: Bool,
+        uuid: String? = nil,
+        resolution: CrispControlResolution? = nil,
+        brightnessBackend: CrispControlBrightnessBackend? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.brightness = brightness
+        self.isBuiltin = isBuiltin
+        self.uuid = uuid
+        self.resolution = resolution
+        self.brightnessBackend = brightnessBackend
+    }
 }
 struct CrispControlRequest: Codable, Equatable {
     enum Command: String, Codable {
@@ -69,6 +104,20 @@ struct CrispControlBrightnessChange: Equatable {
     let brightness: Double
 }
 enum CrispControlModel {
+    static func brightnessBackend(
+        isBuiltin: Bool,
+        hdrSoftwareDimming: Bool,
+        ddcAvailable: Bool?
+    ) -> CrispControlBrightnessBackend {
+        if isBuiltin { return .builtin }
+        if hdrSoftwareDimming { return .software }
+        switch ddcAvailable {
+        case true: return .ddc
+        case false: return .software
+        case nil: return .unknown
+        }
+    }
+
     static func encode<T: Encodable>(_ value: T, sorted: Bool = false) throws -> Data {
         let encoder = JSONEncoder()
         if sorted { encoder.outputFormatting = .sortedKeys }
@@ -126,7 +175,8 @@ enum CrispControlCLIModel {
 
         Commands
           crispctl displays list
-              Every online display: id, name, brightness (0-100), isBuiltin.
+              Every online display: id, name, brightness (0-100), isBuiltin,
+              plus uuid, current resolution, and brightnessBackend metadata.
           crispctl brightness get <display-id>
               Current brightness of one display.
           crispctl brightness set <display-id> <percent>
@@ -138,14 +188,18 @@ enum CrispControlCLIModel {
               This text. Also --help and -h.
 
         Display ids
-          Runtime ids from displays list. They can change after an unplug or a
-          wake, so list first, then act.
+          UUID is stable across reconnects and identifies the display. Commands
+          still require the numeric runtime id, which can change after an unplug
+          or a wake, so run a fresh displays list before acting.
 
         Output
           One JSON object per call. Success: {"ok":true,...}. Failure:
           {"ok":false,"error":"..."}. Later versions may add fields; ignore
           what you do not know. Crisp's own refusals come back on stdout,
           crispctl's own errors (no socket, bad arguments) go to stderr.
+          brightnessBackend is Crisp's current route: builtin, ddc, software,
+          or unknown while external DDC availability is undetermined. An HDR
+          software-dimming override reports software.
 
         Exit codes
           0  ok

--- a/Crisp/Services/BrightnessService.swift
+++ b/Crisp/Services/BrightnessService.swift
@@ -732,6 +732,20 @@ final class BrightnessService: @unchecked Sendable {
         ddcAvailableLock.withLock { ddcAvailable[displayID] }
     }
 
+    /// Returns a read-only snapshot of Crisp's current brightness route.
+    @MainActor
+    func brightnessBackend(for display: DisplayInfo) -> CrispControlBrightnessBackend {
+        let displayID = display.displayID
+        let state = ddcAvailableLock.withLock {
+            (hdrDimmedDisplays.contains(displayID), ddcAvailable[displayID])
+        }
+        return CrispControlModel.brightnessBackend(
+            isBuiltin: display.isBuiltin,
+            hdrSoftwareDimming: state.0,
+            ddcAvailable: state.1
+        )
+    }
+
     /// Clears all per-display state for a disconnected display.
     /// Call this when a display is removed so stale state cannot pollute a reconnect.
     @MainActor

--- a/Crisp/Services/CrispControlServer.swift
+++ b/Crisp/Services/CrispControlServer.swift
@@ -80,10 +80,25 @@ final class CrispControlServer {
     }
 
     private func response(to request: Data) async -> Data {
-        let displays = displayManager.displays.map {
-            CrispControlDisplay(
-                id: $0.displayID, name: $0.name,
-                brightness: min($0.brightness, 100), isBuiltin: $0.isBuiltin
+        let displays = displayManager.displays.map { display in
+            let resolution = display.currentDisplayMode.map { mode in
+                CrispControlResolution(
+                    logicalWidth: mode.width,
+                    logicalHeight: mode.height,
+                    pixelWidth: mode.pixelWidth,
+                    pixelHeight: mode.pixelHeight,
+                    refreshRate: mode.refreshRate,
+                    isHiDPI: mode.isHiDPI
+                )
+            }
+            return CrispControlDisplay(
+                id: display.displayID,
+                name: display.name,
+                brightness: min(display.brightness, 100),
+                isBuiltin: display.isBuiltin,
+                uuid: display.displayUUID,
+                resolution: resolution,
+                brightnessBackend: BrightnessService.shared.brightnessBackend(for: display)
             )
         }
         let result = CrispControlModel.handle(request, displays: displays)

--- a/CrispTests/CrispControlModelTests.swift
+++ b/CrispTests/CrispControlModelTests.swift
@@ -5,7 +5,17 @@ final class CrispControlModelTests: XCTestCase {
         id: 7,
         name: "Studio Display",
         brightness: 64,
-        isBuiltin: false
+        isBuiltin: false,
+        uuid: "37D8832A-2D66-02CA-B9F7-8F30A301B230",
+        resolution: CrispControlResolution(
+            logicalWidth: 2560,
+            logicalHeight: 1440,
+            pixelWidth: 5120,
+            pixelHeight: 2880,
+            refreshRate: 60,
+            isHiDPI: true
+        ),
+        brightnessBackend: .ddc
     )
 
     func testParserSupportsExactlyThreeCommands() {
@@ -78,12 +88,85 @@ final class CrispControlModelTests: XCTestCase {
         XCTAssertEqual(list.response, .success(displays: [display]))
         XCTAssertNil(list.brightnessChange)
 
+        let listJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: CrispControlModel.encode(list.response))
+                as? [String: Any]
+        )
+        let listedDisplay = try XCTUnwrap((listJSON["displays"] as? [[String: Any]])?.first)
+        XCTAssertEqual(listedDisplay["uuid"] as? String, display.uuid)
+        XCTAssertEqual(listedDisplay["brightnessBackend"] as? String, "ddc")
+        XCTAssertEqual((listedDisplay["resolution"] as? [String: Any])?["logicalWidth"] as? Int, 2560)
+
         let get = CrispControlModel.handle(
             Data(#"{"command":"getBrightness","display":7}"#.utf8),
             displays: [display]
         )
         XCTAssertEqual(get.response, .success(display: display))
         XCTAssertNil(get.brightnessChange)
+
+        let getJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: CrispControlModel.encode(get.response))
+                as? [String: Any]
+        )
+        let returnedDisplay = try XCTUnwrap(getJSON["display"] as? [String: Any])
+        XCTAssertEqual(returnedDisplay["uuid"] as? String, display.uuid)
+        XCTAssertEqual(returnedDisplay["brightnessBackend"] as? String, "ddc")
+        XCTAssertEqual((returnedDisplay["resolution"] as? [String: Any])?["pixelWidth"] as? Int, 5120)
+    }
+
+    func testDisplayMetadataAllowsMissingCurrentResolutionAndLegacyResponses() throws {
+        let displayWithoutMode = CrispControlDisplay(
+            id: 8,
+            name: "Projector",
+            brightness: 50,
+            isBuiltin: false,
+            uuid: "stable-projector",
+            resolution: nil,
+            brightnessBackend: .unknown
+        )
+        let encoded = CrispControlModel.encode(.success(displays: [displayWithoutMode]))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        let encodedDisplay = try XCTUnwrap((json["displays"] as? [[String: Any]])?.first)
+        XCTAssertNil(encodedDisplay["resolution"])
+
+        let legacy = #"{"ok":true,"display":{"id":7,"name":"Studio Display","brightness":64,"isBuiltin":false}}"#
+        let decoded = try JSONDecoder().decode(CrispControlResponse.self, from: Data(legacy.utf8))
+        XCTAssertNil(decoded.display?.uuid)
+        XCTAssertNil(decoded.display?.resolution)
+        XCTAssertNil(decoded.display?.brightnessBackend)
+    }
+
+    func testBrightnessBackendClassifierCoversCurrentRouting() {
+        XCTAssertEqual(
+            CrispControlModel.brightnessBackend(
+                isBuiltin: true, hdrSoftwareDimming: false, ddcAvailable: nil
+            ),
+            .builtin
+        )
+        XCTAssertEqual(
+            CrispControlModel.brightnessBackend(
+                isBuiltin: false, hdrSoftwareDimming: false, ddcAvailable: true
+            ),
+            .ddc
+        )
+        XCTAssertEqual(
+            CrispControlModel.brightnessBackend(
+                isBuiltin: false, hdrSoftwareDimming: false, ddcAvailable: false
+            ),
+            .software
+        )
+        XCTAssertEqual(
+            CrispControlModel.brightnessBackend(
+                isBuiltin: false, hdrSoftwareDimming: true, ddcAvailable: true
+            ),
+            .software
+        )
+        XCTAssertEqual(
+            CrispControlModel.brightnessBackend(
+                isBuiltin: false, hdrSoftwareDimming: false, ddcAvailable: nil
+            ),
+            .unknown
+        )
     }
 
     func testSetEncodesOnlyOKAndCreatesRequestedBrightnessChange() {

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ crispctl brightness set <display-id> <percent>
 crispctl help
 ```
 
-`crispctl help` is the full reference (output format, display ids, exit codes); point an agent at it before it does anything else.
+`crispctl help` is the full reference (output format, display ids, exit codes); point an agent at it before it does anything else. `displays list` includes additive UUID, current-resolution, and brightness-backend metadata. The backend is Crisp's current route (`builtin`, `ddc`, `software`, or `unknown` while external DDC availability is undetermined); HDR software dimming reports `software`.
 
-Crisp must already be running. Display selectors are numeric runtime IDs from `displays list`, and output is JSON by default. `brightness set` is a manual change like using the slider and clears the active preset. A successful request means the change was accepted and queued, not independently verified; it is not retried automatically.
+Crisp must already be running. A display UUID is stable across reconnects for identification, but commands still require the numeric runtime display ID from a fresh `displays list`; output is JSON by default. `brightness set` is a manual change like using the slider and clears the active preset. A successful request means the change was accepted and queued, not independently verified; it is not retried automatically.
 
 The current public Crisp 1.5.0 release, normal DMG, and Homebrew cask do not include `crispctl`.
 


### PR DESCRIPTION
## Scope

Extends the existing `CrispControlDisplay` response with additive metadata only:

- stable display `uuid`;
- current logical/pixel resolution, refresh rate, and HiDPI state when known;
- `brightnessBackend`: `builtin`, `ddc`, `software`, or `unknown`.

`displays list` is the intended consumer; `brightness get` receives the same fields naturally because it already returns the shared display DTO. No commands, arguments, socket behavior, exit codes, set semantics, or response-classification rules change.

The backend snapshot is read-only: it uses existing state under the existing lock, does no DDC I/O/probe/retry/write, and reports HDR software dimming as `software` before any prior DDC-success state.

This is independent of the unmerged #71 DDC-latency work and does not copy or depend on it.

## Verification

- `git diff --check`
- `xcodegen generate`
- `xcodebuild ... -scheme Crisp ... SWIFT_TREAT_WARNINGS_AS_ERRORS=NO test` — 81 tests, 0 failures, 0 skipped
- `xcodebuild ... -scheme crispctl -configuration Release ... CODE_SIGNING_ALLOWED=NO SWIFT_TREAT_WARNINGS_AS_ERRORS=YES build`
- `swiftlint lint --strict --quiet`

The strict warnings-as-errors Crisp wrapper is blocked on this machine by the existing Xcode 27 Beta `DisplayManager.swift:113` `#ImplicitStrongCapture` diagnostic; the identical failure was reproduced from unmodified current `origin/main`.

## Hardware validation

**Not performed.** No Crisp App launch, `crispctl` connection to a running app, or real display/hardware read or write was performed for this PR.
