### PR TITLE
Normalize combined brightness using estimated luminance

### DIFF
--- a/Crisp/Models/DisplayInfo.swift
+++ b/Crisp/Models/DisplayInfo.swift
@@ -31,6 +31,9 @@ class DisplayInfo: ObservableObject, Identifiable {
     let vendorNumber: UInt32
     let modelNumber: UInt32
     let serialNumber: UInt32
+    /// Nominal SDR luminance ceiling in nits. Used only to normalize the
+    /// combined brightness control across unlike display classes.
+    let nominalMaxNits: Double?
 
     /// A stable identifier for the physical display that persists across sleep/wake
     /// even if macOS reassigns the CGDirectDisplayID.
@@ -84,9 +87,17 @@ class DisplayInfo: ObservableObject, Identifiable {
         self.currentDisplayMode = DisplayMode.currentMode(for: displayID)
         let vendor = CGDisplayVendorNumber(displayID)
         let model = CGDisplayModelNumber(displayID)
+        let serial = CGDisplaySerialNumber(displayID)
         self.vendorNumber = vendor
         self.modelNumber = model
-        self.serialNumber = CGDisplaySerialNumber(displayID)
+        self.serialNumber = serial
+        self.nominalMaxNits = DisplayLuminanceService.maximumSDRNits(
+            displayID: displayID,
+            isBuiltin: builtin,
+            vendor: vendor,
+            model: model,
+            serial: serial
+        )
 
         if builtin {
             self.name = String(localized: "Built-in Display")

--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -353,6 +353,16 @@
         }
       }
     },
+    "Absolute brightness ratio" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "绝对亮度比率"
+          }
+        }
+      }
+    },
     "Cancel" : {
       "localizations" : {
         "zh-Hans" : {
@@ -1983,6 +1993,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新为当前值"
+          }
+        }
+      }
+    },
+    "Calculated from each panel's nits; adjust only if they still look different" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "根据各屏幕的 nit 值计算；若观感仍有差异再微调"
           }
         }
       }

--- a/Crisp/Services/AutoBrightnessService.swift
+++ b/Crisp/Services/AutoBrightnessService.swift
@@ -11,7 +11,6 @@ private let _DisplayServices_GetBrightness: (@convention(c) (CGDirectDisplayID, 
     guard let sym = dlsym(handle, "DisplayServicesGetBrightness") else { return nil }
     return unsafeBitCast(sym, to: (@convention(c) (CGDirectDisplayID, UnsafeMutablePointer<Float>) -> Int32).self)
 }()
-
 // CoreDisplay private API, reads the user-set brightness of a display (0.0–1.0).
 // Loaded via dlsym at runtime to avoid linking against the private CoreDisplay framework.
 private let _CoreDisplay_GetBrightness: (@convention(c) (CGDirectDisplayID) -> Double)? = {
@@ -253,6 +252,10 @@ final class AutoBrightnessService: ObservableObject, @unchecked Sendable {
         needsRebaseline = false
 
         let snapshot = DisplayManagerAccessor.shared.displays
+        let builtinDisplay = snapshot.first(where: { $0.isBuiltin })
+        let builtinLinear = builtinDisplay.flatMap {
+            BrightnessService.shared.linearBrightness(for: $0.displayID)
+        }
         for display in snapshot {
             // Only sync to external (non-builtin) displays.
             guard !display.isBuiltin else { continue }
@@ -270,8 +273,20 @@ final class AutoBrightnessService: ObservableObject, @unchecked Sendable {
                 // in the boost region, and capping at 100 would silently drag a
                 // boosted display back down on every built-in change.
                 target = min(display.maxBrightness, max(0.0, builtinPct + offset))
+            } else if let builtinLinear,
+                      let builtinMaxNits = builtinDisplay?.nominalMaxNits,
+                      let externalMaxNits = display.nominalMaxNits {
+                // Absolute means absolute luminance, not equal slider percentages.
+                // The built-in curve is highly nonlinear, so derive DDC percent
+                // from estimated nits using the same calibration as Combined.
+                let matched = CombinedBrightnessMath.externalBrightnessMatchingBuiltin(
+                    builtinLinear: builtinLinear,
+                    builtinMaxNits: builtinMaxNits,
+                    externalMaxNits: externalMaxNits,
+                    builtinAdjustment: SettingsService.shared.combinedBuiltinBrightnessFactor)
+                target = min(100.0, max(0.0, matched * sensitivity))
             } else {
-                // Absolute mirror (old behavior): external tracks the built-in's level.
+                // Missing luminance metadata: preserve the old percentage mirror.
                 target = min(100.0, max(0.0, builtin * sensitivity * 100.0))
             }
 

--- a/Crisp/Services/BrightnessService.swift
+++ b/Crisp/Services/BrightnessService.swift
@@ -21,6 +21,16 @@ private let _DSGetBrightness: (@convention(c) (CGDirectDisplayID, UnsafeMutableP
           let sym = dlsym(h, "DisplayServicesGetBrightness") else { return nil }
     return unsafeBitCast(sym, to: (@convention(c) (CGDirectDisplayID, UnsafeMutablePointer<Float>) -> Int32).self)
 }()
+private let _DSSetLinearBrightness: (@convention(c) (CGDirectDisplayID, Float) -> Int32)? = {
+    guard let h = dlopen("/System/Library/PrivateFrameworks/DisplayServices.framework/DisplayServices", RTLD_LAZY),
+          let sym = dlsym(h, "DisplayServicesSetLinearBrightness") else { return nil }
+    return unsafeBitCast(sym, to: (@convention(c) (CGDirectDisplayID, Float) -> Int32).self)
+}()
+private let _DSGetLinearBrightness: (@convention(c) (CGDirectDisplayID, UnsafeMutablePointer<Float>) -> Int32)? = {
+    guard let h = dlopen("/System/Library/PrivateFrameworks/DisplayServices.framework/DisplayServices", RTLD_LAZY),
+          let sym = dlsym(h, "DisplayServicesGetLinearBrightness") else { return nil }
+    return unsafeBitCast(sym, to: (@convention(c) (CGDirectDisplayID, UnsafeMutablePointer<Float>) -> Int32).self)
+}()
 
 // DisplayServices brightness-change notifications: push updates so the UI tracks the
 // built-in panel live (native keys, auto-brightness, Night Shift/TrueTone) instead of
@@ -263,6 +273,15 @@ final class BrightnessService: @unchecked Sendable {
 
     // MARK: - Public API
 
+    /// Native panel brightness in a linear luminance domain. Multiplying this
+    /// by DisplayInfo.nominalMaxNits yields the current estimated nits.
+    func linearBrightness(for displayID: CGDirectDisplayID) -> Double? {
+        guard let get = _DSGetLinearBrightness else { return nil }
+        var value: Float = 0
+        guard get(displayID, &value) == 0 else { return nil }
+        return min(1.0, max(0.0, Double(value)))
+    }
+
     /// `animated: true` glides the built-in slider to the freshly-read value
     /// instead of snapping, used by the ~1s poll so an ambient-sensor auto-adjust
     /// reads as smooth motion. Instant (default) on load/wake where the slider
@@ -432,6 +451,67 @@ final class BrightnessService: @unchecked Sendable {
         }
     }
 
+    /// Sets a built-in panel in linear luminance space, then reads back the
+    /// corresponding native user-slider value so every UI stays truthful.
+    @MainActor
+    func setBuiltinLinearBrightness(_ linearBrightness: Double, for display: DisplayInfo) async {
+        guard display.isBuiltin, let set = _DSSetLinearBrightness else {
+            await setBrightness(linearBrightness * 100.0, for: display)
+            return
+        }
+        let displayID = display.displayID
+        let target = min(1.0, max(0.0, linearBrightness))
+        cancelAnimation(for: displayID)
+        manualAdjustLock.withLock { lastManualAdjustDate = Date() }
+        PresetService.shared.noteManualChange()
+        noteManualBrightnessChange(displayID: displayID, isBuiltin: true, value: display.brightness)
+
+        let userBrightness: Double? = await withCheckedContinuation { continuation in
+            queue.async {
+                guard set(displayID, Float(target)) == 0, let get = _DSGetBrightness else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                var user: Float = 0
+                continuation.resume(returning: get(displayID, &user) == 0 ? Double(user) * 100.0 : nil)
+            }
+        }
+        if let userBrightness { display.brightness = userBrightness }
+        BrightnessBoostService.shared.syncOverlay(for: display)
+    }
+
+    /// Smooth counterpart used by clicks, step buttons, and calibration changes.
+    /// The animation itself is linear in nits; macOS converts every tick back to
+    /// its nonlinear native slider curve.
+    @MainActor
+    func setBuiltinLinearBrightnessSmooth(
+        _ linearBrightness: Double,
+        for display: DisplayInfo,
+        duration: TimeInterval = 0.20
+    ) {
+        guard display.isBuiltin, let set = _DSSetLinearBrightness else {
+            setBrightnessSmooth(linearBrightness * 100.0, for: display, duration: duration)
+            return
+        }
+        let displayID = display.displayID
+        let target = min(1.0, max(0.0, linearBrightness))
+        let from = self.linearBrightness(for: displayID) ?? target
+        manualAdjustLock.withLock { lastManualAdjustDate = Date() }
+        PresetService.shared.noteManualChange()
+        noteManualBrightnessChange(displayID: displayID, isBuiltin: true, value: display.brightness)
+
+        animator(for: displayID).animate(
+            from: from,
+            to: target,
+            steps: max(8, Int(duration / 0.016)),
+            duration: duration
+        ) { [weak display] value, _ in
+            guard let display, set(displayID, Float(value)) == 0, let get = _DSGetBrightness else { return }
+            var user: Float = 0
+            if get(displayID, &user) == 0 { display.brightness = Double(user) * 100.0 }
+        }
+    }
+
     // MARK: - Coalescing DDC Writer
 
     /// Latest pending brightness percent per display. Only one DDC write is in flight
@@ -454,7 +534,7 @@ final class BrightnessService: @unchecked Sendable {
     /// DDC 0 on most monitors means "minimum backlight", which is still visibly bright.
     /// Below this percent we layer gamma dimming on top of the hardware write so the
     /// bottom of the slider actually reaches dark (gamma keeps its own 5% floor).
-    private let gammaBlendThreshold = 15.0
+    private let gammaBlendThreshold = CombinedBrightnessMath.externalGammaBlendThreshold
 
     /// Externals currently in HDR mode. A DisplayHDR monitor manages its own
     /// luminance and silently discards DDC brightness writes (they still ack,

--- a/Crisp/Services/DisplayLuminanceService.swift
+++ b/Crisp/Services/DisplayLuminanceService.swift
@@ -1,0 +1,91 @@
+import Foundation
+import CoreGraphics
+import IOKit
+
+private let _CoreDisplayCreateInfoDictionary: (@convention(c) (CGDirectDisplayID) -> Unmanaged<CFDictionary>?)? = {
+    guard let handle = dlopen("/System/Library/Frameworks/CoreDisplay.framework/CoreDisplay", RTLD_LAZY),
+          let symbol = dlsym(handle, "CoreDisplay_DisplayCreateInfoDictionary") else { return nil }
+    return unsafeBitCast(
+        symbol,
+        to: (@convention(c) (CGDirectDisplayID) -> Unmanaged<CFDictionary>?).self
+    )
+}()
+
+/// Reads the display's absolute-luminance ceiling used to put built-in and DDC
+/// brightness on one scale. Apple publishes SDR nits through CoreDisplay; an
+/// external monitor publishes CTA/EDID max luminance in IORegistry as 16.16.
+enum DisplayLuminanceService {
+    static func maximumSDRNits(
+        displayID: CGDirectDisplayID,
+        isBuiltin: Bool,
+        vendor: UInt32,
+        model: UInt32,
+        serial: UInt32
+    ) -> Double? {
+        if isBuiltin, let value = builtinMaximumSDRNits(displayID: displayID) {
+            return value
+        }
+        guard !isBuiltin else { return nil }
+        return externalMaximumNits(vendor: vendor, model: model, serial: serial)
+    }
+
+    private static func builtinMaximumSDRNits(displayID: CGDirectDisplayID) -> Double? {
+        guard let dictionary = _CoreDisplayCreateInfoDictionary?(displayID)?.takeRetainedValue()
+                as? [String: Any] else { return nil }
+        // Non-reference is the normal Apple XDR preset; the reference peak
+        // is the fallback for fixed-luminance reference presets.
+        for key in ["NonReferencePeakSDRLuminance", "ReferencePeakSDRLuminance"] {
+            if let value = number(dictionary[key]), value > 0 { return value }
+        }
+        return nil
+    }
+
+    private static func externalMaximumNits(vendor: UInt32, model: UInt32, serial: UInt32) -> Double? {
+        let root = IORegistryGetRootEntry(kIOMainPortDefault)
+        guard root != IO_OBJECT_NULL else { return nil }
+        defer { IOObjectRelease(root) }
+
+        var iterator: io_iterator_t = 0
+        guard IORegistryEntryCreateIterator(
+            root,
+            kIOServicePlane,
+            IOOptionBits(kIORegistryIterateRecursively),
+            &iterator
+        ) == KERN_SUCCESS else { return nil }
+        defer { IOObjectRelease(iterator) }
+
+        var entry = IOIteratorNext(iterator)
+        while entry != IO_OBJECT_NULL {
+            defer {
+                IOObjectRelease(entry)
+                entry = IOIteratorNext(iterator)
+            }
+            guard let attributes = IORegistryEntryCreateCFProperty(
+                    entry,
+                    "DisplayAttributes" as CFString,
+                    kCFAllocatorDefault,
+                    0
+                  )?.takeRetainedValue() as? [String: Any],
+                  let product = attributes["ProductAttributes"] as? [String: Any],
+                  number(product["LegacyManufacturerID"]) == Double(vendor),
+                  number(product["ProductID"]) == Double(model) else { continue }
+
+            let registrySerial = number(product["SerialNumber"]) ?? 0
+            if serial != 0, registrySerial != 0, Double(serial) != registrySerial { continue }
+            guard let luminance = attributes["Luminance"] as? [String: Any],
+                  let raw = number(luminance["Max"]), raw > 0 else { continue }
+            // CoreDisplay publishes CTA luminance as unsigned 16.16 fixed point.
+            let nits = raw > 10_000 ? raw / 65_536.0 : raw
+            if nits >= 40, nits <= 10_000 { return nits }
+        }
+        return nil
+    }
+
+    private static func number(_ value: Any?) -> Double? {
+        if let value = value as? NSNumber { return value.doubleValue }
+        if let value = value as? Double { return value }
+        if let value = value as? Int { return Double(value) }
+        if let value = value as? UInt32 { return Double(value) }
+        return nil
+    }
+}

--- a/Crisp/Services/SettingsService.swift
+++ b/Crisp/Services/SettingsService.swift
@@ -56,6 +56,7 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
         static let launchAtLoginPrompted  = "crisp.launchAtLogin.prompted"
         static let menuWidth              = "crisp.menuWidth"
         static let showCombinedBrightness = "crisp.showCombinedBrightness"
+        static let combinedBuiltinFactor  = "crisp.combinedBuiltinBrightnessAdjustment.v2"
         static let showVolumeSliders      = "crisp.showVolumeSliders"
         static let ddcCacheTTL            = "crisp.ddcCacheTTL"
         static let colorPickerHistory     = "crisp.colorPickerHistory"
@@ -84,6 +85,12 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
 
     @Published var showCombinedBrightness: Bool = true {
         didSet { defaults.set(showCombinedBrightness, forKey: Keys.showCombinedBrightness) }
+    }
+
+    /// Fine tuning on top of the absolute-luminance match. 1.0 means equal
+    /// estimated nits; lower values dim the built-in relative to externals.
+    @Published var combinedBuiltinBrightnessFactor: Double = CombinedBrightnessMath.defaultBuiltinAdjustment {
+        didSet { defaults.set(combinedBuiltinBrightnessFactor, forKey: Keys.combinedBuiltinFactor) }
     }
 
     /// Volume sliders for DDC-volume monitors. Hiding them only affects the
@@ -190,6 +197,15 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
             ? defaults.double(forKey: Keys.menuWidth) : 320
         showCombinedBrightness = defaults.object(forKey: Keys.showCombinedBrightness) != nil
             ? defaults.bool(forKey: Keys.showCombinedBrightness) : true
+        if defaults.object(forKey: Keys.combinedBuiltinFactor) != nil {
+            let storedFactor = defaults.double(forKey: Keys.combinedBuiltinFactor)
+            combinedBuiltinBrightnessFactor = storedFactor.isFinite
+                ? min(CombinedBrightnessMath.builtinAdjustmentRange.upperBound,
+                      max(CombinedBrightnessMath.builtinAdjustmentRange.lowerBound, storedFactor))
+                : CombinedBrightnessMath.defaultBuiltinAdjustment
+        } else {
+            combinedBuiltinBrightnessFactor = CombinedBrightnessMath.defaultBuiltinAdjustment
+        }
         showVolumeSliders = defaults.object(forKey: Keys.showVolumeSliders) != nil
             ? defaults.bool(forKey: Keys.showVolumeSliders) : true
         ddcCacheTTL = defaults.object(forKey: Keys.ddcCacheTTL) != nil

--- a/Crisp/Utilities/CombinedBrightnessMath.swift
+++ b/Crisp/Utilities/CombinedBrightnessMath.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Pure absolute-luminance mapping for the combined brightness control.
+/// Display slider percentages are not comparable: Apple panels use a strongly
+/// perceptual curve while DDC exposes the monitor's luminance control directly.
+enum CombinedBrightnessMath {
+    /// Fine tuning after the nits-based match. 1.0 means equal estimated nits.
+    static let builtinAdjustmentRange: ClosedRange<Double> = 0.1...1.5
+    static let defaultBuiltinAdjustment = 1.0
+    /// Must stay aligned with BrightnessService's DDC + gamma blend boundary.
+    static let externalGammaBlendThreshold = 15.0
+
+    /// Converts the shared 0...100 control to a target luminance.
+    static func targetNits(combined: Double, referenceMaxNits: Double) -> Double {
+        guard combined.isFinite, referenceMaxNits.isFinite, referenceMaxNits > 0 else { return 0 }
+        return min(100.0, max(0.0, combined)) / 100.0 * referenceMaxNits
+    }
+
+    /// Converts target luminance to a display's native 0...maxBrightness scale.
+    static func targetBrightness(
+        combined: Double,
+        maxBrightness: Double,
+        displayMaxNits: Double?,
+        referenceMaxNits: Double?
+    ) -> Double {
+        guard maxBrightness.isFinite, maxBrightness > 0,
+              let displayMaxNits, displayMaxNits.isFinite, displayMaxNits > 0,
+              let referenceMaxNits, referenceMaxNits.isFinite, referenceMaxNits > 0,
+              maxBrightness <= 100.5 else {
+            return min(maxBrightness, max(0.0, combined / 100.0 * maxBrightness))
+        }
+        let fraction = targetNits(combined: combined, referenceMaxNits: referenceMaxNits)
+            / displayMaxNits
+        let percent = externalBrightness(forLuminanceFraction: fraction)
+        return min(maxBrightness, max(0.0, percent))
+    }
+
+    /// Converts a display's native brightness back to the shared control scale.
+    static func controlValue(
+        brightness: Double,
+        maxBrightness: Double,
+        displayMaxNits: Double?,
+        referenceMaxNits: Double?
+    ) -> Double {
+        guard brightness.isFinite, maxBrightness.isFinite, maxBrightness > 0,
+              let displayMaxNits, displayMaxNits.isFinite, displayMaxNits > 0,
+              let referenceMaxNits, referenceMaxNits.isFinite, referenceMaxNits > 0,
+              maxBrightness <= 100.5 else {
+            return min(100.0, max(0.0, brightness / maxBrightness * 100.0))
+        }
+        let fraction = externalLuminanceFraction(forBrightness: brightness)
+        let nits = fraction * displayMaxNits
+        return min(100.0, max(0.0, nits / referenceMaxNits * 100.0))
+    }
+
+    /// Linear native-panel level (0...1) for the same absolute target. This is
+    /// passed to DisplayServicesSetLinearBrightness so macOS performs its own
+    /// nonlinear user-slider conversion instead of Crisp guessing the curve.
+    static func builtinLinearTarget(
+        combined: Double,
+        referenceMaxNits: Double,
+        builtinMaxNits: Double,
+        adjustment: Double
+    ) -> Double {
+        guard builtinMaxNits.isFinite, builtinMaxNits > 0 else { return 0 }
+        let safeAdjustment = adjustment.isFinite
+            ? min(builtinAdjustmentRange.upperBound, max(builtinAdjustmentRange.lowerBound, adjustment))
+            : defaultBuiltinAdjustment
+        let nits = targetNits(combined: combined, referenceMaxNits: referenceMaxNits) * safeAdjustment
+        return min(1.0, max(0.0, nits / builtinMaxNits))
+    }
+
+    /// Absolute-mode auto brightness runs in the opposite direction: derive
+    /// the external target from the built-in panel's current linear level.
+    static func externalBrightnessMatchingBuiltin(
+        builtinLinear: Double,
+        builtinMaxNits: Double,
+        externalMaxNits: Double,
+        builtinAdjustment: Double
+    ) -> Double {
+        guard builtinLinear.isFinite, builtinMaxNits.isFinite, builtinMaxNits > 0,
+              externalMaxNits.isFinite, externalMaxNits > 0 else { return 0 }
+        let safeAdjustment = builtinAdjustment.isFinite
+            ? min(builtinAdjustmentRange.upperBound,
+                  max(builtinAdjustmentRange.lowerBound, builtinAdjustment))
+            : defaultBuiltinAdjustment
+        let externalNits = builtinLinear * builtinMaxNits / safeAdjustment
+        return externalBrightness(forLuminanceFraction: externalNits / externalMaxNits)
+    }
+
+    /// Below 15%, Crisp layers gamma dimming on top of DDC backlight dimming.
+    /// The two factors multiply, so this inverse square root is required for
+    /// the requested nits instead of treating the low range as linear.
+    private static func externalBrightness(forLuminanceFraction fraction: Double) -> Double {
+        let clamped = min(1.0, max(0.0, fraction))
+        let thresholdFraction = externalGammaBlendThreshold / 100.0
+        guard clamped < thresholdFraction else { return clamped * 100.0 }
+        return sqrt(clamped * 100.0 * externalGammaBlendThreshold)
+    }
+
+    private static func externalLuminanceFraction(forBrightness brightness: Double) -> Double {
+        let percent = min(100.0, max(0.0, brightness))
+        guard percent < externalGammaBlendThreshold else { return percent / 100.0 }
+        return percent / 100.0 * percent / externalGammaBlendThreshold
+    }
+}

--- a/Crisp/Views/BrightnessSliderView.swift
+++ b/Crisp/Views/BrightnessSliderView.swift
@@ -260,18 +260,76 @@ struct BrightnessSliderView: View {
 
 struct CombinedBrightnessView: View {
     let displays: [DisplayInfo]
+    @ObservedObject private var settings = SettingsService.shared
     @State private var combinedBrightness: Double = 50
     @State private var isDragging: Bool = false
     @State private var dragConfirmed: Bool = false
     @State private var deferredFirstChange: Bool = false
     @State private var clickGliding: Bool = false
 
+    /// Externals define the shared scale; unlike the built-in panel, their
+    /// current DDC percentage is already the combined control's reference.
+    private var referenceDisplays: [DisplayInfo] {
+        let externals = displays.filter { !$0.isBuiltin }
+        return externals.isEmpty ? displays : externals
+    }
+
+    private var referenceMaxNits: Double? {
+        let values = referenceDisplays.compactMap(\.nominalMaxNits)
+        guard !values.isEmpty else { return nil }
+        return values.reduce(0, +) / Double(values.count)
+    }
+
     private var averageBrightness: Double {
-        guard !displays.isEmpty else { return 50 }
-        // Proportional: each display contributes its position within its own
-        // range, so a boosted display at 160/160 and a plain one at 100/100
-        // both read as 100%.
-        return displays.map { $0.brightness / $0.maxBrightness * 100.0 }.reduce(0, +) / Double(displays.count)
+        guard !referenceDisplays.isEmpty else { return 50 }
+        return referenceDisplays.map {
+            CombinedBrightnessMath.controlValue(
+                brightness: $0.brightness,
+                maxBrightness: $0.maxBrightness,
+                displayMaxNits: $0.nominalMaxNits,
+                referenceMaxNits: referenceMaxNits)
+        }.reduce(0, +) / Double(referenceDisplays.count)
+    }
+
+    private func targetBrightness(_ combined: Double, for display: DisplayInfo) -> Double {
+        guard !display.isBuiltin else {
+            return combined / 100.0 * display.maxBrightness
+        }
+        return CombinedBrightnessMath.targetBrightness(
+            combined: combined,
+            maxBrightness: display.maxBrightness,
+            displayMaxNits: display.nominalMaxNits,
+            referenceMaxNits: referenceMaxNits)
+    }
+
+    private func builtinLinearTarget(_ combined: Double, for display: DisplayInfo) -> Double? {
+        guard display.isBuiltin, display.maxBrightness <= 100.5,
+              let referenceMaxNits,
+              let builtinMaxNits = display.nominalMaxNits else { return nil }
+        return CombinedBrightnessMath.builtinLinearTarget(
+            combined: combined,
+            referenceMaxNits: referenceMaxNits,
+            builtinMaxNits: builtinMaxNits,
+            adjustment: settings.combinedBuiltinBrightnessFactor)
+    }
+
+    private func setSmooth(_ combined: Double, for display: DisplayInfo) {
+        if let linear = builtinLinearTarget(combined, for: display) {
+            BrightnessService.shared.setBuiltinLinearBrightnessSmooth(linear, for: display)
+        } else {
+            BrightnessService.shared.setBrightnessSmooth(
+                targetBrightness(combined, for: display), for: display)
+        }
+    }
+
+    private func setImmediate(_ combined: Double, for display: DisplayInfo) async {
+        if let linear = builtinLinearTarget(combined, for: display) {
+            await BrightnessService.shared.setBuiltinLinearBrightness(linear, for: display)
+        } else {
+            let target = targetBrightness(combined, for: display)
+            display.brightness = target
+            await BrightnessService.shared.setBrightness(target, for: display)
+        }
     }
 
     var body: some View {
@@ -302,8 +360,7 @@ struct CombinedBrightnessView: View {
                             // probe sync would snap it back down through the fade.
                             clickGliding = true
                             for display in displays {
-                                BrightnessService.shared.setBrightnessSmooth(
-                                    combinedBrightness / 100.0 * display.maxBrightness, for: display)
+                                setSmooth(combinedBrightness, for: display)
                             }
                             Task { @MainActor in
                                 try? await Task.sleep(nanoseconds: 600_000_000)  // fallback release
@@ -313,8 +370,7 @@ struct CombinedBrightnessView: View {
                             // Drag ended, flush final value to all displays.
                             Task { @MainActor in
                                 for display in displays {
-                                    await BrightnessService.shared.setBrightness(
-                                        combinedBrightness / 100.0 * display.maxBrightness, for: display)
+                                    await setImmediate(combinedBrightness, for: display)
                                 }
                             }
                         }
@@ -335,9 +391,7 @@ struct CombinedBrightnessView: View {
                     }
                     Task { @MainActor in
                         for display in displays {
-                            let target = newValue / 100.0 * display.maxBrightness
-                            display.brightness = target
-                            await BrightnessService.shared.setBrightness(target, for: display)
+                            await setImmediate(newValue, for: display)
                         }
                     }
                 }
@@ -355,14 +409,23 @@ struct CombinedBrightnessView: View {
             ForEach(displays) { display in
                 BrightnessProbe(display: display) {
                     // While a click-glide runs, hold the handle at the click target and
-                    // release once the fading average reaches it (mirrors the per-display
-                    // slider's clickGliding hold).
+                    // release once the fading reference average reaches it (mirrors the
+                    // per-display slider's clickGliding hold).
                     if clickGliding {
                         if abs(averageBrightness - combinedBrightness) < 0.75 { clickGliding = false }
                         return
                     }
                     if !isDragging { combinedBrightness = averageBrightness }
                 }
+            }
+        }
+        .onChange(of: settings.combinedBuiltinBrightnessFactor) { _, _ in
+            // Changing the calibration should be visible immediately. Keep the
+            // external reference fixed and re-aim the built-in around it.
+            guard !isDragging else { return }
+            combinedBrightness = averageBrightness
+            for display in displays where display.isBuiltin {
+                setSmooth(combinedBrightness, for: display)
             }
         }
         .onAppear {
@@ -377,7 +440,7 @@ struct CombinedBrightnessView: View {
         // the displays' real brightness via BrightnessProbe, so it glides in exact
         // sync with the per-display handles instead of lagging a separate ramp.
         for display in displays {
-            BrightnessService.shared.setBrightnessSmooth(target / 100.0 * display.maxBrightness, for: display)
+            setSmooth(target, for: display)
         }
     }
 }

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -438,6 +438,28 @@ struct SettingsView: View {
         }
     }
 
+    private var physicalDisplays: [DisplayInfo] {
+        displayManager.displays.filter {
+            !VirtualDisplayService.shared.isVirtualDisplay($0.displayID)
+        }
+    }
+
+    /// Effective linear-brightness slope: external peak nits divided by the
+    /// built-in SDR peak, then multiplied by the user's fine tuning.
+    private var combinedBuiltinLuminanceRatio: Double? {
+        guard let builtinMax = physicalDisplays.first(where: { $0.isBuiltin })?.nominalMaxNits else {
+            return nil
+        }
+        let externalMaxima = physicalDisplays.filter { !$0.isBuiltin }.compactMap(\.nominalMaxNits)
+        guard !externalMaxima.isEmpty else { return nil }
+        let externalMax = externalMaxima.reduce(0, +) / Double(externalMaxima.count)
+        return externalMax / builtinMax * settings.combinedBuiltinBrightnessFactor
+    }
+
+    private var combinedBuiltinLuminanceRatioPercent: Int {
+        Int(((combinedBuiltinLuminanceRatio ?? settings.combinedBuiltinBrightnessFactor) * 100).rounded())
+    }
+
     /// Opt-in control for brightness-key redirection, shown inside the Brightness Keys section
     /// only while Accessibility is missing. The toggle is the deliberate, in-context trigger for
     /// the native trust prompt (nothing is requested at launch); it also opens the exact Settings
@@ -516,7 +538,7 @@ struct SettingsView: View {
             // slider exists (one per connected display, virtuals excluded since
             // they get no slider): with a single slider, "combined" would just
             // duplicate it. The preference persists, so it returns on reconnect.
-            if displayManager.displays.filter({ !VirtualDisplayService.shared.isVirtualDisplay($0.displayID) }).count > 1 {
+            if physicalDisplays.count > 1 {
                 Toggle(isOn: Binding(
                     get: { settings.showCombinedBrightness },
                     set: { newValue in withAnimation(.panelResize) { settings.showCombinedBrightness = newValue } }
@@ -533,6 +555,37 @@ struct SettingsView: View {
                 .controlSize(.small)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 3)
+
+                if settings.showCombinedBrightness && physicalDisplays.contains(where: { $0.isBuiltin }) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Absolute brightness ratio")
+                                    .font(.callout)
+                                Text("Calculated from each panel's nits; adjust only if they still look different")
+                                    .font(.caption2)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            Text("\(combinedBuiltinLuminanceRatioPercent)%")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .monospacedDigit()
+                        }
+                        Slider(
+                            value: $settings.combinedBuiltinBrightnessFactor,
+                            in: CombinedBrightnessMath.builtinAdjustmentRange,
+                            step: 0.02
+                        )
+                        .controlSize(.small)
+                        .accessibilityLabel("Absolute brightness ratio")
+                        .accessibilityValue("\(combinedBuiltinLuminanceRatioPercent)%")
+                    }
+                    .padding(.leading, 46)
+                    .padding(.trailing, 12)
+                    .padding(.vertical, 3)
+                    .curtainReveal(settings.showCombinedBrightness)
+                }
             }
 
             // Show volume sliders (issue #23). Hidden while no connected monitor

--- a/CrispTests/CombinedBrightnessMathTests.swift
+++ b/CrispTests/CombinedBrightnessMathTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+
+final class CombinedBrightnessMathTests: XCTestCase {
+    func testCombinedValueMapsToReferenceNits() {
+        XCTAssertEqual(
+            CombinedBrightnessMath.targetNits(combined: 50, referenceMaxNits: 400),
+            200,
+            accuracy: 0.001
+        )
+    }
+
+    func testExternalUsesItsOwnAbsoluteLuminanceRange() {
+        XCTAssertEqual(
+            CombinedBrightnessMath.targetBrightness(
+                combined: 50,
+                maxBrightness: 100,
+                displayMaxNits: 300,
+                referenceMaxNits: 400
+            ),
+            66.667,
+            accuracy: 0.001
+        )
+    }
+
+    func testExternalValueConvertsBackToReferenceScale() {
+        XCTAssertEqual(
+            CombinedBrightnessMath.controlValue(
+                brightness: 66.667,
+                maxBrightness: 100,
+                displayMaxNits: 300,
+                referenceMaxNits: 400
+            ),
+            50,
+            accuracy: 0.001
+        )
+    }
+
+    func testLowExternalRangeAccountsForStackedDDCAndGammaDimming() {
+        let brightness = CombinedBrightnessMath.targetBrightness(
+            combined: 2,
+            maxBrightness: 100,
+            displayMaxNits: 400,
+            referenceMaxNits: 400
+        )
+        XCTAssertEqual(brightness, sqrt(30), accuracy: 0.001)
+        XCTAssertEqual(
+            CombinedBrightnessMath.controlValue(
+                brightness: brightness,
+                maxBrightness: 100,
+                displayMaxNits: 400,
+                referenceMaxNits: 400
+            ),
+            2,
+            accuracy: 0.001
+        )
+    }
+
+    func testBuiltinUsesLinearNitsInsteadOfNativeSliderPercent() {
+        XCTAssertEqual(
+            CombinedBrightnessMath.builtinLinearTarget(
+                combined: 50,
+                referenceMaxNits: 400,
+                builtinMaxNits: 600,
+                adjustment: 1
+            ),
+            1.0 / 3.0,
+            accuracy: 0.001
+        )
+    }
+
+    func testBuiltinFineTuningScalesAbsoluteTarget() {
+        XCTAssertEqual(
+            CombinedBrightnessMath.builtinLinearTarget(
+                combined: 50,
+                referenceMaxNits: 400,
+                builtinMaxNits: 600,
+                adjustment: 0.75
+            ),
+            0.25,
+            accuracy: 0.001
+        )
+    }
+
+    func testAbsoluteAutoBrightnessInvertsCombinedMapping() {
+        XCTAssertEqual(
+            CombinedBrightnessMath.externalBrightnessMatchingBuiltin(
+                builtinLinear: 1.0 / 3.0,
+                builtinMaxNits: 600,
+                externalMaxNits: 400,
+                builtinAdjustment: 1
+            ),
+            50,
+            accuracy: 0.001
+        )
+    }
+
+    func testMissingMetadataFallsBackToProportionalMapping() {
+        XCTAssertEqual(
+            CombinedBrightnessMath.targetBrightness(
+                combined: 50,
+                maxBrightness: 160,
+                displayMaxNits: nil,
+                referenceMaxNits: nil
+            ),
+            80,
+            accuracy: 0.001
+        )
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -73,6 +73,7 @@ targets:
       - path: Crisp/Models/GammaPersistenceKey.swift
       - path: Crisp/Models/VariableRefreshModes.swift
       - path: Crisp/Models/KeyboardShortcut.swift
+      - path: Crisp/Utilities/CombinedBrightnessMath.swift
       - path: Crisp/Models/DisplayPreset.swift
       - path: Crisp/Models/CrispControlModel.swift
     settings:


### PR DESCRIPTION
## What & why

Combined Brightness currently treats slider percentages as comparable across every panel. They are not: Apple's built-in brightness control follows a strongly nonlinear user curve, monitors expose different peak luminance ranges, and Crisp adds a second gamma-dimming stage below 15% on external displays. Equal percentages can therefore produce visibly different luminance.

This change:
- derives nominal SDR peak luminance for the built-in panel from CoreDisplay and for external monitors from IORegistry/EDID metadata
- maps Combined Brightness through a shared estimated-nit scale and lets macOS convert the built-in linear target back to its native slider curve
- accounts for Crisp's stacked DDC + gamma behavior in the low external range
- uses the same mapping for Auto Brightness's absolute mode so it does not overwrite the calibrated result
- adds a fine-tuning ratio for remaining panel/EDID differences, with Simplified Chinese localization
- falls back to the existing proportional mapping when luminance metadata or the private linear-brightness API is unavailable

## How tested

- `./scripts/release.sh v0.0.0-ci` — built and signed a universal arm64/x86_64 app and DMG targeting macOS 14
- full app compile with warnings treated as errors using the command-line Swift toolchain
- focused mapping harness covering forward/inverse nit conversion and the sub-15% DDC/gamma range
- runtime smoke test with one Apple built-in panel and two DDC monitors: luminance metadata resolved, linear built-in writes read back correctly, and absolute auto-brightness converged on the same mapping
- verified the compiled release app exposes the new setting and Simplified Chinese strings
- added `CombinedBrightnessMathTests`; the full XCTest target is left to CI because this machine has Command Line Tools but not full Xcode

## Checklist
- [x] Builds locally (`./dev.sh`, or `./scripts/release.sh v0.0.0-ci` for the full release build)
- [x] Added/updated `Crisp/Resources/Localizable.xcstrings` for any new user-facing strings
- [ ] Screenshot or short clip for any UI change
