### PR TITLE
Fix native panel resolution detection for smooth scaling

### DIFF
--- a/Crisp/Models/DisplayInfo.swift
+++ b/Crisp/Models/DisplayInfo.swift
@@ -31,27 +31,25 @@ class DisplayInfo: ObservableObject, Identifiable {
     let vendorNumber: UInt32
     let modelNumber: UInt32
     let serialNumber: UInt32
+    /// Captured while this object is created. Do not resolve this lazily from
+    /// `displayID`: macOS may reuse that numeric ID for different hardware.
+    let displayUUID: String
+    /// EDID/IORegistry evidence in unrotated panel space. Loaded with the mode list.
+    @Published private(set) var detectedPanelResolution: DetectedPanelResolution?
+    /// User fallback for displays whose EDID is unavailable or wrong.
+    @Published private(set) var manualPanelResolution: PanelResolution?
 
     /// A stable identifier for the physical display that persists across sleep/wake
     /// even if macOS reassigns the CGDirectDisplayID.
-    var displayUUID: String {
-        if let cfUUID = CGDisplayCreateUUIDFromDisplayID(displayID),
-           let uuidStr = CFUUIDCreateString(nil, cfUUID.takeRetainedValue()) {
-            return uuidStr as String
-        }
-        // Fallback: vendor+model+serial hash is more stable than raw displayID
-        return "v\(vendorNumber)-m\(modelNumber)-s\(serialNumber)"
+    /// Physical native resolution in CG's rotated space. EDID/native-format metadata
+    /// wins over WindowServer's mode list, whose largest non-HiDPI entry can be a
+    /// compatibility fallback (for example 1024x768 on a 4K panel).
+    var nativeResolution: (width: Int, height: Int) {
+        let panel = resolvedPanelResolution.resolution
+        return isRotated ? (panel.height, panel.width) : (panel.width, panel.height)
     }
 
-    /// The native (highest non-HiDPI) resolution, used for HiDPI enablement and presets.
-    /// Reported in CG's rotated space: on a 90/270-rotated display this is portrait,
-    /// matching availableModes.
-    var nativeResolution: (width: Int, height: Int) {
-        let nativeMode = availableModes
-            .filter { !$0.isHiDPI }
-            .max(by: { ($0.width * $0.height) < ($1.width * $1.height) })
-        return (nativeMode?.width ?? pixelWidth, nativeMode?.height ?? pixelHeight)
-    }
+    var panelResolutionSource: PanelResolutionSource { resolvedPanelResolution.source }
 
     /// Whether macOS renders this display rotated 90/270 (portrait on a landscape panel).
     var isRotated: Bool {
@@ -63,8 +61,26 @@ class DisplayInfo: ObservableObject, Identifiable {
     /// so plist writes and checks must use these dims; mode-list comparisons stay in
     /// the rotated space of nativeResolution/availableModes.
     var panelNativeResolution: (width: Int, height: Int) {
-        let (w, h) = nativeResolution
-        return isRotated ? (h, w) : (w, h)
+        let resolution = resolvedPanelResolution.resolution
+        return (resolution.width, resolution.height)
+    }
+
+    private var resolvedPanelResolution: ResolvedPanelResolution {
+        let unscaledModes = availableModes.filter { !$0.isHiDPI }.map {
+            isRotated
+                ? PanelResolution(width: $0.height, height: $0.width)
+                : PanelResolution(width: $0.width, height: $0.height)
+        }
+        let current = isRotated
+            ? PanelResolution(width: pixelHeight, height: pixelWidth)
+            : PanelResolution(width: pixelWidth, height: pixelHeight)
+        return PanelResolutionResolver.resolve(
+            manual: manualPanelResolution,
+            edid: detectedPanelResolution?.edid,
+            registry: detectedPanelResolution?.registry,
+            unscaledModes: unscaledModes,
+            currentPixels: current
+        )
     }
 
     init(displayID: CGDirectDisplayID) {
@@ -87,6 +103,16 @@ class DisplayInfo: ObservableObject, Identifiable {
         self.vendorNumber = vendor
         self.modelNumber = model
         self.serialNumber = CGDisplaySerialNumber(displayID)
+        if let cfUUID = CGDisplayCreateUUIDFromDisplayID(displayID),
+           let uuidStr = CFUUIDCreateString(nil, cfUUID.takeRetainedValue()) {
+            self.displayUUID = uuidStr as String
+        } else {
+            // Fallback: vendor+model+serial is more stable than raw displayID.
+            self.displayUUID = "v\(vendor)-m\(model)-s\(self.serialNumber)"
+        }
+        self.detectedPanelResolution = nil
+        self.manualPanelResolution = SettingsService.shared.panelResolutionOverride(
+            vendor: vendor, product: model, serial: self.serialNumber)
 
         if builtin {
             self.name = String(localized: "Built-in Display")
@@ -100,11 +126,34 @@ class DisplayInfo: ObservableObject, Identifiable {
 
     func loadDetails() async {
         let displayID = self.displayID
+        let vendor = vendorNumber
+        let product = modelNumber
+        let serial = serialNumber
+        let builtin = isBuiltin
 
-        let modes = await Task.detached(priority: .userInitiated) {
-            DisplayMode.availableModes(for: displayID)
+        async let detectionTask = Task.detached(priority: .utility) {
+            builtin ? nil : PanelResolutionDetector.detect(
+                vendor: vendor, product: product, serial: serial)
+        }.value
+        async let modeTask = Task.detached(priority: .userInitiated) {
+            DisplayMode.enumerateModes(for: displayID)
         }.value
 
-        self.availableModes = modes
+        let detection = await detectionTask
+        let enumeration = await modeTask
+        self.detectedPanelResolution = detection
+
+        let evidence = manualPanelResolution ?? detection?.edid ?? detection?.registry
+        let aspect = evidence.map {
+            isRotated ? Double($0.height) / Double($0.width)
+                : Double($0.width) / Double($0.height)
+        }
+        self.availableModes = enumeration.resolved(nativeAspect: aspect)
+    }
+
+    func setManualPanelResolution(_ resolution: PanelResolution?) {
+        SettingsService.shared.setPanelResolutionOverride(
+            resolution, vendor: vendorNumber, product: modelNumber, serial: serialNumber)
+        manualPanelResolution = resolution
     }
 }

--- a/Crisp/Models/DisplayMode.swift
+++ b/Crisp/Models/DisplayMode.swift
@@ -2,7 +2,7 @@ import Foundation
 import CoreGraphics
 
 /// Represents a single display mode (resolution + refresh rate + HiDPI flag).
-struct DisplayMode: Identifiable, Equatable {
+struct DisplayMode: Identifiable, Equatable, Sendable {
     /// Unique identifier: IODisplayModeID
     let id: Int32
     /// Logical width in points
@@ -45,20 +45,47 @@ struct DisplayMode: Identifiable, Equatable {
             ?? rawModes.map { $0.pixelWidth }.max() ?? 0
     }
 
+    /// One WindowServer enumeration, resolved after native-resolution detection
+    /// supplies a better aspect ratio. Keeping the unfiltered hidden candidates
+    /// lets registry detection and mode discovery run concurrently.
+    struct Enumeration: Sendable {
+        fileprivate let visibleModes: [DisplayMode]
+        fileprivate let hiddenHiDPIModes: [DisplayMode]
+        fileprivate let inferredNativeAspect: Double
+
+        func resolved(nativeAspect overrideNativeAspect: Double? = nil) -> [DisplayMode] {
+            let nativeAspect = overrideNativeAspect.flatMap { $0 > 0 ? $0 : nil }
+                ?? inferredNativeAspect
+            let hidden = hiddenHiDPIModes.filter { mode in
+                guard nativeAspect > 0 else { return true }
+                let aspect = Double(mode.width) / Double(mode.height)
+                return abs(aspect - nativeAspect) / nativeAspect < 0.02
+            }
+            return DisplayMode.sorted(visibleModes + hidden)
+        }
+    }
+
     /// Returns all display modes for the given display, sorted by logical width descending.
     /// Pass `includeHiDPI: true` (default) to include all scaled modes.
-    static func availableModes(for displayID: CGDirectDisplayID) -> [DisplayMode] {
+    static func availableModes(for displayID: CGDirectDisplayID,
+                               nativeAspect overrideNativeAspect: Double? = nil) -> [DisplayMode] {
+        enumerateModes(for: displayID).resolved(nativeAspect: overrideNativeAspect)
+    }
+
+    /// Enumerates visible and CGS-hidden modes without committing to an aspect
+    /// filter. The caller can resolve the snapshot once metadata detection ends.
+    static func enumerateModes(for displayID: CGDirectDisplayID) -> Enumeration {
         let options: CFDictionary = [kCGDisplayShowDuplicateLowResolutionModes: true] as CFDictionary
         guard let rawModes = CGDisplayCopyAllDisplayModes(displayID, options) as? [CGDisplayMode],
               !rawModes.isEmpty else {
-            return []
+            return Enumeration(visibleModes: [], hiddenHiDPIModes: [], inferredNativeAspect: 0)
         }
 
         let maxPixelWidth = nativePixelWidth(from: rawModes)
         let variableIDs = VariableRefreshModes.variableModeIDs(from: cgsModeRecords(for: displayID))
 
         var seen = Set<Int32>()
-        var modes: [DisplayMode] = rawModes.compactMap { mode -> DisplayMode? in
+        let modes: [DisplayMode] = rawModes.compactMap { mode -> DisplayMode? in
             let modeID = mode.ioDisplayModeID
             guard seen.insert(modeID).inserted else { return nil }  // deduplicate
             guard mode.isUsableForDesktopGUI() else { return nil }
@@ -86,15 +113,19 @@ struct DisplayMode: Identifiable, Equatable {
         // clean scaled resolutions (1600x900, 2048x1152, full 2560x1440 refresh set, ...) that
         // CGS carries without any override, so we can offer and apply them directly like BetterDisplay.
         let knownIDs = Set(modes.map { $0.id })
-        let nativeAR = DisplayModeGeometry.nativeAspect(from: rawModes.map {
+        let inferredNativeAspect = DisplayModeGeometry.nativeAspect(from: rawModes.map {
             DisplayModeGeometry(width: $0.width, height: $0.height,
                                 pixelWidth: $0.pixelWidth, pixelHeight: $0.pixelHeight)
         })
-        modes += cgsHiddenHiDPIModes(for: displayID, excludingIDs: knownIDs,
-                                     maxPixelWidth: maxPixelWidth, nativeAspect: nativeAR,
-                                     variableIDs: variableIDs)
+        let hiddenModes = cgsHiddenHiDPIModes(
+            for: displayID, excludingIDs: knownIDs,
+            maxPixelWidth: maxPixelWidth, variableIDs: variableIDs)
+        return Enumeration(visibleModes: modes, hiddenHiDPIModes: hiddenModes,
+                           inferredNativeAspect: inferredNativeAspect)
+    }
 
-        return modes.sorted { lhs, rhs in
+    private static func sorted(_ modes: [DisplayMode]) -> [DisplayMode] {
+        modes.sorted { lhs, rhs in
             if lhs.width != rhs.width { return lhs.width > rhs.width }
             if lhs.height != rhs.height { return lhs.height > rhs.height }
             if lhs.refreshRate != rhs.refreshRate { return lhs.refreshRate > rhs.refreshRate }
@@ -133,7 +164,6 @@ struct DisplayMode: Identifiable, Equatable {
     private static func cgsHiddenHiDPIModes(for displayID: CGDirectDisplayID,
                                             excludingIDs known: Set<Int32>,
                                             maxPixelWidth: Int,
-                                            nativeAspect: Double,
                                             variableIDs: Set<Int32>) -> [DisplayMode] {
         var count: Int32 = 0
         guard CGSGetNumberOfDisplayModes(displayID, &count) == .success, count > 0 else { return [] }
@@ -148,9 +178,6 @@ struct DisplayMode: Identifiable, Equatable {
             let id = Int32(bitPattern: d.modeNumber)
             if known.contains(id) { continue }            // already surfaced by CG
             let w = Int(d.width), h = Int(d.height)
-            // Panel aspect only: CGS also lists off-aspect HiDPI modes (e.g. 4:3 on a 16:9 panel)
-            // that render pillar-boxed; drop them, the way the built-in notch filter does.
-            if nativeAspect > 0, abs(Double(w) / Double(h) - nativeAspect) / nativeAspect >= 0.02 { continue }
             let pw = Int((Float(d.width) * d.density).rounded())
             let ph = Int((Float(d.height) * d.density).rounded())
             out.append(DisplayMode(id: id, width: w, height: h,

--- a/Crisp/Models/DisplayPreset.swift
+++ b/Crisp/Models/DisplayPreset.swift
@@ -60,3 +60,41 @@ enum PresetCapture: String, CaseIterable, Identifiable {
         }
     }
 }
+
+/// Pure routing decision for preset resolution restoration. Beyond-cap HiDPI
+/// sizes must use the mirror path even when the physical display exposes a
+/// same-size 1× fallback mode.
+struct PresetModeCandidate: Equatable {
+    let width: Int
+    let height: Int
+    let isHiDPI: Bool
+}
+
+enum PresetResolutionRoute: Equatable {
+    case physical(index: Int)
+    case mirror
+    case unavailable
+}
+
+enum PresetResolutionRouter {
+    static func route(width: Int, height: Int, isHiDPI: Bool,
+                      candidates: [PresetModeCandidate],
+                      beyondCapStops: [PanelResolution]) -> PresetResolutionRoute {
+        if isHiDPI, beyondCapStops.contains(where: {
+            $0.width == width && $0.height == height
+        }) {
+            return .mirror
+        }
+        if let index = candidates.firstIndex(where: {
+            $0.width == width && $0.height == height && $0.isHiDPI == isHiDPI
+        }) {
+            return .physical(index: index)
+        }
+        if let index = candidates.firstIndex(where: {
+            $0.width == width && $0.height == height
+        }) {
+            return .physical(index: index)
+        }
+        return .unavailable
+    }
+}

--- a/Crisp/Models/PanelResolution.swift
+++ b/Crisp/Models/PanelResolution.swift
@@ -1,0 +1,208 @@
+import Foundation
+
+/// Physical pixel dimensions of a display panel in its unrotated scanout space.
+struct PanelResolution: Codable, Equatable, Hashable {
+    let width: Int
+    let height: Int
+
+    /// Reject malformed EDID/registry values and unsafe manual input while still
+    /// allowing unusual portrait and ultrawide panels.
+    var isPlausible: Bool {
+        guard width >= 640, height >= 480, width <= 16_384, height <= 16_384 else { return false }
+        let aspect = Double(width) / Double(height)
+        return aspect >= 0.25 && aspect <= 4.0
+    }
+}
+
+enum PanelResolutionSource: Equatable {
+    case manual
+    case edid
+    case registry
+    case displayModes
+    case currentPixels
+}
+
+struct ResolvedPanelResolution: Equatable {
+    let resolution: PanelResolution
+    let source: PanelResolutionSource
+}
+
+/// Accumulates native-size evidence without letting a later malformed registry
+/// value erase a result that was already parsed successfully.
+struct PanelResolutionEvidence {
+    private(set) var edid: PanelResolution?
+    private(set) var registry: PanelResolution?
+
+    var hasResolution: Bool { edid != nil || registry != nil }
+
+    mutating func recordEDID(_ data: Data) {
+        guard let resolution = EDIDParser.preferredResolution(from: data) else { return }
+        edid = resolution
+    }
+
+    mutating func recordRegistry(width: Int, height: Int) {
+        let resolution = PanelResolution(width: width, height: height)
+        guard resolution.isPlausible else { return }
+        registry = resolution
+    }
+}
+
+/// Pure precedence policy shared by DisplayInfo and headless tests.
+enum PanelResolutionResolver {
+    static func resolve(manual: PanelResolution?, edid: PanelResolution?,
+                        registry: PanelResolution?, unscaledModes: [PanelResolution],
+                        currentPixels: PanelResolution) -> ResolvedPanelResolution {
+        if let manual, manual.isPlausible {
+            return ResolvedPanelResolution(resolution: manual, source: .manual)
+        }
+        if let edid, edid.isPlausible {
+            return ResolvedPanelResolution(resolution: edid, source: .edid)
+        }
+        if let registry, registry.isPlausible {
+            return ResolvedPanelResolution(resolution: registry, source: .registry)
+        }
+        if let largest = unscaledModes.filter(\.isPlausible).max(by: {
+            $0.width * $0.height < $1.width * $1.height
+        }) {
+            return ResolvedPanelResolution(resolution: largest, source: .displayModes)
+        }
+        return ResolvedPanelResolution(resolution: currentPixels, source: .currentPixels)
+    }
+}
+
+/// Headless geometry for the BetterDisplay-style 16-point smooth-scaling grid.
+enum SmoothScalingGeometry {
+    static func logicalSizes(nativeWidth: Int, nativeHeight: Int,
+                             minScale: Double = 0.5,
+                             maximumBackingWidth: Int? = nil) -> [PanelResolution] {
+        guard nativeWidth > 0, nativeHeight > 0 else { return [] }
+        let minWidth = Int((Double(nativeWidth) * minScale).rounded())
+        var sizes: [PanelResolution] = []
+        var width = nativeWidth
+        while width >= minWidth {
+            let height = Int((Double(width) * Double(nativeHeight) / Double(nativeWidth)).rounded())
+            let resolution = PanelResolution(width: width, height: height)
+            if resolution.isPlausible,
+               maximumBackingWidth.map({ width * 2 <= $0 }) ?? true {
+                sizes.append(resolution)
+            }
+            width -= 16
+        }
+        return sizes
+    }
+}
+
+/// Keeps a virtual display's declaration list below WindowServer's practical
+/// ceiling while retaining a contiguous slider window around the requested
+/// looks-like size. The virtual can be rebuilt around a later request when the
+/// slider moves outside this window.
+enum MirrorModeGeometry {
+    static func boundedStops(_ stops: [PanelResolution], including required: PanelResolution,
+                             maximumCount: Int) -> [PanelResolution] {
+        guard maximumCount > 0 else { return [] }
+
+        var seen = Set<PanelResolution>()
+        var unique = (stops + [required])
+            .filter { seen.insert($0).inserted }
+            .sorted {
+                if $0.width != $1.width { return $0.width > $1.width }
+                return $0.height > $1.height
+            }
+        guard unique.count > maximumCount else { return unique }
+
+        let requiredIndex = unique.firstIndex(of: required) ?? unique.count - 1
+        let centeredStart = max(0, requiredIndex - maximumCount / 2)
+        let start = min(centeredStart, unique.count - maximumCount)
+        unique = Array(unique[start..<(start + maximumCount)])
+        return unique
+    }
+}
+
+/// Minimal, defensive EDID parser for explicitly preferred/native timings.
+/// It intentionally does not infer panel size from every advertised compatibility
+/// mode: only the base preferred DTD and CTA timings carrying a native marker count.
+enum EDIDParser {
+    static func preferredResolution(from data: Data) -> PanelResolution? {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 128,
+              Array(bytes[0..<8]) == [0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00],
+              checksumIsValid(Array(bytes[0..<128])) else { return nil }
+
+        var native: [PanelResolution] = []
+        if bytes[24] & 0x02 != 0,
+           let preferred = detailedTiming(bytes, at: 54) { native.append(preferred) }
+
+        let extensionCount = min(Int(bytes[126]), bytes.count / 128 - 1)
+        for index in 0..<extensionCount {
+            let start = (index + 1) * 128
+            let block = Array(bytes[start..<(start + 128)])
+            guard checksumIsValid(block), block[0] == 0x02 else { continue }
+            native.append(contentsOf: ctaNativeResolutions(block))
+        }
+
+        return native.filter(\.isPlausible).max {
+            $0.width * $0.height < $1.width * $1.height
+        }
+    }
+
+    private static func checksumIsValid(_ block: [UInt8]) -> Bool {
+        block.count == 128 && block.reduce(0, { $0 + Int($1) }) & 0xff == 0
+    }
+
+    private static func detailedTiming(_ bytes: [UInt8], at offset: Int) -> PanelResolution? {
+        guard offset >= 0, offset + 17 < bytes.count else { return nil }
+        let pixelClock = Int(bytes[offset]) | Int(bytes[offset + 1]) << 8
+        guard pixelClock != 0 else { return nil }
+        let width = Int(bytes[offset + 2]) | Int(bytes[offset + 4] & 0xf0) << 4
+        let height = Int(bytes[offset + 5]) | Int(bytes[offset + 7] & 0xf0) << 4
+        let result = PanelResolution(width: width, height: height)
+        return result.isPlausible ? result : nil
+    }
+
+    private static func ctaNativeResolutions(_ block: [UInt8]) -> [PanelResolution] {
+        let dtdOffset = block[2] == 0 ? 127 : min(Int(block[2]), 127)
+        var resolutions: [PanelResolution] = []
+        var cursor = 4
+        while cursor < dtdOffset {
+            let header = block[cursor]
+            let tag = header >> 5
+            let length = Int(header & 0x1f)
+            guard cursor + 1 + length <= dtdOffset else { break }
+            if tag == 0x02 {
+                for svd in block[(cursor + 1)..<(cursor + 1 + length)] where svd & 0x80 != 0 {
+                    if let resolution = resolution(forCTAVIC: svd & 0x7f) {
+                        resolutions.append(resolution)
+                    }
+                }
+            }
+            cursor += 1 + length
+        }
+
+        var timingOffset = dtdOffset
+        var nativeDTDCount = Int(block[3] & 0x0f)
+        while nativeDTDCount > 0, timingOffset + 17 < 127 {
+            if let resolution = detailedTiming(block, at: timingOffset) {
+                resolutions.append(resolution)
+            }
+            timingOffset += 18
+            nativeDTDCount -= 1
+        }
+        return resolutions
+    }
+
+    /// CTA-861 video identification codes whose active dimensions are relevant
+    /// to panel-native inference. Multiple refresh/aspect variants share a size.
+    private static func resolution(forCTAVIC vic: UInt8) -> PanelResolution? {
+        switch vic {
+        case 1: return PanelResolution(width: 640, height: 480)
+        case 2, 3: return PanelResolution(width: 720, height: 480)
+        case 4, 19, 41, 47: return PanelResolution(width: 1280, height: 720)
+        case 5, 16, 20, 31...34, 39, 40, 46, 63, 64:
+            return PanelResolution(width: 1920, height: 1080)
+        case 17, 18: return PanelResolution(width: 720, height: 576)
+        case 93...97, 103...107: return PanelResolution(width: 3840, height: 2160)
+        case 98...102: return PanelResolution(width: 4096, height: 2160)
+        default: return nil
+        }
+    }
+}

--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -4,6 +4,96 @@
     "" : {
 
     },
+    "Detected from display metadata" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从显示器元数据检测"
+          }
+        }
+      }
+    },
+    "Detected from EDID" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "从 EDID 检测"
+          }
+        }
+      }
+    },
+    "Enter a valid panel size from 640×480 up to 16384×16384." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请输入从 640×480 到 16384×16384 的有效面板尺寸。"
+          }
+        }
+      }
+    },
+    "Inferred from current mode" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "根据当前模式推断"
+          }
+        }
+      }
+    },
+    "Inferred from display modes" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "根据显示模式推断"
+          }
+        }
+      }
+    },
+    "Manual" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "手动"
+          }
+        }
+      }
+    },
+    "Native resolution" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "原生分辨率"
+          }
+        }
+      }
+    },
+    "Use detected resolution" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用检测到的分辨率"
+          }
+        }
+      }
+    },
+    "Use this only when the detected panel size is wrong." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅在检测到的面板尺寸不正确时使用此设置。"
+          }
+        }
+      }
+    },
     ", collapsed" : {
       "localizations" : {
         "zh-Hans" : {

--- a/Crisp/Services/CGHelpers.swift
+++ b/Crisp/Services/CGHelpers.swift
@@ -2,12 +2,22 @@ import Foundation
 
 /// Shared utilities for wrapping blocking CoreGraphics calls.
 enum CGHelpers {
+    enum TimedResult<T: Sendable>: Sendable {
+        case completed(T)
+        case timedOut
+    }
+
+    /// WindowServer display transactions are process-global. Keeping their
+    /// blocking bodies on one queue prevents a timed-out operation from
+    /// overlapping a later transaction while it continues underneath.
+    private static let operationQueue = DispatchQueue(
+        label: "com.crisp.cg-operations", qos: .userInitiated)
 
     /// Runs a blocking operation on a background thread with a timeout.
     ///
-    /// The operation is dispatched to a `.userInitiated` global queue. If it
-    /// completes within `seconds`, its return value is forwarded. If the
-    /// deadline fires first, `fallback` is returned instead.
+    /// Operations execute serially. A request that times out while waiting for
+    /// an earlier blocking body is skipped when it reaches the front, rather
+    /// than running a stale transaction after its caller has moved on.
     ///
     /// This is useful for any CoreGraphics / WindowServer IPC call that can
     /// hang indefinitely (e.g. `CGCompleteDisplayConfiguration`,
@@ -27,7 +37,21 @@ enum CGHelpers {
             let lock = NSLock()
             var didResume = false
 
-            DispatchQueue.global(qos: .userInitiated).async {
+            DispatchQueue.global().asyncAfter(deadline: .now() + seconds) {
+                lock.lock()
+                guard !didResume else { lock.unlock(); return }
+                didResume = true
+                lock.unlock()
+                cont.resume(returning: fallback)
+            }
+
+            operationQueue.async {
+                lock.lock()
+                // The request expired before its blocking body started. Do not
+                // run it later: that would apply stale display state.
+                guard !didResume else { lock.unlock(); return }
+                lock.unlock()
+
                 let result = operation()
                 lock.lock()
                 guard !didResume else { lock.unlock(); return }
@@ -36,12 +60,41 @@ enum CGHelpers {
                 cont.resume(returning: result)
             }
 
+        }
+    }
+
+    /// Queues mandatory compensating work that may not be skipped, but still
+    /// returns `.timedOut` to its caller at the deadline. If the queue drains
+    /// later, the operation runs and reports through `lateCompletion`, allowing
+    /// the owner to repair its state without leaving an async UI task hung.
+    static func runMandatoryWithTimeout<T: Sendable>(
+        seconds: Double,
+        operation: @escaping @Sendable () -> T,
+        lateCompletion: @escaping @Sendable (T) -> Void
+    ) async -> TimedResult<T> {
+        await withCheckedContinuation { continuation in
+            let lock = NSLock()
+            var didResume = false
+
             DispatchQueue.global().asyncAfter(deadline: .now() + seconds) {
                 lock.lock()
                 guard !didResume else { lock.unlock(); return }
                 didResume = true
                 lock.unlock()
-                cont.resume(returning: fallback)
+                continuation.resume(returning: .timedOut)
+            }
+
+            operationQueue.async {
+                let result = operation()
+                lock.lock()
+                if didResume {
+                    lock.unlock()
+                    lateCompletion(result)
+                } else {
+                    didResume = true
+                    lock.unlock()
+                    continuation.resume(returning: .completed(result))
+                }
             }
         }
     }

--- a/Crisp/Services/DisplayManager.swift
+++ b/Crisp/Services/DisplayManager.swift
@@ -2,6 +2,15 @@ import Foundation
 import CoreGraphics
 import AppKit
 
+private func currentDisplayUUID(_ displayID: CGDirectDisplayID) -> String {
+    if let cf = CGDisplayCreateUUIDFromDisplayID(displayID),
+       let value = CFUUIDCreateString(nil, cf.takeRetainedValue()) {
+        return value as String
+    }
+    return "v\(CGDisplayVendorNumber(displayID))-m\(CGDisplayModelNumber(displayID))"
+        + "-s\(CGDisplaySerialNumber(displayID))"
+}
+
 // Global C-compatible callback for display reconfiguration.
 // Must be a top-level function (not a closure) to be used as a C function pointer.
 private func displayReconfigCallback(
@@ -137,6 +146,13 @@ class DisplayManager: ObservableObject {
     }
 
     func refreshDisplays() {
+        var displayCount: UInt32 = 0
+        guard CGGetOnlineDisplayList(0, nil, &displayCount) == .success else { return }
+        var displayIDs = [CGDirectDisplayID](repeating: 0, count: Int(displayCount))
+        guard CGGetOnlineDisplayList(displayCount, &displayIDs, &displayCount) == .success else {
+            return
+        }
+
         // Display IDs can be reshuffled across a reconnect storm with no ID
         // ever leaving the online list (two panels swapping IDs), so the
         // per-removed-ID cleanup below can miss a now-crossed channel map.
@@ -144,17 +160,20 @@ class DisplayManager: ObservableObject {
         // matching on the next DDC operation.
         DDCService.shared.invalidateAllChannelMappings()
 
-        var displayCount: UInt32 = 0
-        CGGetOnlineDisplayList(0, nil, &displayCount)
-        var displayIDs = [CGDirectDisplayID](repeating: 0, count: Int(displayCount))
-        CGGetOnlineDisplayList(displayCount, &displayIDs, &displayCount)
-
-        let currentIDs = Set(displays.map { $0.displayID })
+        let existingByID = Dictionary(uniqueKeysWithValues: displays.map { ($0.displayID, $0) })
+        let currentIDs = Set(existingByID.keys)
         let newIDSet = Set((0..<Int(displayCount)).map { displayIDs[$0] })
 
         // Clean up DDC cache for removed displays to prevent stale entries accumulating
         let removedIDs = currentIDs.subtracting(newIDSet)
-        removedIDs.forEach {
+        let replacedIDs = currentIDs.intersection(newIDSet).filter { id in
+            guard let existing = existingByID[id] else { return false }
+            return existing.vendorNumber != CGDisplayVendorNumber(id)
+                || existing.modelNumber != CGDisplayModelNumber(id)
+                || existing.serialNumber != CGDisplaySerialNumber(id)
+                || existing.displayUUID != currentDisplayUUID(id)
+        }
+        removedIDs.union(replacedIDs).forEach {
             DDCService.shared.clearCache(for: $0)
             BrightnessService.shared.invalidateDDCState(for: $0)
             GammaService.shared.invalidate(for: $0)
@@ -168,8 +187,6 @@ class DisplayManager: ObservableObject {
         MirroredModeService.shared.reconcile(online: newIDSet)
 
         // Diff-based refresh: keep existing DisplayInfo objects (preserves @Published state)
-        let existingByID = Dictionary(uniqueKeysWithValues: displays.map { ($0.displayID, $0) })
-
         var updatedDisplays: [DisplayInfo] = []
         var addedDisplays: [DisplayInfo] = []
 
@@ -178,7 +195,13 @@ class DisplayManager: ObservableObject {
             // A mirror virtual (#65) is a rendering trick, not a display: keep it out
             // so no view, preset, brightness path, or the arranger ever sees one.
             if MirroredModeService.isMirrorVirtual(id) { continue }
-            if let existing = existingByID[id] {
+            let sameHardware = existingByID[id].map {
+                $0.vendorNumber == CGDisplayVendorNumber(id)
+                    && $0.modelNumber == CGDisplayModelNumber(id)
+                    && $0.serialNumber == CGDisplaySerialNumber(id)
+                    && $0.displayUUID == currentDisplayUUID(id)
+            } ?? false
+            if let existing = existingByID[id], sameHardware {
                 updatedDisplays.append(existing)
             } else {
                 let info = DisplayInfo(displayID: id)

--- a/Crisp/Services/HiDPIService.swift
+++ b/Crisp/Services/HiDPIService.swift
@@ -11,6 +11,16 @@ final class HiDPIService: @unchecked Sendable {
 
     private let overridesBase = URL(fileURLWithPath: "/Library/Displays/Contents/Resources/Overrides")
 
+    /// Apple Silicon WindowServer rejects scaled backings wider than 6720 pixels
+    /// on current DCP generations. Do not write modes that cannot enumerate.
+    private var maximumSmoothBackingWidth: Int? {
+#if arch(arm64)
+        6720
+#else
+        nil
+#endif
+    }
+
     // MARK: - Public API
 
     /// Checks whether HiDPI is enabled for the given display via plist override.
@@ -62,8 +72,10 @@ final class HiDPIService: @unchecked Sendable {
 
         refreshTask = Task {
             try? await Task.sleep(nanoseconds: 500_000_000)
+            let (nativeWidth, nativeHeight) = display.nativeResolution
+            let nativeAspect = nativeHeight > 0 ? Double(nativeWidth) / Double(nativeHeight) : nil
             async let modes = Task.detached(priority: .userInitiated) {
-                DisplayMode.availableModes(for: physicalID)
+                DisplayMode.availableModes(for: physicalID, nativeAspect: nativeAspect)
             }.value
             async let current = Task.detached(priority: .userInitiated) {
                 DisplayMode.currentMode(for: physicalID)
@@ -84,12 +96,16 @@ final class HiDPIService: @unchecked Sendable {
     func enableSmoothScaling(vendor: UInt32, product: UInt32,
                              nativeWidth: Int, nativeHeight: Int) -> String? {
         let target = generateSmoothScaledModes(nativeWidth: nativeWidth, nativeHeight: nativeHeight)
-        if overridePlistMatches(vendor: vendor, product: product, scaledModes: target) {
+        if overridePlistMatches(vendor: vendor, product: product,
+                                nativeWidth: nativeWidth, nativeHeight: nativeHeight,
+                                scaledModes: target) {
             // Already installed; re-probe (no admin) in case the modes need re-enumerating.
             triggerDisplayReenumeration(vendor: vendor, product: product)
             return nil
         }
-        return writeScaledModesPlist(vendor: vendor, product: product, scaledModes: target)
+        return writeScaledModesPlist(vendor: vendor, product: product,
+                                     nativeWidth: nativeWidth, nativeHeight: nativeHeight,
+                                     scaledModes: target)
     }
 
     /// True when enabling smooth scaling would need a privileged write (admin prompt),
@@ -98,6 +114,7 @@ final class HiDPIService: @unchecked Sendable {
     func smoothScalingWouldPrompt(vendor: UInt32, product: UInt32,
                                   nativeWidth: Int, nativeHeight: Int) -> Bool {
         !overridePlistMatches(vendor: vendor, product: product,
+                              nativeWidth: nativeWidth, nativeHeight: nativeHeight,
                               scaledModes: generateSmoothScaledModes(nativeWidth: nativeWidth,
                                                                      nativeHeight: nativeHeight))
     }
@@ -107,17 +124,29 @@ final class HiDPIService: @unchecked Sendable {
     private func enableHiDPIPlist(vendor: UInt32, product: UInt32,
                                   nativeWidth: Int, nativeHeight: Int) -> String? {
         writeScaledModesPlist(vendor: vendor, product: product,
+                              nativeWidth: nativeWidth, nativeHeight: nativeHeight,
                               scaledModes: generateScaledModes(nativeWidth: nativeWidth,
                                                                nativeHeight: nativeHeight))
     }
 
     /// Writes the override plist with the given scale-resolutions entries via admin auth,
     /// then re-probes so macOS re-enumerates modes. Shared by normal HiDPI and smooth scaling.
-    private func writeScaledModesPlist(vendor: UInt32, product: UInt32, scaledModes: [Data]) -> String? {
+    private func writeScaledModesPlist(vendor: UInt32, product: UInt32,
+                                       nativeWidth: Int, nativeHeight: Int,
+                                       scaledModes: [Data]) -> String? {
         let dirPath = overrideDir(vendor: vendor).path
         let plistPath = overridePlistURL(vendor: vendor, product: product).path
 
         let plist: [String: Any] = [
+            // Tahoe can ignore a bare scale-resolutions array even when the
+            // enclosing vendor/product path matches. Repeat the identity and
+            // physical panel dimensions in the payload, as Apple's own display
+            // overrides and BetterDisplay do. DisplayPixelDimensions is the
+            // unscaled panel size, encoded as two big-endian UInt32 values.
+            "DisplayVendorID": Int(vendor),
+            "DisplayProductID": Int(product),
+            "DisplayPixelDimensions": encodeScaledMode(
+                backingW: nativeWidth, backingH: nativeHeight),
             "scale-resolutions": scaledModes
         ]
 
@@ -250,14 +279,22 @@ final class HiDPIService: @unchecked Sendable {
     /// True when the on-disk override plist's scale-resolutions already equals `scaledModes`
     /// (order-independent). Lets callers skip the privileged rewrite, and its admin prompt,
     /// when nothing would change. Reading /Library/Displays needs no privileges.
-    private func overridePlistMatches(vendor: UInt32, product: UInt32, scaledModes: [Data]) -> Bool {
+    private func overridePlistMatches(vendor: UInt32, product: UInt32,
+                                      nativeWidth: Int, nativeHeight: Int,
+                                      scaledModes: [Data]) -> Bool {
         let url = overridePlistURL(vendor: vendor, product: product)
         guard let data = try? Data(contentsOf: url),
               let obj = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
               let dict = obj as? [String: Any],
+              let existingVendor = dict["DisplayVendorID"] as? Int,
+              let existingProduct = dict["DisplayProductID"] as? Int,
+              let dimensions = dict["DisplayPixelDimensions"] as? Data,
               let existing = dict["scale-resolutions"] as? [Data]
         else { return false }
-        return Set(existing) == Set(scaledModes)
+        return existingVendor == Int(vendor)
+            && existingProduct == Int(product)
+            && dimensions == encodeScaledMode(backingW: nativeWidth, backingH: nativeHeight)
+            && Set(existing) == Set(scaledModes)
     }
 
     private func generateScaledModes(nativeWidth: Int, nativeHeight: Int) -> [Data] {
@@ -274,10 +311,10 @@ final class HiDPIService: @unchecked Sendable {
         return logical.map { encodeScaledMode(backingW: $0.0 * 2, backingH: $0.1 * 2) }
     }
 
-    /// Dense HiDPI "looks like" ladder for smooth scaling: native plus a sub-native ladder,
-    /// each injected as a 2×-backed HiDPI mode. This is what lets the smooth-scaling slider
-    /// feel continuous. Injecting this many modes also floods the System Settings resolution
-    /// list, so it's only used for displays the user opts into smooth scaling for.
+    /// Dense HiDPI "looks like" ladder for smooth scaling: supported sub-native sizes,
+    /// each injected as a 2×-backed HiDPI mode. The real 1× native endpoint already exists
+    /// and is added by the UI. Injecting this many modes also floods the System Settings
+    /// resolution list, so it's only used for displays the user opts into smooth scaling for.
     func generateSmoothScaledModes(nativeWidth: Int, nativeHeight: Int,
                                    minScale: Double = 0.5) -> [Data] {
         smoothScaledLogicalSizes(nativeWidth: nativeWidth, nativeHeight: nativeHeight, minScale: minScale)
@@ -285,23 +322,21 @@ final class HiDPIService: @unchecked Sendable {
     }
 
     /// The logical (point) sizes smooth scaling injects, on BetterDisplay's flexible-scaling
-    /// grid: native width stepped down by 16 points with height held to the panel's exact
-    /// aspect, down to `minScale`×native. 16px is fine enough that the slider drags
+    /// grid: width stepped down by 16 points with height held to the panel's exact
+    /// aspect, down to `minScale`×native and capped at the backing width supported by
+    /// the platform. 16px is fine enough that the slider drags
     /// continuously (a 1440p panel yields ~80 stops). Standard sizes land on the grid for free
     /// (1920 = 2560−16·40, 1600 = 2560−16·60, 2048 = 2560−16·32), so no anchoring is needed.
     /// Exposed so the UI can tell whether these have enumerated yet: they only appear after the
     /// display re-enumerates (soft-reconnect / physical reconnect).
     func smoothScaledLogicalSizes(nativeWidth: Int, nativeHeight: Int,
-                                  minScale: Double = 0.5) -> [(width: Int, height: Int)] {
-        let minW = Int((Double(nativeWidth) * minScale).rounded())
-        var stops: [(width: Int, height: Int)] = []
-        var w = nativeWidth
-        while w >= minW {
-            let h = Int((Double(w) * Double(nativeHeight) / Double(nativeWidth)).rounded())
-            if w >= 800, h >= 600 { stops.append((width: w, height: h)) }
-            w -= 16  // BetterDisplay's step; 16px stays even, so backing (×2) stays integer
-        }
-        return stops  // native first, then descending: distinct widths, no dedup needed
+                                  minScale: Double = 0.5,
+                                  enforcePlatformBackingLimit: Bool = true)
+        -> [(width: Int, height: Int)] {
+        SmoothScalingGeometry.logicalSizes(
+            nativeWidth: nativeWidth, nativeHeight: nativeHeight, minScale: minScale,
+            maximumBackingWidth: enforcePlatformBackingLimit ? maximumSmoothBackingWidth : nil
+        ).map { (width: $0.width, height: $0.height) }
     }
 
     /// Encodes a backing (pixel) resolution as the 8-byte big-endian entry the

--- a/Crisp/Services/HotkeyService.swift
+++ b/Crisp/Services/HotkeyService.swift
@@ -137,7 +137,13 @@ final class HotkeyService {
         }
         Self.log.info("hidpi toggle: switching display \(displayID) to \(target.width)x\(target.height) hidpi=\(target.isHiDPI)")
         Task { @MainActor in
-            _ = await ResolutionService.shared.setDisplayMode(target, for: displayID)
+            // A beyond-cap HiDPI mode makes the physical panel a mirror target.
+            // Keep teardown and the twin switch atomic, or ResolutionService
+            // would redirect the LoDPI mode onto the virtual source.
+            _ = await MirroredModeService.shared.withMirrorRestored(for: display) {
+                await ResolutionService.shared.setDisplayMode(
+                    target, for: displayID, expectedDisplayUUID: display.displayUUID)
+            }
         }
     }
 

--- a/Crisp/Services/MirrorService.swift
+++ b/Crisp/Services/MirrorService.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import ApplicationServices
 
 /// Provides hardware-level screen mirroring via CGDisplayConfiguration API.
 final class MirrorService: @unchecked Sendable {
@@ -25,24 +26,33 @@ final class MirrorService: @unchecked Sendable {
     /// Makes `target` mirror `source`.
     /// The entire Begin→Mirror→Complete transaction runs inside `CGHelpers.runWithTimeout`
     /// so `CGCompleteDisplayConfiguration` cannot block indefinitely on WindowServer IPC.
-    /// - Returns: true on success.
+    /// - Returns: true when both configuration and commit succeed.
     @discardableResult
-    func enableMirror(source: CGDirectDisplayID, target: CGDirectDisplayID) async -> Bool {
+    func enableMirror(
+        source: CGDirectDisplayID,
+        target: CGDirectDisplayID,
+        expectedTargetUUID: String
+    ) async -> Bool {
         // Mirroring a display onto itself is invalid and causes undefined CG behaviour.
         guard source != target else {
             return false
         }
         return await CGHelpers.runWithTimeout(seconds: 10, fallback: false) {
+            // The numeric ID is volatile. A queued transaction must not attach
+            // the virtual to different hardware that inherited the ID.
+            guard Self.displayUUID(for: target) == expectedTargetUUID else { return false }
             var config: CGDisplayConfigRef?
             guard CGBeginDisplayConfiguration(&config) == .success,
                   let cfg = config else { return false }
-            CGConfigureDisplayMirrorOfDisplay(cfg, target, source)
-            let result = CGCompleteDisplayConfiguration(cfg, .forSession)
-            if result != .success {
+            guard CGConfigureDisplayMirrorOfDisplay(cfg, target, source) == .success else {
                 CGCancelDisplayConfiguration(cfg)
                 return false
             }
-            return true
+            guard CGCompleteDisplayConfiguration(cfg, .forSession) == .success else {
+                return false
+            }
+            return Self.displayUUID(for: target) == expectedTargetUUID
+                && CGDisplayMirrorsDisplay(target) == source
         }
     }
 
@@ -67,22 +77,67 @@ final class MirrorService: @unchecked Sendable {
     // MARK: - Disable
 
     /// Stops `displayID` from mirroring.
-    /// The entire Begin→Mirror→Complete transaction runs inside `CGHelpers.runWithTimeout`
-    /// so `CGCompleteDisplayConfiguration` cannot block indefinitely on WindowServer IPC.
-    /// - Returns: true on success.
+    /// This is mandatory compensating teardown: it may time out for the caller,
+    /// but remains queued and reports its eventual result through the callback.
+    /// - Returns: the completed result, or `.timedOut` while cleanup remains queued.
     @discardableResult
-    func disableMirror(displayID: CGDirectDisplayID) async -> Bool {
-        return await CGHelpers.runWithTimeout(seconds: 10, fallback: false) {
-            var config: CGDisplayConfigRef?
-            guard CGBeginDisplayConfiguration(&config) == .success,
-                  let cfg = config else { return false }
-            CGConfigureDisplayMirrorOfDisplay(cfg, displayID, kCGNullDirectDisplay)
-            let result = CGCompleteDisplayConfiguration(cfg, .forSession)
-            if result != .success {
-                CGCancelDisplayConfiguration(cfg)
-                return false
-            }
-            return true
+    func disableMirror(
+        displayID: CGDirectDisplayID,
+        expectedSource: CGDirectDisplayID,
+        expectedTargetUUID: String,
+        lateCompletion: @escaping @Sendable (Bool) -> Void = { _ in }
+    ) async -> CGHelpers.TimedResult<Bool> {
+        return await CGHelpers.runMandatoryWithTimeout(
+            seconds: 10,
+            operation: {
+                // Resolve the stable physical target only when this mandatory
+                // body reaches the front of the process-global queue. The ID
+                // captured by the caller may have been reassigned meanwhile.
+                guard let online = Self.onlineDisplayIDs() else { return false }
+                guard let liveTarget = ([displayID] + online).first(where: {
+                    online.contains($0) && Self.displayUUID(for: $0) == expectedTargetUUID
+                }) else {
+                    // The intended panel is gone, so it can no longer depend on
+                    // our virtual master.
+                    return true
+                }
+                // Do not disturb an unrelated mirror relationship. If the
+                // intended panel no longer mirrors this exact virtual, the
+                // requested pair is already dismantled.
+                guard CGDisplayMirrorsDisplay(liveTarget) == expectedSource else { return true }
+                var config: CGDisplayConfigRef?
+                guard CGBeginDisplayConfiguration(&config) == .success,
+                      let cfg = config else { return false }
+                guard CGConfigureDisplayMirrorOfDisplay(
+                    cfg, liveTarget, kCGNullDirectDisplay) == .success else {
+                    CGCancelDisplayConfiguration(cfg)
+                    return false
+                }
+                guard CGCompleteDisplayConfiguration(cfg, .forSession) == .success else {
+                    return false
+                }
+                guard let refreshed = Self.onlineDisplayIDs() else { return false }
+                guard let currentTarget = refreshed.first(where: {
+                    Self.displayUUID(for: $0) == expectedTargetUUID
+                }) else { return true }
+                return CGDisplayMirrorsDisplay(currentTarget) != expectedSource
+            }, lateCompletion: lateCompletion)
+    }
+
+    private static func displayUUID(for displayID: CGDirectDisplayID) -> String {
+        if let cf = CGDisplayCreateUUIDFromDisplayID(displayID),
+           let value = CFUUIDCreateString(nil, cf.takeRetainedValue()) {
+            return value as String
         }
+        return "v\(CGDisplayVendorNumber(displayID))-m\(CGDisplayModelNumber(displayID))"
+            + "-s\(CGDisplaySerialNumber(displayID))"
+    }
+
+    private static func onlineDisplayIDs() -> [CGDirectDisplayID]? {
+        var count: UInt32 = 0
+        guard CGGetOnlineDisplayList(0, nil, &count) == .success else { return nil }
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetOnlineDisplayList(count, &ids, &count) == .success else { return nil }
+        return Array(ids.prefix(Int(count)))
     }
 }

--- a/Crisp/Services/MirroredModeService.swift
+++ b/Crisp/Services/MirroredModeService.swift
@@ -1,5 +1,6 @@
 import CoreGraphics
 import Foundation
+import ApplicationServices
 import os.log
 
 /// True HiDPI past WindowServer's scaled-backing cap (issue #65). On 5K2K
@@ -29,6 +30,47 @@ final class MirroredModeService: ObservableObject {
     /// Live CGVirtualDisplay per mirrored physical display. Releasing a value
     /// is what destroys its virtual display, so this dictionary IS the state.
     private var active: [CGDirectDisplayID: CGVirtualDisplay] = [:]
+    /// Stops declared on each active virtual. A request outside the bounded
+    /// window can rebuild immediately instead of waiting through mode retries.
+    private var declaredStops: [CGDirectDisplayID: Set<PanelResolution>] = [:]
+    /// Virtual IDs whose strong reference was dropped but whose asynchronous
+    /// WindowServer teardown has not yet been confirmed. Stable identity must
+    /// not be recreated until these IDs leave the online list.
+    private var retiringVirtualIDs: [UInt32: CGDirectDisplayID] = [:]
+    /// The descriptor identity associated with each (volatile) physical ID.
+    /// Kept across disconnects so a reconnect under a new CGDirectDisplayID
+    /// still finds teardown state keyed by the stable virtual product ID.
+    private var identityKeysByPhysicalID: [CGDirectDisplayID: UInt32] = [:]
+    private struct PhysicalFingerprint: Equatable {
+        let vendor: UInt32
+        let model: UInt32
+        let serial: UInt32
+        let uuid: String
+    }
+    /// Guards against macOS reusing a numeric display ID for different
+    /// hardware during a reconnect storm.
+    private var fingerprintsByPhysicalID: [CGDirectDisplayID: PhysicalFingerprint] = [:]
+
+    private struct OperationTail {
+        let token: UUID
+        let task: Task<Bool, Never>
+    }
+    /// Serializes every apply/restore/native-size mutation per physical panel.
+    /// MainActor alone is insufficient because these operations await and are
+    /// therefore reentrant.
+    private var operationTails: [UInt32: OperationTail] = [:]
+    /// Physical displays with a mandatory unmirror queued behind a timed-out
+    /// WindowServer call. New operations fail fast until its late completion
+    /// repairs state, while the caller that requested teardown stays bounded.
+    private var deferredCleanupIdentityKeys: Set<UInt32> = []
+    /// Stable identities whose CGVirtualDisplay.apply is still queued/running
+    /// after its caller timed out. No second object with the same descriptor
+    /// identity may be constructed until the late result has been retired.
+    private var deferredCreationIdentityKeys: Set<UInt32> = []
+    /// Failed/timed-out creations kept alive during a bounded registration
+    /// settle. The stable identity lease remains held until the object is
+    /// explicitly released and the online descriptor list is rescanned.
+    private var failedCreationObjects: [UInt32: CGVirtualDisplay] = [:]
 
     /// Published mirror of `active`'s keys so views can observe activity.
     @Published private(set) var activePhysicalIDs: Set<CGDirectDisplayID> = []
@@ -38,6 +80,10 @@ final class MirroredModeService: ObservableObject {
     /// isVirtualDisplay filter treating these as virtual). Lets launch recovery
     /// recognize a stray mirror virtual left by a crash.
     static let mirrorSerialMarker: UInt32 = 0x4D49_5252
+
+    /// Each stop becomes two CGVirtualDisplayMode declarations. Stay below the
+    /// observed ~400-object applySettings ceiling with a little safety margin.
+    private static let maximumVirtualStops = 190
 
     // MARK: - Queries
 
@@ -67,43 +113,99 @@ final class MirroredModeService: ObservableObject {
     func apply(display: DisplayInfo, width: Int, height: Int) async -> Bool {
         guard !display.isBuiltin else { return false }
         let physicalID = display.displayID
+        guard await prepareIdentity(for: display) else { return false }
+
+        return await enqueueOperation(for: physicalID) { [self] in
+            await performApply(display: display, width: width, height: height)
+        }
+    }
+
+    private func performApply(display: DisplayInfo, width: Int, height: Int) async -> Bool {
+        let physicalID = display.displayID
+        let identityKey = Self.mirrorIdentityKey(for: display)
+        guard !deferredCleanupIdentityKeys.contains(identityKey) else {
+            Self.log.error("apply \(width)x\(height): mandatory unmirror is still queued")
+            return false
+        }
+        guard !deferredCreationIdentityKeys.contains(identityKey) else {
+            Self.log.error("apply \(width)x\(height): virtual creation cleanup is still pending")
+            return false
+        }
+        guard await confirmRetiredVirtual(for: physicalID) else {
+            Self.log.error("apply \(width)x\(height): previous virtual is still online")
+            return false
+        }
 
         if let vdID = active[physicalID]?.displayID {
-            guard await setLooksLike(width: width, height: height, on: vdID) else {
-                Self.log.error("apply \(width)x\(height): setLooksLike failed on existing virtual \(vdID)")
-                return false
+            let requested = PanelResolution(width: width, height: height)
+            let isDeclared = declaredStops[physicalID]?.contains(requested) == true
+            if isDeclared, await setLooksLike(width: width, height: height, on: vdID) {
+                // Re-arm the mirror if something dropped it under us (a wake or a
+                // WindowServer reset can collapse a mirror set without telling us).
+                if CGDisplayMirrorsDisplay(physicalID) != vdID {
+                    Self.log.info("apply \(width)x\(height): reused virtual \(vdID), re-arming mirror")
+                    let enabled = await MirrorService.shared.enableMirror(
+                        source: vdID, target: physicalID,
+                        expectedTargetUUID: display.displayUUID)
+                    if !enabled { _ = await performRestore(physicalID: physicalID) }
+                    return enabled
+                }
+                Self.log.info("apply \(width)x\(height): reused virtual \(vdID)")
+                return true
             }
-            // Re-arm the mirror if something dropped it under us (a wake or a
-            // WindowServer reset can collapse a mirror set without telling us).
-            if CGDisplayMirrorsDisplay(physicalID) != vdID {
-                Self.log.info("apply \(width)x\(height): reused virtual \(vdID), re-arming mirror")
-                return await MirrorService.shared.enableMirror(source: vdID, target: physicalID)
-            }
-            Self.log.info("apply \(width)x\(height): reused virtual \(vdID)")
-            return true
+
+            // A manual native-size correction, or movement outside a bounded
+            // very-wide mode window, makes the old virtual's grid obsolete.
+            // Tear it down and rebuild around the requested stop.
+            Self.log.info("apply \(width)x\(height): rebuilding virtual \(vdID), requested stop declared: \(isDeclared)")
+            guard await performRestore(physicalID: physicalID) else { return false }
         }
 
-        guard let virtualDisplay = await createMirrorVirtual(for: display,
-                                                             mustInclude: (width, height))
-        else {
-            Self.log.error("apply \(width)x\(height): createMirrorVirtual failed")
+        // Retirement bookkeeping is process-local. A previous crashed process
+        // can briefly leave the same stable virtual identity online, so verify
+        // the authoritative display list immediately before constructing one.
+        guard await confirmNoUntrackedVirtual(for: physicalID) else {
+            Self.log.error("apply \(width)x\(height): matching mirror virtual is still online")
             return false
         }
-        active[physicalID] = virtualDisplay
+
+        var pendingCreation = await createMirrorVirtual(
+            for: display, mustInclude: (width, height))
+        guard pendingCreation != nil else {
+            Self.log.error("apply \(width)x\(height): createMirrorVirtual failed")
+            // applySettings may have timed out while its serialized blocking
+            // body continued. If it gave the virtual an ID, do not permit the
+            // next attempt to reuse this monitor's stable identity until that
+            // failed object has actually left WindowServer.
+            _ = await confirmRetiredVirtual(for: physicalID)
+            return false
+        }
+        let virtualID: CGDirectDisplayID
+        do {
+            // Limit the local strong reference to this scope. After assigning
+            // `active`, that dictionary must be the sole owner so a failure
+            // cleanup can actually destroy the display before confirming it.
+            guard let created = pendingCreation else { return false }
+            virtualID = created.display.displayID
+            active[physicalID] = created.display
+            declaredStops[physicalID] = created.stops
+        }
+        pendingCreation = nil
         activePhysicalIDs.insert(physicalID)
 
-        guard await setLooksLike(width: width, height: height, on: virtualDisplay.displayID) else {
-            Self.log.error("apply \(width)x\(height): setLooksLike failed on fresh virtual \(virtualDisplay.displayID)")
-            await restore(physicalID: physicalID)
+        guard await setLooksLike(width: width, height: height, on: virtualID) else {
+            Self.log.error("apply \(width)x\(height): setLooksLike failed on fresh virtual \(virtualID)")
+            _ = await performRestore(physicalID: physicalID)
             return false
         }
-        guard await MirrorService.shared.enableMirror(source: virtualDisplay.displayID,
-                                                      target: physicalID) else {
-            Self.log.error("apply \(width)x\(height): enableMirror failed (virtual \(virtualDisplay.displayID) -> physical \(physicalID))")
-            await restore(physicalID: physicalID)
+        guard await MirrorService.shared.enableMirror(source: virtualID,
+                                                      target: physicalID,
+                                                      expectedTargetUUID: display.displayUUID) else {
+            Self.log.error("apply \(width)x\(height): enableMirror failed (virtual \(virtualID) -> physical \(physicalID))")
+            _ = await performRestore(physicalID: physicalID)
             return false
         }
-        Self.log.info("apply \(width)x\(height): mirrored physical \(physicalID) onto virtual \(virtualDisplay.displayID)")
+        Self.log.info("apply \(width)x\(height): mirrored physical \(physicalID) onto virtual \(virtualID)")
         return true
     }
 
@@ -113,27 +215,155 @@ final class MirroredModeService: ObservableObject {
     /// always unmirror first (the probe's verified-safe order).
     @discardableResult
     func restore(display: DisplayInfo) async -> Bool {
-        await restore(physicalID: display.displayID)
+        guard await prepareIdentity(for: display) else { return false }
+        return await restore(physicalID: display.displayID)
     }
 
     @discardableResult
     func restore(physicalID: CGDirectDisplayID) async -> Bool {
+        if identityKeysByPhysicalID[physicalID] == nil,
+           let virtualID = active[physicalID]?.displayID {
+            identityKeysByPhysicalID[physicalID] = CGDisplayModelNumber(virtualID)
+        }
+        return await enqueueOperation(for: physicalID) { [self] in
+            await performRestore(physicalID: physicalID)
+        }
+    }
+
+    /// Changes the panel-resolution source only after any mirror virtual has
+    /// been safely retired. The mutation and the ensuing detail reload stay in
+    /// the same per-display operation, so an apply cannot race in between and
+    /// rebuild from stale dimensions.
+    @discardableResult
+    func updatePanelResolution(
+        for display: DisplayInfo,
+        change: @escaping @MainActor () async -> Void
+    ) async -> Bool {
+        guard await prepareIdentity(for: display) else { return false }
+        return await enqueueOperation(for: display.displayID) { [self] in
+            guard await performRestore(physicalID: display.displayID) else { return false }
+            await change()
+            return true
+        }
+    }
+
+    /// Runs a physical-display mode change after teardown, without allowing a
+    /// new mirror apply to slip between those two steps.
+    @discardableResult
+    func withMirrorRestored(
+        for display: DisplayInfo,
+        operation: @escaping @MainActor () async -> Bool
+    ) async -> Bool {
+        guard await prepareIdentity(for: display) else { return false }
+        return await enqueueOperation(for: display.displayID) { [self] in
+            guard await performRestore(physicalID: display.displayID) else { return false }
+            return await operation()
+        }
+    }
+
+    private func performRestore(physicalID: CGDirectDisplayID) async -> Bool {
+        guard let identityKey = identityKeysByPhysicalID[physicalID],
+              !deferredCleanupIdentityKeys.contains(identityKey) else { return false }
+        guard await confirmRetiredVirtual(for: physicalID) else { return false }
         guard let vdID = active[physicalID]?.displayID else { return true }
+        guard let expectedTargetUUID = fingerprintsByPhysicalID[physicalID]?.uuid else {
+            return false
+        }
         Self.log.info("restore: unmirroring physical \(physicalID), destroying virtual \(vdID)")
-        // Only a confirmed unmirror may let the virtual go. disableMirror's false
-        // covers both a refused transaction and a slow one still in flight
-        // (runWithTimeout's fallback), and in either case the panel may still be
-        // mirroring this virtual; keep the entry, so the master stays alive and
-        // the next slider move or reconcile() gets another go.
-        guard await MirrorService.shared.disableMirror(displayID: physicalID) else {
+        // Only a confirmed unmirror may let the virtual go. Mandatory teardown
+        // waits for older timed-out transactions to drain before it runs, so a
+        // late enable cannot escape this cleanup. If CG still refuses it and the
+        // panel remains a target, keep the master alive for the next retry.
+        deferredCleanupIdentityKeys.insert(identityKey)
+        let disableResult = await MirrorService.shared.disableMirror(
+            displayID: physicalID,
+            expectedSource: vdID,
+            expectedTargetUUID: expectedTargetUUID,
+            lateCompletion: { [weak self] disabled in
+                Task { @MainActor [weak self] in
+                    await self?.finishDeferredRestore(
+                        identityKey: identityKey, physicalID: physicalID,
+                        virtualID: vdID, disabled: disabled)
+                }
+            })
+        switch disableResult {
+        case .timedOut:
+            Self.log.error("restore: unmirror of physical \(physicalID) timed out; cleanup remains queued")
+            return false
+        case .completed(let disabled):
+            deferredCleanupIdentityKeys.remove(identityKey)
+            guard disabled else {
+                Self.log.error("restore: unmirror of physical \(physicalID) failed (result \(disabled)), keeping virtual \(vdID)")
+                return false
+            }
+        }
+
+        guard beginVirtualRetirement(physicalID: physicalID, virtualID: vdID) else {
             Self.log.error("restore: unmirror of physical \(physicalID) failed, keeping virtual \(vdID)")
             return false
         }
-        // Dropping the last reference starts WindowServer's async teardown.
+        return await confirmRetiredVirtual(for: physicalID)
+    }
+
+    private func finishDeferredRestore(
+        identityKey: UInt32,
+        physicalID: CGDirectDisplayID,
+        virtualID: CGDirectDisplayID,
+        disabled: Bool
+    ) async {
+        guard deferredCleanupIdentityKeys.contains(identityKey) else { return }
+        defer { deferredCleanupIdentityKeys.remove(identityKey) }
+
+        guard disabled else {
+            Self.log.error("restore: deferred unmirror of physical \(physicalID) failed (result \(disabled))")
+            return
+        }
+        guard beginVirtualRetirement(physicalID: physicalID, virtualID: virtualID) else {
+            return
+        }
+        _ = await confirmRetiredVirtual(for: physicalID)
+    }
+
+    private func beginVirtualRetirement(
+        physicalID: CGDirectDisplayID,
+        virtualID: CGDirectDisplayID
+    ) -> Bool {
+        guard active[physicalID]?.displayID == virtualID,
+              let identityKey = identityKeysByPhysicalID[physicalID] else { return false }
+        // Dropping the last strong reference starts WindowServer's async teardown.
         active.removeValue(forKey: physicalID)
+        declaredStops.removeValue(forKey: physicalID)
         activePhysicalIDs.remove(physicalID)
-        await waitForDisplayOffline(vdID)
+        retiringVirtualIDs[identityKey] = virtualID
         return true
+    }
+
+    private func enqueueOperation(
+        for physicalID: CGDirectDisplayID,
+        operation: @escaping @MainActor () async -> Bool
+    ) async -> Bool {
+        guard let identityKey = identityKeysByPhysicalID[physicalID] else { return false }
+        let previous = operationTails[identityKey]?.task
+        let token = UUID()
+        let task = Task { @MainActor in
+            _ = await previous?.value
+            guard await prepareQueuedState(for: physicalID, identityKey: identityKey) else {
+                return false
+            }
+            return await operation()
+        }
+        operationTails[identityKey] = OperationTail(token: token, task: task)
+        let result = await task.value
+        if operationTails[identityKey]?.token == token {
+            operationTails.removeValue(forKey: identityKey)
+            // reconcile() deliberately leaves in-flight state alone. Re-read
+            // the online set after the final queued operation so an unplug that
+            // happened during an await cannot leave the virtual retained.
+            if let online = currentOnlineDisplayIDs() {
+                reconcile(online: online)
+            }
+        }
+        return result
     }
 
     /// Keeps the bookkeeping truthful against the fresh online list (called from
@@ -145,10 +375,31 @@ final class MirroredModeService: ObservableObject {
     /// Set-based rather than per removed ID because the mirror virtual is never
     /// in `DisplayManager.displays`, so its death never shows in that diff.
     func reconcile(online: Set<CGDirectDisplayID>) {
-        for (physicalID, virtualDisplay) in active
-        where !online.contains(physicalID) || !online.contains(virtualDisplay.displayID) {
+        for (physicalID, virtualDisplay) in active {
+            let identityKey = identityKeysByPhysicalID[physicalID]
+            guard identityKey.flatMap({ operationTails[$0] }) == nil else { continue }
+            if online.contains(physicalID),
+               let expected = fingerprintsByPhysicalID[physicalID],
+               currentFingerprint(for: physicalID) != expected {
+                // The numeric ID now names different hardware. Keep the master
+                // alive and run the verified unmirror-first path asynchronously.
+                Task { _ = await self.restore(physicalID: physicalID) }
+                continue
+            }
+            guard !online.contains(physicalID)
+                    || !online.contains(virtualDisplay.displayID) else { continue }
+            if online.contains(virtualDisplay.displayID) {
+                if let identityKey {
+                    retiringVirtualIDs[identityKey] = virtualDisplay.displayID
+                }
+            }
             active.removeValue(forKey: physicalID)
+            declaredStops.removeValue(forKey: physicalID)
             activePhysicalIDs.remove(physicalID)
+            if let identityKey { deferredCleanupIdentityKeys.remove(identityKey) }
+        }
+        for (identityKey, virtualID) in retiringVirtualIDs where !online.contains(virtualID) {
+            retiringVirtualIDs.removeValue(forKey: identityKey)
         }
     }
 
@@ -176,7 +427,9 @@ final class MirroredModeService: ObservableObject {
         let hidpiTop = display.availableModes.filter { $0.isHiDPI }.map(\.width).max() ?? 0
         guard hidpiTop > 0 else { return [] }
         return HiDPIService.shared
-            .smoothScaledLogicalSizes(nativeWidth: nativeW, nativeHeight: nativeH)
+            .smoothScaledLogicalSizes(
+                nativeWidth: nativeW, nativeHeight: nativeH,
+                enforcePlatformBackingLimit: false)
             .filter { $0.width > hidpiTop && $0.width < nativeW }
     }
 
@@ -196,7 +449,12 @@ final class MirroredModeService: ObservableObject {
             && CGDisplaySerialNumber(id) == Self.mirrorSerialMarker
             && !active.values.contains(where: { $0.displayID == id }) {
             guard let target = MirrorService.shared.mirrorTargets(of: id) else { continue }
-            Task { await MirrorService.shared.disableMirror(displayID: target) }
+            let targetUUID = Self.displayUUID(for: target)
+            Task {
+                await MirrorService.shared.disableMirror(
+                    displayID: target, expectedSource: id,
+                    expectedTargetUUID: targetUUID)
+            }
         }
     }
 
@@ -206,6 +464,10 @@ final class MirroredModeService: ObservableObject {
     /// also collapse the mirror set, this just makes it orderly.)
     func teardownAll() {
         for physicalID in active.keys {
+            guard let virtualID = active[physicalID]?.displayID,
+                  let expectedUUID = fingerprintsByPhysicalID[physicalID]?.uuid,
+                  Self.displayUUID(for: physicalID) == expectedUUID,
+                  CGDisplayMirrorsDisplay(physicalID) == virtualID else { continue }
             var config: CGDisplayConfigRef?
             guard CGBeginDisplayConfiguration(&config) == .success, let cfg = config else { continue }
             CGConfigureDisplayMirrorOfDisplay(cfg, physicalID, kCGNullDirectDisplay)
@@ -214,6 +476,13 @@ final class MirroredModeService: ObservableObject {
             }
         }
         active.removeAll()
+        declaredStops.removeAll()
+        retiringVirtualIDs.removeAll()
+        identityKeysByPhysicalID.removeAll()
+        fingerprintsByPhysicalID.removeAll()
+        deferredCleanupIdentityKeys.removeAll()
+        deferredCreationIdentityKeys.removeAll()
+        failedCreationObjects.removeAll()
         activePhysicalIDs.removeAll()
     }
 
@@ -228,8 +497,13 @@ final class MirroredModeService: ObservableObject {
     /// (verified live on a 5K2K panel). One refresh rate keeps the dense
     /// ladder under the ~400-object ceiling where applySettings rejects the
     /// whole set.
+    private struct CreatedMirror {
+        let display: CGVirtualDisplay
+        let stops: Set<PanelResolution>
+    }
+
     private func createMirrorVirtual(for display: DisplayInfo,
-                                     mustInclude: (width: Int, height: Int)) async -> CGVirtualDisplay? {
+                                     mustInclude: (width: Int, height: Int)) async -> CreatedMirror? {
         let (nativeW, nativeH) = display.nativeResolution
         guard nativeW > 0, nativeH > 0 else { return nil }
 
@@ -258,17 +532,19 @@ final class MirroredModeService: ObservableObject {
         descriptor.vendorID = VirtualDisplayService.crispVirtualVendorID
         // Stable per monitor; the serial carries the mirror marker. Two
         // identical monitors mirroring at once would collide, accepted edge.
-        let panelIdentity = display.vendorNumber ^ display.modelNumber
-        descriptor.productID = panelIdentity != 0 ? panelIdentity : 0x4D52
+        let panelIdentity = Self.mirrorIdentityKey(for: display)
+        descriptor.productID = panelIdentity
         descriptor.serialNum = Self.mirrorSerialMarker
 
         // Every beyond-cap stop on the smooth-scaling grid, in the same
         // (rotated) space as availableModes and the slider; the requested size
         // is force-included in case it sits off that grid.
-        var stops = Self.beyondCapStops(for: display)
-        if !stops.contains(where: { $0.width == mustInclude.width && $0.height == mustInclude.height }) {
-            stops.append((width: mustInclude.width, height: mustInclude.height))
+        let required = PanelResolution(width: mustInclude.width, height: mustInclude.height)
+        let candidates = Self.beyondCapStops(for: display).map {
+            PanelResolution(width: $0.width, height: $0.height)
         }
+        let stops = MirrorModeGeometry.boundedStops(
+            candidates, including: required, maximumCount: Self.maximumVirtualStops)
 
         // One rate only (the panel's own, 60 when unreadable): every stop costs
         // TWO mode objects below, and a second rate would put a dense ladder
@@ -308,15 +584,28 @@ final class MirroredModeService: ObservableObject {
         // CG transaction (same as VirtualDisplayService.create).
         let vd = virtualDisplay
         let s = settings
-        let applied: Bool = await CGHelpers.runWithTimeout(seconds: 10, fallback: false) {
-            vd.apply(s)
+        deferredCreationIdentityKeys.insert(panelIdentity)
+        let applyResult = await CGHelpers.runMandatoryWithTimeout(
+            seconds: 10,
+            operation: { vd.apply(s) },
+            lateCompletion: { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.stageFailedCreation(
+                        identityKey: panelIdentity, virtualDisplay: vd)
+                }
+            })
+        guard case .completed(let applied) = applyResult else {
+            Self.log.error("createMirrorVirtual: applySettings timed out; identity lease retained")
+            return nil
         }
         guard applied, virtualDisplay.displayID != kCGNullDirectDisplay else {
             Self.log.error("createMirrorVirtual: applySettings \(applied ? "ok but null displayID" : "failed") (\(modes.count) modes)")
+            stageFailedCreation(identityKey: panelIdentity, virtualDisplay: virtualDisplay)
             return nil
         }
+        deferredCreationIdentityKeys.remove(panelIdentity)
         Self.log.info("createMirrorVirtual: virtual \(virtualDisplay.displayID) up, \(modes.count) modes declared")
-        return virtualDisplay
+        return CreatedMirror(display: virtualDisplay, stops: Set(stops))
     }
 
     // MARK: - Helpers
@@ -351,12 +640,215 @@ final class MirroredModeService: ObservableObject {
     /// Waits (bounded) for a torn-down virtual display to leave the online
     /// list; same event-driven pattern as VirtualDisplayService, duplicated
     /// because both keep it private to their own teardown story.
-    private func waitForDisplayOffline(_ displayID: CGDirectDisplayID) async {
+    private func confirmRetiredVirtual(for physicalID: CGDirectDisplayID) async -> Bool {
+        guard let identityKey = identityKeysByPhysicalID[physicalID],
+              let virtualID = retiringVirtualIDs[identityKey] else { return true }
+        guard await waitForDisplayOffline(virtualID) else {
+            Self.log.error("restore: virtual \(virtualID) is still online; refusing stable-identity reuse")
+            return false
+        }
+        retiringVirtualIDs.removeValue(forKey: identityKey)
+        return true
+    }
+
+    private func stageFailedCreation(
+        identityKey: UInt32,
+        virtualDisplay: CGVirtualDisplay
+    ) {
+        guard deferredCreationIdentityKeys.contains(identityKey) else { return }
+        failedCreationObjects[identityKey] = virtualDisplay
+        Task { @MainActor [weak self] in
+            await self?.settleFailedCreation(identityKey: identityKey)
+        }
+    }
+
+    private func settleFailedCreation(identityKey: UInt32) async {
+        guard deferredCreationIdentityKeys.contains(identityKey) else { return }
+
+        // apply(_:) can return before WindowServer publishes displayID. Hold the
+        // object and lease through a bounded registration window.
+        var virtualID = kCGNullDirectDisplay
+        for _ in 0..<15 {
+            virtualID = failedCreationObjects[identityKey]?.displayID ?? kCGNullDirectDisplay
+            if virtualID != kCGNullDirectDisplay { break }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        if virtualID != kCGNullDirectDisplay {
+            retiringVirtualIDs[identityKey] = virtualID
+        }
+
+        // Explicitly release the failed display, then rescan its stable
+        // descriptor identity in case registration raced the last ID sample.
+        failedCreationObjects.removeValue(forKey: identityKey)
+        await Task.yield()
+        if virtualID == kCGNullDirectDisplay {
+            for _ in 0..<15 {
+                let scan = matchingOnlineMirrorVirtual(identityKey: identityKey)
+                if let conflict = scan.displayID {
+                    virtualID = conflict
+                    retiringVirtualIDs[identityKey] = conflict
+                    break
+                }
+                try? await Task.sleep(nanoseconds: 100_000_000)
+            }
+            if virtualID == kCGNullDirectDisplay {
+                // Only a successful scan at the END of the settle window can
+                // prove that a late registration did not appear. An earlier
+                // empty result becomes stale if the trailing queries fail.
+                let finalScan = matchingOnlineMirrorVirtual(identityKey: identityKey)
+                if let conflict = finalScan.displayID {
+                    virtualID = conflict
+                    retiringVirtualIDs[identityKey] = conflict
+                } else if !finalScan.succeeded {
+                    Self.log.error("createMirrorVirtual: final online rescan failed; identity lease retained")
+                    Task { @MainActor [weak self] in
+                        try? await Task.sleep(nanoseconds: 1_000_000_000)
+                        await self?.settleFailedCreation(identityKey: identityKey)
+                    }
+                    return
+                }
+            }
+        }
+
+        deferredCreationIdentityKeys.remove(identityKey)
+        guard virtualID != kCGNullDirectDisplay else { return }
+        guard await waitForDisplayOffline(virtualID) else {
+            Self.log.error("createMirrorVirtual: failed virtual \(virtualID) remains online")
+            return
+        }
+        if retiringVirtualIDs[identityKey] == virtualID {
+            retiringVirtualIDs.removeValue(forKey: identityKey)
+        }
+    }
+
+    private func matchingOnlineMirrorVirtual(
+        identityKey: UInt32
+    ) -> (succeeded: Bool, displayID: CGDirectDisplayID?) {
+        guard let online = currentOnlineDisplayIDs() else { return (false, nil) }
+        let conflict = online.first { candidate in
+            Self.isMirrorVirtual(candidate) && CGDisplayModelNumber(candidate) == identityKey
+                && !active.values.contains(where: { $0.displayID == candidate })
+        }
+        return (true, conflict)
+    }
+
+    private func confirmNoUntrackedVirtual(for physicalID: CGDirectDisplayID) async -> Bool {
+        guard let identityKey = identityKeysByPhysicalID[physicalID] else { return false }
+        guard !deferredCreationIdentityKeys.contains(identityKey) else { return false }
+        while true {
+            guard let online = currentOnlineDisplayIDs() else { return false }
+            let currentPhysicalVirtualID = active[physicalID]?.displayID
+            let conflicts = online.filter {
+                $0 != currentPhysicalVirtualID
+                    && Self.isMirrorVirtual($0)
+                    && CGDisplayModelNumber($0) == identityKey
+            }
+            guard let conflict = conflicts.first else { return true }
+
+            // Another physical panel with the same descriptor identity may own
+            // one of these virtuals. Reject without poisoning its retirement
+            // record; its owner must remain able to restore itself.
+            if conflicts.contains(where: { conflictID in
+                active.values.contains(where: { $0.displayID == conflictID })
+            }) {
+                Self.log.error("createMirrorVirtual: identity \(identityKey) is owned by another active virtual")
+                return false
+            }
+
+            retiringVirtualIDs[identityKey] = conflict
+            guard await confirmRetiredVirtual(for: physicalID) else { return false }
+            // Re-read the authoritative list: more than one crash stray can
+            // share the same descriptor identity.
+        }
+    }
+
+    private static func mirrorIdentityKey(for display: DisplayInfo) -> UInt32 {
+        let panelIdentity = display.vendorNumber ^ display.modelNumber
+        return panelIdentity != 0 ? panelIdentity : 0x4D52
+    }
+
+    private func prepareIdentity(for display: DisplayInfo) async -> Bool {
+        let physicalID = display.displayID
+        let fingerprint = Self.fingerprint(for: display)
+        guard currentFingerprint(for: physicalID) == fingerprint else {
+            Self.log.error("operation rejected: physical ID \(physicalID) now names different hardware")
+            return false
+        }
+
+        if let previousFingerprint = fingerprintsByPhysicalID[physicalID],
+           previousFingerprint != fingerprint {
+            guard identityKeysByPhysicalID[physicalID] != nil else { return false }
+            let cleaned = await enqueueOperation(for: physicalID) { [self] in
+                await performRestore(physicalID: physicalID)
+            }
+            guard cleaned else { return false }
+        }
+
+        identityKeysByPhysicalID[physicalID] = Self.mirrorIdentityKey(for: display)
+        fingerprintsByPhysicalID[physicalID] = fingerprint
+        return true
+    }
+
+    private static func fingerprint(for display: DisplayInfo) -> PhysicalFingerprint {
+        PhysicalFingerprint(vendor: display.vendorNumber, model: display.modelNumber,
+                            serial: display.serialNumber, uuid: display.displayUUID)
+    }
+
+    private func currentFingerprint(for physicalID: CGDirectDisplayID) -> PhysicalFingerprint {
+        PhysicalFingerprint(vendor: CGDisplayVendorNumber(physicalID),
+                            model: CGDisplayModelNumber(physicalID),
+                            serial: CGDisplaySerialNumber(physicalID),
+                            uuid: Self.displayUUID(for: physicalID))
+    }
+
+    private func prepareQueuedState(
+        for physicalID: CGDirectDisplayID,
+        identityKey: UInt32
+    ) async -> Bool {
+        guard let online = currentOnlineDisplayIDs() else { return false }
+        for (storedID, _) in active
+        where identityKeysByPhysicalID[storedID] == identityKey {
+            let storedPanelStillLive = online.contains(storedID)
+                && fingerprintsByPhysicalID[storedID] == currentFingerprint(for: storedID)
+            // A distinct, still-live identical panel is a real identity-key
+            // collision. Leave its mirror alone; the conflict scan will reject
+            // creating a second descriptor with that key.
+            if storedPanelStillLive { continue }
+            if !(await performRestore(physicalID: storedID)) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func displayUUID(for displayID: CGDirectDisplayID) -> String {
+        if let cf = CGDisplayCreateUUIDFromDisplayID(displayID),
+           let value = CFUUIDCreateString(nil, cf.takeRetainedValue()) {
+            return value as String
+        }
+        return "v\(CGDisplayVendorNumber(displayID))-m\(CGDisplayModelNumber(displayID))"
+            + "-s\(CGDisplaySerialNumber(displayID))"
+    }
+
+    private func isDisplayOnline(_ displayID: CGDirectDisplayID) -> Bool {
+        // A failed query is not evidence of removal; conservatively retain the
+        // identity and let a later callback/retry confirm it.
+        currentOnlineDisplayIDs()?.contains(displayID) ?? true
+    }
+
+    private func currentOnlineDisplayIDs() -> Set<CGDirectDisplayID>? {
         var count: UInt32 = 0
-        CGGetOnlineDisplayList(0, nil, &count)
+        guard CGGetOnlineDisplayList(0, nil, &count) == .success else { return nil }
         var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
-        CGGetOnlineDisplayList(count, &ids, &count)
-        guard ids.contains(displayID) else { return }
+        guard CGGetOnlineDisplayList(count, &ids, &count) == .success else { return nil }
+        return Set(ids.prefix(Int(count)))
+    }
+
+    /// The remove event is only a wake-up hint: always re-read the authoritative
+    /// online list before allowing the stable identity to be created again.
+    private func waitForDisplayOffline(_ displayID: CGDirectDisplayID) async -> Bool {
+        guard isDisplayOnline(displayID) else { return true }
         await ReconfigEvents.shared.next(for: displayID, matching: .removeFlag, timeout: 1.5)
+        return !isDisplayOnline(displayID)
     }
 }

--- a/Crisp/Services/PanelResolutionDetector.swift
+++ b/Crisp/Services/PanelResolutionDetector.swift
@@ -1,0 +1,134 @@
+import Foundation
+import IOKit
+import IOKit.graphics
+
+/// Native-size evidence read from the IORegistry. On Intel, raw IODisplayEDID is
+/// commonly available. Apple Silicon DCP often withholds the raw bytes but publishes
+/// the EDID-derived NativeFormatHorizontalPixels/NativeFormatVerticalPixels pair.
+struct DetectedPanelResolution {
+    let edid: PanelResolution?
+    let registry: PanelResolution?
+}
+
+enum PanelResolutionDetector {
+    static func detect(vendor: UInt32, product: UInt32, serial: UInt32) -> DetectedPanelResolution {
+        var evidence = PanelResolutionEvidence()
+
+        // Query only services that can carry display identity/native-format data.
+        // A recursive walk from the IORegistry root visits thousands of unrelated
+        // entries on Apple Silicon and can add hundreds of milliseconds per display.
+        for serviceClass in displayServiceClasses {
+            var iterator: io_iterator_t = 0
+            let result = serviceClass.withCString { className in
+                IOServiceGetMatchingServices(
+                    kIOMainPortDefault, IOServiceMatching(className), &iterator)
+            }
+            guard result == KERN_SUCCESS else { continue }
+            defer { IOObjectRelease(iterator) }
+
+            var entry = IOIteratorNext(iterator)
+            while entry != IO_OBJECT_NULL {
+                let matched = properties(of: entry).map {
+                    inspect($0, vendor: vendor, product: product, serial: serial,
+                            evidence: &evidence)
+                } ?? false
+                IOObjectRelease(entry)
+
+                // Intel commonly yields EDID from IODisplayConnect; DCP systems
+                // commonly yield NativeFormat from AppleCLCD2/framebuffer nodes.
+                // Once the matching node supplied either source, this is all the
+                // current platform exposes and there is no reason to keep walking.
+                if matched, evidence.hasResolution {
+                    return DetectedPanelResolution(edid: evidence.edid, registry: evidence.registry)
+                }
+                entry = IOIteratorNext(iterator)
+            }
+        }
+
+        return DetectedPanelResolution(edid: evidence.edid, registry: evidence.registry)
+    }
+
+    private static var displayServiceClasses: [String] {
+#if arch(arm64)
+        // DCP display properties live on AppleCLCD2 or its newer shim. Keep
+        // IODisplayConnect as a fallback for third-party/DisplayLink drivers.
+        ["AppleCLCD2", "IOMobileFramebufferShim", "IODisplayConnect"]
+#else
+        ["IODisplayConnect"]
+#endif
+    }
+
+    private static func properties(of entry: io_registry_entry_t) -> [String: Any]? {
+        var unmanaged: Unmanaged<CFMutableDictionary>?
+        guard IORegistryEntryCreateCFProperties(
+            entry, &unmanaged, kCFAllocatorDefault, 0
+        ) == KERN_SUCCESS, let dictionary = unmanaged?.takeRetainedValue() else { return nil }
+        return dictionary as? [String: Any]
+    }
+
+    @discardableResult
+    private static func inspect(_ properties: [String: Any], vendor: UInt32, product: UInt32,
+                                serial: UInt32,
+                                evidence: inout PanelResolutionEvidence) -> Bool {
+        var matched = false
+        if let data = properties[kIODisplayEDIDKey as String] as? Data,
+           edidIdentityMatches(data, vendor: vendor, product: product, serial: serial) {
+            matched = true
+            evidence.recordEDID(data)
+        }
+
+        guard let attributes = properties["DisplayAttributes"] as? [String: Any],
+              let identity = attributes["ProductAttributes"] as? [String: Any],
+              identityMatches(identity, vendor: vendor, product: product, serial: serial)
+        else { return matched }
+
+        if let data = attributes[kIODisplayEDIDKey as String] as? Data {
+            evidence.recordEDID(data)
+        }
+
+        // NativeFormat has appeared both directly under DisplayAttributes and
+        // under ProductAttributes across DCP generations; accept either shape.
+        if let width = int(attributes["NativeFormatHorizontalPixels"])
+            ?? int(identity["NativeFormatHorizontalPixels"]),
+           let height = int(attributes["NativeFormatVerticalPixels"])
+            ?? int(identity["NativeFormatVerticalPixels"]) {
+            evidence.recordRegistry(width: width, height: height)
+        }
+        return true
+    }
+
+    private static func identityMatches(_ identity: [String: Any], vendor: UInt32,
+                                        product: UInt32, serial: UInt32) -> Bool {
+        guard uint32(identity["LegacyManufacturerID"]) == vendor,
+              uint32(identity["ProductID"]) == product else { return false }
+        let candidateSerial = uint32(identity["SerialNumber"]) ?? 0
+        return serial == 0 || candidateSerial == 0 || serial == candidateSerial
+    }
+
+    /// EDID manufacturer is big-endian; product and serial are little-endian.
+    private static func edidIdentityMatches(_ data: Data, vendor: UInt32,
+                                            product: UInt32, serial: UInt32) -> Bool {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 16 else { return false }
+        let edidVendor = UInt32(bytes[8]) << 8 | UInt32(bytes[9])
+        let edidProduct = UInt32(bytes[10]) | UInt32(bytes[11]) << 8
+        let edidSerial = UInt32(bytes[12]) | UInt32(bytes[13]) << 8
+            | UInt32(bytes[14]) << 16 | UInt32(bytes[15]) << 24
+        return edidVendor == vendor && edidProduct == product
+            && (serial == 0 || edidSerial == 0 || serial == edidSerial)
+    }
+
+    private static func uint32(_ value: Any?) -> UInt32? {
+        if let value = value as? UInt32 { return value }
+        if let value = value as? Int { return UInt32(truncatingIfNeeded: value) }
+        if let value = value as? NSNumber { return value.uint32Value }
+        return nil
+    }
+
+    private static func int(_ value: Any?) -> Int? {
+        if let value = value as? Int { return value }
+        if let value = value as? UInt32 { return Int(value) }
+        if let value = value as? NSNumber { return value.intValue }
+        return nil
+    }
+}

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -3,6 +3,26 @@ import CoreGraphics
 import ColorSync
 import IOKit
 
+private final class PhysicalToggleReservations: @unchecked Sendable {
+    private let lock = NSLock()
+    private var disabledUUIDs: Set<String> = []
+
+    func contains(_ uuid: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        return disabledUUIDs.contains(uuid)
+    }
+
+    func insert(_ uuid: String) {
+        lock.lock(); defer { lock.unlock() }
+        disabledUUIDs.insert(uuid)
+    }
+
+    func remove(_ uuid: String) {
+        lock.lock(); defer { lock.unlock() }
+        disabledUUIDs.remove(uuid)
+    }
+}
+
 /// Disconnects / reconnects REAL (physical) displays on the fly, the way BetterDisplay's
 /// "Disconnect Display" works. This is fundamentally different from VirtualDisplayService:
 /// there we create/destroy a CGVirtualDisplay object; here we toggle an existing hardware
@@ -19,6 +39,7 @@ import IOKit
 @MainActor
 final class PhysicalDisplayToggleService: ObservableObject {
     static let shared = PhysicalDisplayToggleService()
+    nonisolated private static let toggleReservations = PhysicalToggleReservations()
     private init() {
         loadDesired()
     }
@@ -66,30 +87,66 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// auto-HiDPI path (autoEnableHiDPIIfNeeded) can blink two different displays at once,
     /// and each needs its own marker. See softReconnect / recoverStrandedSoftReconnect.
     private let softReconnectPendingKey = "crisp.PhysicalDisplayToggleService.softReconnectPending"
+    /// Last numeric ID for each marker above. WindowServer's all-screens-black
+    /// placeholder can temporarily be the only SLS entry, but enable still
+    /// accepts the disabled panel's last-known ID.
+    private let softReconnectLastKnownIDsKey =
+        "crisp.PhysicalDisplayToggleService.softReconnectLastKnownIDs"
     /// UUIDs of displays whose softReconnect is mid-blink right now. Their markers above are
     /// legitimately set for that whole window, and the blink's own removeFlag event fires
     /// refreshDisplays (and thus recoverStrandedSoftReconnect) before the toggle finishes;
     /// this keeps the recovery path and the sweep from re-enabling a display out from under
     /// its own retry loop. Per-display, so concurrent blinks don't mask each other.
     private var softReconnectInFlight: Set<String> = []
+    /// User disconnects whose serialized SLS transaction has not reached a
+    /// verified online/offline outcome yet. Their pre-persisted reconnect row
+    /// must survive display-list refreshes and process termination.
+    private var pendingDisconnectUUIDs: Set<String> = []
+    /// De-duplicates the delayed postcondition checks used when display
+    /// enumeration itself is temporarily unavailable.
+    private var disconnectVerificationRetryUUIDs: Set<String> = []
 
     private func pendingSoftReconnectUUIDs() -> [String] {
         UserDefaults.standard.stringArray(forKey: softReconnectPendingKey) ?? []
     }
 
-    private func addPendingSoftReconnect(_ displayUUID: String) {
+    private func pendingSoftReconnectLastKnownIDs() -> [String: CGDirectDisplayID] {
+        let stored = UserDefaults.standard.dictionary(forKey: softReconnectLastKnownIDsKey) ?? [:]
+        return stored.reduce(into: [:]) { result, entry in
+            if let number = entry.value as? NSNumber {
+                result[entry.key] = number.uint32Value
+            }
+        }
+    }
+
+    private func addPendingSoftReconnect(
+        _ displayUUID: String,
+        displayID: CGDirectDisplayID
+    ) {
         var pending = pendingSoftReconnectUUIDs()
-        guard !pending.contains(displayUUID) else { return }
-        pending.append(displayUUID)
-        UserDefaults.standard.set(pending, forKey: softReconnectPendingKey)
+        if !pending.contains(displayUUID) {
+            pending.append(displayUUID)
+            UserDefaults.standard.set(pending, forKey: softReconnectPendingKey)
+        }
+        var lastKnownIDs = pendingSoftReconnectLastKnownIDs()
+        lastKnownIDs[displayUUID] = displayID
+        UserDefaults.standard.set(lastKnownIDs, forKey: softReconnectLastKnownIDsKey)
     }
 
     private func removePendingSoftReconnect(_ displayUUID: String) {
+        Self.toggleReservations.remove(displayUUID)
         let pending = pendingSoftReconnectUUIDs().filter { $0 != displayUUID }
         if pending.isEmpty {
             UserDefaults.standard.removeObject(forKey: softReconnectPendingKey)
         } else {
             UserDefaults.standard.set(pending, forKey: softReconnectPendingKey)
+        }
+        var lastKnownIDs = pendingSoftReconnectLastKnownIDs()
+        lastKnownIDs.removeValue(forKey: displayUUID)
+        if lastKnownIDs.isEmpty {
+            UserDefaults.standard.removeObject(forKey: softReconnectLastKnownIDsKey)
+        } else {
+            UserDefaults.standard.set(lastKnownIDs, forKey: softReconnectLastKnownIDsKey)
         }
     }
 
@@ -121,10 +178,15 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// All display IDs known to the window server, INCLUDING ones disabled via
     /// `SLSConfigureDisplayEnabled` (which `CGGetOnlineDisplayList` omits).
     private func allDisplaysIncludingDisabled() -> [CGDirectDisplayID] {
+        Self.allDisplayIDsIncludingDisabled() ?? []
+    }
+
+    nonisolated private static func allDisplayIDsIncludingDisabled() -> [CGDirectDisplayID]? {
         var count: UInt32 = 0
-        guard SLSGetDisplayList(0, nil, &count) == .success, count > 0 else { return [] }
+        guard SLSGetDisplayList(0, nil, &count) == .success else { return nil }
+        guard count > 0 else { return [] }
         var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
-        guard SLSGetDisplayList(count, &ids, &count) == .success else { return [] }
+        guard SLSGetDisplayList(count, &ids, &count) == .success else { return nil }
         return Array(ids.prefix(Int(count)))
     }
 
@@ -151,11 +213,16 @@ final class PhysicalDisplayToggleService: ObservableObject {
     }
 
     private func uuid(for displayID: CGDirectDisplayID) -> String {
+        Self.uuid(for: displayID)
+    }
+
+    nonisolated private static func uuid(for displayID: CGDirectDisplayID) -> String {
         if let cf = CGDisplayCreateUUIDFromDisplayID(displayID),
            let s = CFUUIDCreateString(nil, cf.takeRetainedValue()) {
             return s as String
         }
-        return "id-\(displayID)"
+        return "v\(CGDisplayVendorNumber(displayID))-m\(CGDisplayModelNumber(displayID))"
+            + "-s\(CGDisplaySerialNumber(displayID))"
     }
 
     // MARK: - Disconnect / Reconnect
@@ -165,8 +232,23 @@ final class PhysicalDisplayToggleService: ObservableObject {
     @discardableResult
     func disconnect(_ display: DisplayInfo) async -> Result<Void, ToggleError> {
         guard isSupported else { return .failure(.unsupportedPlatform) }
+        guard !pendingDisconnectUUIDs.contains(display.displayUUID) else {
+            return .failure(.configurationFailed(.failure))
+        }
         let displayID = display.displayID
         if wouldLeaveNoActiveDisplay(displayID) { return .failure(.wouldLeaveNoActiveDisplay) }
+
+        var disconnectResult: Result<Void, ToggleError>?
+        let mirrorRestored = await MirroredModeService.shared.withMirrorRestored(for: display) {
+            disconnectResult = await self.performDisconnect(display)
+            return true
+        }
+        guard mirrorRestored else { return .failure(.configurationFailed(.failure)) }
+        return disconnectResult ?? .failure(.configurationFailed(.failure))
+    }
+
+    private func performDisconnect(_ display: DisplayInfo) async -> Result<Void, ToggleError> {
+        let displayID = display.displayID
 
         // Snapshot BEFORE disabling, afterwards the display is gone from the normal APIs.
         let snapshot = DisconnectedDisplay(
@@ -177,13 +259,23 @@ final class PhysicalDisplayToggleService: ObservableObject {
             height: display.pixelHeight
         )
 
-        let result = await setEnabled(false, displayID: displayID)
-        if case .success = result {
-            disconnected.removeAll { $0.uuid == snapshot.uuid }
-            disconnected.append(snapshot)
-            saveDesired()
+        // Persist before the blocking transaction. If it times out after the
+        // disable side effect (or the app exits), a Reconnect row still exists.
+        recordDisconnected(snapshot)
+        pendingDisconnectUUIDs.insert(snapshot.uuid)
+        let timed = await setEnabled(
+            false, displayID: displayID, expectedUUID: snapshot.uuid,
+            lateCompletion: { [weak self] result in
+                Task { @MainActor [weak self] in
+                    _ = await self?.finishDisconnect(snapshot, apiResult: result)
+                }
+            })
+        switch timed {
+        case .completed(let result):
+            return await finishDisconnect(snapshot, apiResult: result)
+        case .timedOut:
+            return .failure(.configurationFailed(.failure))
         }
-        return result
     }
 
     /// Reconnects a previously disconnected display and drops it from the disconnected set.
@@ -195,12 +287,19 @@ final class PhysicalDisplayToggleService: ObservableObject {
         }
         // The CGDirectDisplayID can be reassigned; re-resolve by UUID against the full list.
         let targetID = resolveCurrentID(for: record) ?? record.displayID
-        let result = await setEnabled(true, displayID: targetID)
-        if case .success = result {
-            disconnected.removeAll { $0.uuid == uuid }
-            saveDesired()
+        let timed = await setEnabled(
+            true, displayID: targetID, expectedUUID: uuid,
+            lateCompletion: { [weak self] result in
+                Task { @MainActor [weak self] in
+                    _ = await self?.finishReconnect(uuid: uuid, apiResult: result)
+                }
+            })
+        switch timed {
+        case .completed(let result):
+            return await finishReconnect(uuid: uuid, apiResult: result)
+        case .timedOut:
+            return .failure(.configurationFailed(.failure))
         }
-        return result
     }
 
     /// Finds the current CGDirectDisplayID for a disconnected record by matching its UUID
@@ -256,7 +355,7 @@ final class PhysicalDisplayToggleService: ObservableObject {
         // (no clamshell rule). Refuse only if the guard can't be created: blinking into a
         // guaranteed mid-toggle sleep is how displays get stranded.
         var sleepGuard: CGVirtualDisplay?
-        if Self.hasBattery && wouldLeaveNoActiveDisplay(startID) {
+        if Self.hasBattery && !Self.canDisableWithoutBlackingOut(startID) {
             // Reuse a guard parked by a previous unresolved blink first: the fixed identity
             // can't exist twice, so creating a fresh one alongside it would just fail.
             sleepGuard = lingeringSleepGuard
@@ -273,11 +372,26 @@ final class PhysicalDisplayToggleService: ObservableObject {
         // nothing left to bring it back. recoverStrandedSoftReconnect checks this at the next
         // launch. Cleared as soon as the display is verifiably back online, or immediately
         // below if the disable itself never happened.
-        addPendingSoftReconnect(blinkUUID)
-        guard case .success = await setEnabled(false, displayID: startID) else {
-            removePendingSoftReconnect(blinkUUID)
-            return false
-        }
+        addPendingSoftReconnect(blinkUUID, displayID: startID)
+        let disableResult = await setEnabled(
+            false, displayID: startID, expectedUUID: blinkUUID,
+            // A desktop may intentionally blink its sole panel. On a portable,
+            // however, only the live virtual guard makes that safe. Re-check in
+            // the serialized transaction so another display reserved after the
+            // preflight cannot turn this into an unguarded last-panel disable.
+            protectLastDisplay: Self.hasBattery && sleepGuard == nil,
+            lateCompletion: { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    // Let the timed-out caller unwind its in-flight claim, then
+                    // consume the durable marker whether the late disable
+                    // succeeded, failed, or landed despite an error result.
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                    await self?.recoverStrandedSoftReconnect()
+                }
+            })
+        guard finishSoftReconnectDisable(
+            disableResult, uuid: blinkUUID, sleepGuard: sleepGuard
+        ) else { return false }
         // Wait for the framebuffer to actually drop (removeFlag) before re-enabling;
         // the 0.9s ceiling matches the old fixed sleep if the event never comes.
         await ReconfigEvents.shared.next(for: startID, matching: .removeFlag, timeout: 0.9)
@@ -291,7 +405,9 @@ final class PhysicalDisplayToggleService: ObservableObject {
             // rebuild (observed live), which would hold the mode restore below hostage
             // behind a blocked call and turn it into a second visible blink ~10s after the
             // toggle. Enumeration is the only proof either way.
-            Task { _ = await setEnabled(true, displayID: targetID) }
+            Task {
+                _ = await setEnabled(true, displayID: targetID, expectedUUID: blinkUUID)
+            }
             // The verify window must outlast a display link handshake (2-4s): re-issuing
             // enable while the display is mid-sync restarts the link and blinks it again.
             if await verifyBackOnline(uuid: blinkUUID, timeout: 4.0) { backOnline = true; break }
@@ -320,6 +436,7 @@ final class PhysicalDisplayToggleService: ObservableObject {
             return false
         }
         removePendingSoftReconnect(blinkUUID)
+        Self.toggleReservations.remove(blinkUUID)
         if let previousMode,
            let backID = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == blinkUUID }) {
             // The blink re-reads override plists, which rebuilds the mode list and renumbers
@@ -351,24 +468,182 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// Runs SLSConfigureDisplayEnabled inside a CG configuration transaction.
     /// `.permanently` is the flag the proven implementations (Lunar BlackOut, screen_tune,
     /// BetterDisplay) use, it commits the change so the disconnect actually takes effect.
-    private func setEnabled(_ enabled: Bool, displayID: CGDirectDisplayID) async -> Result<Void, ToggleError> {
-        await CGHelpers.runWithTimeout(seconds: 10, fallback: .failure(.configurationFailed(.failure))) {
+    private func setEnabled(
+        _ enabled: Bool,
+        displayID: CGDirectDisplayID,
+        expectedUUID: String,
+        protectLastDisplay: Bool = true,
+        lateCompletion: @escaping @Sendable (Result<Void, ToggleError>) -> Void = { _ in }
+    ) async -> CGHelpers.TimedResult<Result<Void, ToggleError>> {
+        await CGHelpers.runMandatoryWithTimeout(seconds: 10, operation: {
+            // Resolve at execution time. A request can wait behind a blocked
+            // WindowServer transaction long enough for its numeric ID to be
+            // reassigned to unrelated hardware.
+            guard let allIDs = Self.allDisplayIDsIncludingDisabled() else {
+                return .failure(.displayNotFound)
+            }
+            let resolved = ([displayID] + allIDs).first(where: {
+                Self.uuid(for: $0) == expectedUUID
+                    && (allIDs.contains($0) || $0 == displayID)
+            })
+            // In the all-screens-black placeholder state, SLS omits the real
+            // disabled panel but still honors its last-known ID for an enable.
+            // Never use that fallback for disable, and never when the ID is
+            // visibly assigned to a different SLS display.
+            let liveID = resolved ?? (enabled && !allIDs.contains(displayID) ? displayID : nil)
+            guard let liveID else { return .failure(.displayNotFound) }
+            if !enabled, protectLastDisplay,
+               !Self.canDisableWithoutBlackingOut(liveID) {
+                return .failure(.wouldLeaveNoActiveDisplay)
+            }
+            if !enabled { Self.toggleReservations.insert(expectedUUID) }
             var config: CGDisplayConfigRef?
             guard CGBeginDisplayConfiguration(&config) == .success, let cfg = config else {
+                if !enabled { Self.toggleReservations.remove(expectedUUID) }
                 return .failure(.configurationFailed(.failure))
             }
-            let setErr = SLSConfigureDisplayEnabled(cfg, displayID, enabled)
+            let setErr = SLSConfigureDisplayEnabled(cfg, liveID, enabled)
             guard setErr == .success else {
                 CGCancelDisplayConfiguration(cfg)
+                if !enabled { Self.toggleReservations.remove(expectedUUID) }
                 return .failure(.configurationFailed(setErr))
             }
             let complete = CGCompleteDisplayConfiguration(cfg, .permanently)
             guard complete == .success else {
-                CGCancelDisplayConfiguration(cfg)
                 return .failure(.configurationFailed(complete))
             }
+            if enabled { Self.toggleReservations.remove(expectedUUID) }
+            return .success(())
+        }, lateCompletion: lateCompletion)
+    }
+
+    nonisolated private static func canDisableWithoutBlackingOut(
+        _ displayID: CGDirectDisplayID
+    ) -> Bool {
+        guard CGDisplayIsActive(displayID) != 0 else { return true }
+        var count: UInt32 = 0
+        guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return false }
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetActiveDisplayList(count, &ids, &count) == .success else { return false }
+        let remainingPhysicalCount = ids.prefix(Int(count)).filter { id in
+            guard id != displayID else { return false }
+            let vendor = CGDisplayVendorNumber(id)
+            let model = CGDisplayModelNumber(id)
+            let isPlaceholder = vendor == 0x756E6B6E && model == 0x76697274
+            return vendor != 0xEEEE && !isPlaceholder
+                && !toggleReservations.contains(uuid(for: id))
+        }.count
+        return remainingPhysicalCount > 0
+    }
+
+    private func finishSoftReconnectDisable(
+        _ result: CGHelpers.TimedResult<Result<Void, ToggleError>>,
+        uuid displayUUID: String,
+        sleepGuard: CGVirtualDisplay?
+    ) -> Bool {
+        switch result {
+        case .completed(.success):
+            return true
+        case .completed(.failure):
+            // A completed failure can still leave the requested state applied.
+            // Its operation is no longer pending, so delayed recovery is safe.
+            if sleepGuard != nil { lingeringSleepGuard = sleepGuard }
+            scheduleStrandedSoftReconnectRecovery()
+            return false
+        case .timedOut:
+            // The operation may still be queued. Recovering now could observe
+            // the panel online, clear the marker, and then have the late disable
+            // land. Keep the guard/marker for the lateCompletion callback above.
+            if sleepGuard != nil { lingeringSleepGuard = sleepGuard }
+            return false
+        }
+    }
+
+    private func scheduleStrandedSoftReconnectRecovery() {
+        Task { [weak self] in
+            // Let softReconnect unwind its in-flight claim before recovery
+            // checks the marker and queues a compensating enable.
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            await self?.recoverStrandedSoftReconnect()
+        }
+    }
+
+    private func completedResult(
+        _ result: CGHelpers.TimedResult<Result<Void, ToggleError>>
+    ) -> Result<Void, ToggleError> {
+        switch result {
+        case .completed(let value): return value
+        case .timedOut: return .failure(.configurationFailed(.failure))
+        }
+    }
+
+    private func recordDisconnected(_ snapshot: DisconnectedDisplay) {
+        disconnected.removeAll { $0.uuid == snapshot.uuid }
+        disconnected.append(snapshot)
+        saveDesired()
+    }
+
+    private func finishDisconnect(
+        _ snapshot: DisconnectedDisplay,
+        apiResult: Result<Void, ToggleError>
+    ) async -> Result<Void, ToggleError> {
+        let offline = await verifyOffline(uuid: snapshot.uuid)
+        if offline == true {
+            pendingDisconnectUUIDs.remove(snapshot.uuid)
+            disconnectVerificationRetryUUIDs.remove(snapshot.uuid)
+            Self.toggleReservations.insert(snapshot.uuid)
+            recordDisconnected(snapshot)
             return .success(())
         }
+
+        if offline == nil {
+            // Do not turn an enumeration outage into evidence that the disable
+            // failed. Keep both the durable Reconnect row and the reservation,
+            // then retry until WindowServer can answer the postcondition.
+            Self.toggleReservations.insert(snapshot.uuid)
+            recordDisconnected(snapshot)
+            scheduleDisconnectVerificationRetry(snapshot, apiResult: apiResult)
+            if case .failure = apiResult { return apiResult }
+            return .failure(.configurationFailed(.failure))
+        }
+
+        pendingDisconnectUUIDs.remove(snapshot.uuid)
+        disconnectVerificationRetryUUIDs.remove(snapshot.uuid)
+        disconnected.removeAll { $0.uuid == snapshot.uuid }
+        Self.toggleReservations.remove(snapshot.uuid)
+        saveDesired()
+        if case .failure = apiResult { return apiResult }
+        return .failure(.configurationFailed(.failure))
+    }
+
+    private func scheduleDisconnectVerificationRetry(
+        _ snapshot: DisconnectedDisplay,
+        apiResult: Result<Void, ToggleError>
+    ) {
+        guard disconnectVerificationRetryUUIDs.insert(snapshot.uuid).inserted else { return }
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            guard let self else { return }
+            self.disconnectVerificationRetryUUIDs.remove(snapshot.uuid)
+            guard self.pendingDisconnectUUIDs.contains(snapshot.uuid) else { return }
+            _ = await self.finishDisconnect(snapshot, apiResult: apiResult)
+        }
+    }
+
+    private func finishReconnect(
+        uuid displayUUID: String,
+        apiResult: Result<Void, ToggleError>
+    ) async -> Result<Void, ToggleError> {
+        if await verifyBackOnline(uuid: displayUUID) {
+            pendingDisconnectUUIDs.remove(displayUUID)
+            disconnectVerificationRetryUUIDs.remove(displayUUID)
+            Self.toggleReservations.remove(displayUUID)
+            disconnected.removeAll { $0.uuid == displayUUID }
+            saveDesired()
+            return .success(())
+        }
+        if case .failure = apiResult { return apiResult }
+        return .failure(.configurationFailed(.failure))
     }
 
     /// Safety net for softReconnect's re-enable retries all failing: sweeps every SLS-disabled
@@ -385,18 +660,50 @@ final class PhysicalDisplayToggleService: ObservableObject {
             // retry loop owns bringing it back, and racing it here would reintroduce the
             // recovery-vs-toggle conflict this file just fixed, one display over.
             guard !softReconnectInFlight.contains(displayUUID) else { continue }
-            _ = await setEnabled(true, displayID: id)
+            _ = await setEnabled(true, displayID: id, expectedUUID: displayUUID)
         }
     }
 
     /// Display IDs currently online. SLS-disabled displays are omitted here (see
     /// allDisplaysIncludingDisabled), so "online" doubles as the enabled check.
     private func onlineDisplayIDs() -> Set<CGDirectDisplayID> {
+        onlineDisplayIDsChecked() ?? []
+    }
+
+    private func onlineDisplayIDsChecked() -> Set<CGDirectDisplayID>? {
         var count: UInt32 = 0
-        CGGetOnlineDisplayList(0, nil, &count)
+        guard CGGetOnlineDisplayList(0, nil, &count) == .success else { return nil }
         var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
-        CGGetOnlineDisplayList(count, &ids, &count)
+        guard CGGetOnlineDisplayList(count, &ids, &count) == .success else { return nil }
         return Set(ids.prefix(Int(count)))
+    }
+
+    private func displayIsOnline(uuid displayUUID: String) -> Bool? {
+        guard let all = Self.allDisplayIDsIncludingDisabled(),
+              let online = onlineDisplayIDsChecked() else { return nil }
+        guard let id = all.first(where: { uuid(for: $0) == displayUUID }) else {
+            return false
+        }
+        return online.contains(id)
+    }
+
+    /// Returns nil when neither display enumeration API produced a trustworthy
+    /// answer during the verification window.
+    private func verifyOffline(uuid displayUUID: String, timeout: TimeInterval = 1.0) async -> Bool? {
+        for _ in 0..<max(Int(timeout * 10), 1) {
+            switch displayIsOnline(uuid: displayUUID) {
+            case false?: return true
+            case true?, nil: break
+            }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        // Take a fresh observation after the complete settle window. The last
+        // pre-sleep sample is stale if the disable lands during that sleep.
+        switch displayIsOnline(uuid: displayUUID) {
+        case false?: return true
+        case true?: return false
+        case nil: return nil
+        }
     }
 
     /// True once the display with this UUID is back in the online list, polling up to
@@ -405,8 +712,7 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// disabled (verified live in clamshell). Only enumeration counts.
     private func verifyBackOnline(uuid displayUUID: String, timeout: TimeInterval = 1.0) async -> Bool {
         for _ in 0..<max(Int(timeout * 10), 1) {
-            if let id = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == displayUUID }),
-               onlineDisplayIDs().contains(id) { return true }
+            if displayIsOnline(uuid: displayUUID) == true { return true }
             try? await Task.sleep(nanoseconds: 100_000_000)
         }
         return false
@@ -470,9 +776,16 @@ final class PhysicalDisplayToggleService: ObservableObject {
         var onlineIDs = [CGDirectDisplayID](repeating: 0, count: Int(onlineCount))
         CGGetOnlineDisplayList(onlineCount, &onlineIDs, &onlineCount)
         let onlineUUIDs = Set(onlineIDs.prefix(Int(onlineCount)).map { uuid(for: $0) })
+        for displayUUID in onlineUUIDs
+        where !pendingDisconnectUUIDs.contains(displayUUID)
+            && !softReconnectInFlight.contains(displayUUID) {
+            Self.toggleReservations.remove(displayUUID)
+        }
 
         let before = disconnected.count
-        disconnected.removeAll { onlineUUIDs.contains($0.uuid) }
+        disconnected.removeAll {
+            !pendingDisconnectUUIDs.contains($0.uuid) && onlineUUIDs.contains($0.uuid)
+        }
         if disconnected.count != before { saveDesired() }
     }
 
@@ -512,13 +825,29 @@ final class PhysicalDisplayToggleService: ObservableObject {
             // Re-checked per iteration: a blink can start for a marked display while an
             // earlier iteration was awaiting.
             guard !softReconnectInFlight.contains(markedUUID) else { continue }
-            guard let targetID = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == markedUUID }) else {
+            // An SLS enumeration error is not proof that the display was
+            // unplugged. Defer recovery and retain the marker until a successful
+            // full-list query can establish that it is genuinely gone.
+            guard let allIDs = Self.allDisplayIDsIncludingDisabled() else { continue }
+            let targetID: CGDirectDisplayID
+            if let resolved = allIDs.first(where: { uuid(for: $0) == markedUUID }) {
+                targetID = resolved
+            } else if allIDs.contains(where: { Self.isPlaceholderDisplay($0) }) {
+                // In the all-screens-black state SLS publishes only its
+                // placeholder. The real panel is still attached and can be
+                // enabled through the ID captured before the blink.
+                guard let lastKnownID = pendingSoftReconnectLastKnownIDs()[markedUUID] else {
+                    continue
+                }
+                targetID = lastKnownID
+            } else {
                 // Display gone entirely (unplugged while stranded): a physical replug brings
                 // it back online by itself, so the marker has nothing left to do.
                 removePendingSoftReconnect(markedUUID)
                 continue
             }
-            if onlineDisplayIDs().contains(targetID) {
+            guard let onlineIDs = onlineDisplayIDsChecked() else { continue }
+            if onlineIDs.contains(targetID) {
                 // Recovered normally (or a previous sweep already brought it back).
                 removePendingSoftReconnect(markedUUID)
                 continue
@@ -528,7 +857,8 @@ final class PhysicalDisplayToggleService: ObservableObject {
                 // The API result alone is never trusted (see verifyBackOnline): a lying
                 // "success" here is exactly how a clamshell-sleep interruption erased the
                 // marker while the display stayed disabled.
-                if case .success = await setEnabled(true, displayID: targetID),
+                if case .success = completedResult(await setEnabled(
+                    true, displayID: targetID, expectedUUID: markedUUID)),
                    await verifyBackOnline(uuid: markedUUID) {
                     recovered = true
                     break
@@ -538,7 +868,7 @@ final class PhysicalDisplayToggleService: ObservableObject {
             if !recovered { await reenableUnintentionallyDisabled() }
             // Clear only if the display verifiably came back; otherwise the marker stays set
             // and the addFlag/refresh cadence (or the next launch) retries.
-            if recovered || onlineDisplayIDs().contains(targetID) {
+            if recovered || displayIsOnline(uuid: markedUUID) == true {
                 removePendingSoftReconnect(markedUUID)
             }
         }
@@ -548,6 +878,13 @@ final class PhysicalDisplayToggleService: ObservableObject {
         if lingeringSleepGuard != nil, pendingSoftReconnectUUIDs().isEmpty {
             lingeringSleepGuard = nil
         }
+    }
+
+    nonisolated private static func isPlaceholderDisplay(
+        _ displayID: CGDirectDisplayID
+    ) -> Bool {
+        CGDisplayVendorNumber(displayID) == 0x756E6B6E
+            && CGDisplayModelNumber(displayID) == 0x76697274
     }
 
     /// Guards against overlapping restore attempts from reconfiguration-callback bursts.
@@ -600,7 +937,7 @@ final class PhysicalDisplayToggleService: ObservableObject {
             // Only re-disconnect ones macOS brought back online, and never the last screen.
             guard let liveID = onlineByUUID[record.uuid] else { continue }
             guard !wouldLeaveNoActiveDisplay(liveID) else { continue }
-            _ = await setEnabled(false, displayID: liveID)
+            _ = await setEnabled(false, displayID: liveID, expectedUUID: record.uuid)
         }
     }
 

--- a/Crisp/Services/PresetService.swift
+++ b/Crisp/Services/PresetService.swift
@@ -178,6 +178,7 @@ final class PresetService: ObservableObject, @unchecked Sendable {
         }
 
         let displays = DisplayManagerAccessor.shared.displays
+        var resolutionsApplied = true
 
         for entry in preset.displays {
             guard let display = displays.first(where: { $0.displayUUID == entry.displayUUID }) else { continue }
@@ -190,38 +191,44 @@ final class PresetService: ObservableObject, @unchecked Sendable {
             // alreadyActive no-op below. Brightness and arrangement apply regardless.
             if let w = entry.width, let h = entry.height {
                 let hiDPI = entry.isHiDPI ?? false
-                let targetMode = display.availableModes.first(where: {
-                    $0.width == w && $0.height == h && $0.isHiDPI == hiDPI
-                }) ?? display.availableModes.first(where: {
-                    $0.width == w && $0.height == h
-                })
+                let beyondCapStops = MirroredModeService.beyondCapStops(for: display).map {
+                    PanelResolution(width: $0.width, height: $0.height)
+                }
+                let route = PresetResolutionRouter.route(
+                    width: w, height: h, isHiDPI: hiDPI,
+                    candidates: display.availableModes.map {
+                        PresetModeCandidate(width: $0.width, height: $0.height,
+                                            isHiDPI: $0.isHiDPI)
+                    },
+                    beyondCapStops: beyondCapStops)
 
-                if let mode = targetMode {
-                    let currentMode = display.currentDisplayMode
-                    let alreadyActive = currentMode?.width == mode.width
-                        && currentMode?.height == mode.height
-                        && currentMode?.isHiDPI == mode.isHiDPI
-                    if !alreadyActive {
-                        // A real mode while the panel is a mirror target (#65): unmirror
-                        // first, or WindowServer redirects the change to the virtual source.
-                        // A failed unmirror keeps the mirror up; leave the resolution alone.
-                        var unmirrored = true
-                        if MirroredModeService.shared.isActive(for: displayID) {
-                            unmirrored = await MirroredModeService.shared.restore(display: display)
-                        }
-                        if unmirrored, await ResolutionService.shared.setDisplayMode(mode, for: displayID) {
+                switch route {
+                case .mirror:
+                    // Route before the physical fallback: beyond-cap sizes often
+                    // have a same-size 1× mode, but restoring that would be blurry.
+                    let applied = await MirroredModeService.shared.apply(
+                        display: display, width: w, height: h)
+                    resolutionsApplied = resolutionsApplied && applied
+                case let .physical(index):
+                    let mode = display.availableModes[index]
+                    // Keep teardown and the physical mode transaction atomic
+                    // against a concurrent mirror request. Even an apparently
+                    // already-active physical mode must first leave mirror mode.
+                    let applied = await MirroredModeService.shared.withMirrorRestored(for: display) {
+                        let changed = await ResolutionService.shared.setDisplayMode(
+                            mode, for: displayID,
+                            expectedDisplayUUID: display.displayUUID)
+                        if changed {
                             // refreshDisplays() doesn't re-read the current mode for
                             // already-present displays, so write it back here (as the manual
                             // switch does) or the panel keeps showing the old resolution.
                             display.currentDisplayMode = mode
                         }
+                        return changed
                     }
-                } else if hiDPI, MirroredModeService.beyondCapStops(for: display)
-                            .contains(where: { $0.width == w && $0.height == h }) {
-                    // A beyond-cap size captured while mirrored (#65): it never
-                    // enumerates on the physical panel, so the lookup above cannot
-                    // find it. Mirror mode is the only route there.
-                    await MirroredModeService.shared.apply(display: display, width: w, height: h)
+                    resolutionsApplied = resolutionsApplied && applied
+                case .unavailable:
+                    resolutionsApplied = false
                 }
             }
 
@@ -244,7 +251,7 @@ final class PresetService: ObservableObject, @unchecked Sendable {
             }
         }
 
-        activePresetID = preset.id
+        activePresetID = resolutionsApplied ? preset.id : nil
         // DisplayManager is not a singleton; callers with a DisplayManager ref can call refreshDisplays().
     }
 

--- a/Crisp/Services/ResolutionService.swift
+++ b/Crisp/Services/ResolutionService.swift
@@ -1,5 +1,6 @@
 import Foundation
 @preconcurrency import CoreGraphics
+import ApplicationServices
 
 /// Service responsible for reading and changing display resolution modes.
 @MainActor
@@ -38,7 +39,7 @@ final class ResolutionService: @unchecked Sendable {
     /// CGS-surfaced hidden modes carry whole-Hz uint16 rates while CG modes carry fractional
     /// ones). A 0 means "display default"; treat it as a wildcard so it never blocks an
     /// otherwise exact resolution match.
-    static func refreshMatches(_ a: Double, _ b: Double) -> Bool {
+    nonisolated static func refreshMatches(_ a: Double, _ b: Double) -> Bool {
         if a == 0 || b == 0 { return true }
         return abs(a - b) < 1.0
     }
@@ -108,8 +109,31 @@ final class ResolutionService: @unchecked Sendable {
     ///   2. Find the matching CGDisplayMode on the source by logical size + HiDPI attributes.
     ///   3. Apply via CGConfigureDisplayWithDisplayMode on the source display.
     ///   4. Fallback: try CGSConfigureDisplayMode (private API) on the source.
-    func setDisplayMode(_ mode: DisplayMode, for displayID: CGDirectDisplayID) async -> Bool {
+    func setDisplayMode(
+        _ requestedMode: DisplayMode,
+        for capturedDisplayID: CGDirectDisplayID,
+        expectedDisplayUUID: String
+    ) async -> Bool {
         PresetService.shared.noteManualChange()
+        // Both the numeric display ID and every mode ID can be reassigned by a
+        // reconnect. Resolve the panel and requested attributes only after any
+        // preceding queued operation has finished.
+        guard let displayID = Self.onlineDisplayID(
+            for: expectedDisplayUUID, preferred: capturedDisplayID
+        ) else { return false }
+        let requestedAspect = requestedMode.height > 0
+            ? Double(requestedMode.width) / Double(requestedMode.height) : nil
+        let freshModes = await Task.detached(priority: .userInitiated) {
+            DisplayMode.enumerateModes(for: displayID).resolved(nativeAspect: requestedAspect)
+        }.value
+        guard let mode = freshModes.first(where: {
+            Self.sameModeAttributes($0, requestedMode)
+        }) else { return false }
+
+        if let current = DisplayMode.currentMode(for: displayID),
+           Self.sameModeAttributes(current, mode) {
+            return true
+        }
         // Resolve mirror source, the physical display may mirror a virtual display
         let (targetID, isMirrorRedirect) = resolvedTargetDisplayID(for: displayID)
 
@@ -160,6 +184,40 @@ final class ResolutionService: @unchecked Sendable {
             persistMode(mode, for: displayID)
         }
         return fallbackSuccess
+    }
+
+    nonisolated private static func sameModeAttributes(
+        _ lhs: DisplayMode,
+        _ rhs: DisplayMode
+    ) -> Bool {
+        lhs.width == rhs.width && lhs.height == rhs.height
+            && lhs.pixelWidth == rhs.pixelWidth && lhs.pixelHeight == rhs.pixelHeight
+            && lhs.isHiDPI == rhs.isHiDPI
+            && lhs.isVariableRefresh == rhs.isVariableRefresh
+            && refreshMatches(lhs.refreshRate, rhs.refreshRate)
+    }
+
+    nonisolated private static func onlineDisplayID(
+        for expectedUUID: String,
+        preferred: CGDirectDisplayID
+    ) -> CGDirectDisplayID? {
+        var count: UInt32 = 0
+        guard CGGetOnlineDisplayList(0, nil, &count) == .success else { return nil }
+        var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+        guard CGGetOnlineDisplayList(count, &ids, &count) == .success else { return nil }
+        let online = Array(ids.prefix(Int(count)))
+        return ([preferred] + online).first {
+            online.contains($0) && displayUUID(for: $0) == expectedUUID
+        }
+    }
+
+    nonisolated private static func displayUUID(for displayID: CGDirectDisplayID) -> String {
+        if let cf = CGDisplayCreateUUIDFromDisplayID(displayID),
+           let value = CFUUIDCreateString(nil, cf.takeRetainedValue()) {
+            return value as String
+        }
+        return "v\(CGDisplayVendorNumber(displayID))-m\(CGDisplayModelNumber(displayID))"
+            + "-s\(CGDisplaySerialNumber(displayID))"
     }
 
     // MARK: - Mirror resolution
@@ -242,7 +300,7 @@ final class ResolutionService: @unchecked Sendable {
     /// id segfaults in checkCapacity() on macOS 26. It must run inside a real
     /// CGBegin/CGCompleteDisplayConfiguration transaction (verified against BetterDisplay on Tahoe).
     private func cgsFallback(modeID: UInt32, on displayID: CGDirectDisplayID) async -> Bool {
-        let committed = await Task.detached(priority: .userInitiated) {
+        let committed = await CGHelpers.runWithTimeout(seconds: 10, fallback: false) {
             var config: CGDisplayConfigRef?
             guard CGBeginDisplayConfiguration(&config) == .success, let cfg = config else {
                 return false
@@ -255,7 +313,7 @@ final class ResolutionService: @unchecked Sendable {
             }
 
             return CGCompleteDisplayConfiguration(cfg, .forSession) == .success
-        }.value
+        }
         guard committed else { return false }
         // The commit propagates async. Fast path: already active. Otherwise wait
         // for the mode-change event instead of a blind 100ms sleep (0.5s ceiling

--- a/Crisp/Services/SettingsService.swift
+++ b/Crisp/Services/SettingsService.swift
@@ -65,6 +65,8 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
         // Per-display keys use prefix + displayID
         static let brightnessPrefix       = "crisp.brightness_"
         static let contrastPrefix         = "crisp.contrast_"
+        // Stable physical identity, not CGDirectDisplayID (which changes on reconnect).
+        static let panelResolutionPrefix  = "crisp.panelResolution_"
     }
 
     // MARK: - Published Settings
@@ -150,6 +152,30 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
 
     func setContrast(_ value: Double, for displayID: CGDirectDisplayID) {
         defaults.set(value, forKey: Keys.contrastPrefix + "\(displayID)")
+    }
+
+    func panelResolutionOverride(vendor: UInt32, product: UInt32,
+                                 serial: UInt32) -> PanelResolution? {
+        guard let values = defaults.array(forKey: panelResolutionKey(
+            vendor: vendor, product: product, serial: serial
+        )) as? [Int], values.count == 2 else { return nil }
+        let resolution = PanelResolution(width: values[0], height: values[1])
+        return resolution.isPlausible ? resolution : nil
+    }
+
+    func setPanelResolutionOverride(_ resolution: PanelResolution?, vendor: UInt32,
+                                    product: UInt32, serial: UInt32) {
+        let key = panelResolutionKey(vendor: vendor, product: product, serial: serial)
+        if let resolution, resolution.isPlausible {
+            defaults.set([resolution.width, resolution.height], forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    private func panelResolutionKey(vendor: UInt32, product: UInt32,
+                                    serial: UInt32) -> String {
+        Keys.panelResolutionPrefix + "\(vendor)-\(product)-\(serial)"
     }
 
     // MARK: - Color History

--- a/Crisp/Views/DisplayModeListView.swift
+++ b/Crisp/Views/DisplayModeListView.swift
@@ -38,6 +38,7 @@ final class DisplayModeController: ObservableObject {
     private var isSwitching: Bool = false
     private var cachedGroups: [ResolutionGroup]?
     private var cachedSliderModes: [DisplayMode]?
+    private var panelResolutionReloadTask: Task<Void, Never>?
     /// Panel's adaptive-sync floor (48 on a 48-180Hz panel), for the Variable row label.
     private lazy var vrrMinimumRate: Int? = VariableRefreshRange.minimumRate(
         vendorNumber: display.vendorNumber, modelNumber: display.modelNumber)
@@ -50,11 +51,13 @@ final class DisplayModeController: ObservableObject {
         // so relay exactly those instead of having the views observe the whole
         // DisplayInfo: its brightness publishes at 125Hz during a click-glide,
         // and re-rendering six hosting views per step (each regrouping the
-        // AOC's ~100-mode list) was the glide jank. dropFirst(2) skips the
-        // initial replays both @Published publishers emit on subscribe.
+        // AOC's ~100-mode list) was the glide jank. dropFirst(4) skips the
+        // initial replays these four @Published publishers emit on subscribe.
         displayRelay = display.$currentDisplayMode.map { _ in }
             .merge(with: display.$availableModes.map { _ in })
-            .dropFirst(2)
+            .merge(with: display.$detectedPanelResolution.map { _ in })
+            .merge(with: display.$manualPanelResolution.map { _ in })
+            .dropFirst(4)
             .sink { [weak self] _ in
                 self?.cachedGroups = nil
                 self?.cachedSliderModes = nil
@@ -246,6 +249,7 @@ final class DisplayModeController: ObservableObject {
         guard !isSwitching else { done(); return }
         isSwitching = true
         let displayID = display.displayID
+        let displayUUID = display.displayUUID
         Task { @MainActor in
             var success: Bool
             if mode.id < 0 {
@@ -261,18 +265,15 @@ final class DisplayModeController: ObservableObject {
                 // A failed unmirror keeps the mirror up (restore leaves the
                 // bookkeeping alone then), so report failure instead of pushing
                 // a mode change at a panel that is still a target.
-                var unmirrored = true
-                if MirroredModeService.shared.isActive(for: displayID) {
-                    unmirrored = await MirroredModeService.shared.restore(display: display)
-                }
-                if unmirrored {
-                    success = await ResolutionService.shared.setDisplayMode(mode, for: displayID)
-                    if !success {
+                success = await MirroredModeService.shared.withMirrorRestored(for: display) {
+                    var applied = await ResolutionService.shared.setDisplayMode(
+                        mode, for: displayID, expectedDisplayUUID: displayUUID)
+                    if !applied {
                         try? await Task.sleep(nanoseconds: 200_000_000)
-                        success = await ResolutionService.shared.setDisplayMode(mode, for: displayID)
+                        applied = await ResolutionService.shared.setDisplayMode(
+                            mode, for: displayID, expectedDisplayUUID: displayUUID)
                     }
-                } else {
-                    success = false
+                    return applied
                 }
             }
             if success {
@@ -499,16 +500,33 @@ final class DisplayModeController: ObservableObject {
         // this to ask the rebuilt menu to re-expand the same display afterward.
         let targetUUID = display.displayUUID
         Task { @MainActor in
-            let err: String?
-            if on {
-                err = HiDPIService.shared.enableSmoothScaling(
-                    vendor: display.vendorNumber, product: display.modelNumber,
-                    nativeWidth: nativeW, nativeHeight: nativeH)
-            } else {
-                err = HiDPIService.shared.disableHiDPI(
-                    vendor: display.vendorNumber, product: display.modelNumber)
+            var operationError: String?
+            var reconnected = false
+            let mirrorRestored = await MirroredModeService.shared.withMirrorRestored(for: display) { [self] in
+                if on {
+                    operationError = HiDPIService.shared.enableSmoothScaling(
+                        vendor: display.vendorNumber, product: display.modelNumber,
+                        nativeWidth: nativeW, nativeHeight: nativeH)
+                } else {
+                    operationError = HiDPIService.shared.disableHiDPI(
+                        vendor: display.vendorNumber, product: display.modelNumber)
+                }
+                guard operationError == nil else { return true }
+
+                // The reconnect must stay in the same per-display operation as
+                // teardown and the plist mutation. Otherwise an apply can make
+                // the panel a mirror target again before it is blinked.
+                PanelOpenGuard.suppressAutoDismiss = true
+                defer { PanelOpenGuard.suppressAutoDismiss = false }
+                reconnected = await PhysicalDisplayToggleService.shared.softReconnect(display)
+                HiDPIService.shared.refreshModes(for: display)
+                try? await Task.sleep(nanoseconds: 800_000_000)
+                return true
             }
-            if let err {
+            if !mirrorRestored {
+                operationError = String(localized: "Failed to apply. Please try again.")
+            }
+            if let err = operationError {
                 withAnimation { errorMessage = err }
                 smoothOn = smoothModesPresent   // failed: snap back to reality
                 Task { @MainActor in
@@ -522,13 +540,6 @@ final class DisplayModeController: ObservableObject {
                 // back to the top. Suppress the resign/outside-click dismissal for the
                 // duration so the panel stays put on this display's Resolution section;
                 // nothing to restore because it never closes.
-                PanelOpenGuard.suppressAutoDismiss = true
-                defer { PanelOpenGuard.suppressAutoDismiss = false }
-                // Re-read the override change in software (screen blanks ~1s) instead of
-                // asking for a physical reconnect.
-                let reconnected = await PhysicalDisplayToggleService.shared.softReconnect(display)
-                HiDPIService.shared.refreshModes(for: display)
-                try? await Task.sleep(nanoseconds: 800_000_000)  // let refreshModes land
                 smoothOn = smoothModesPresent
                 refreshSmoothWouldPrompt()
                 if !reconnected && smoothOn != on {
@@ -561,6 +572,45 @@ final class DisplayModeController: ObservableObject {
                 PanelOpenGuard.resignKeyGraceUntil = Date().addingTimeInterval(5)
             }
             smoothBusy = false
+        }
+    }
+
+    /// Persist a physical panel-size fallback after safely retiring any active
+    /// mirror virtual, then rebuild this display's mode data from the new size.
+    func setPanelResolutionOverride(width: Int, height: Int) -> Bool {
+        let resolution = PanelResolution(width: width, height: height)
+        guard resolution.isPlausible else { return false }
+        queuePanelResolutionChange(resolution)
+        return true
+    }
+
+    func clearPanelResolutionOverride() {
+        queuePanelResolutionChange(nil)
+    }
+
+    private func queuePanelResolutionChange(_ resolution: PanelResolution?) {
+        let previous = panelResolutionReloadTask
+        panelResolutionReloadTask = Task { [weak self] in
+            await previous?.value
+            guard let self else { return }
+            let applied = await MirroredModeService.shared.updatePanelResolution(for: display) {
+                self.display.setManualPanelResolution(resolution)
+                await self.display.loadDetails()
+            }
+            guard applied else {
+                withAnimation {
+                    self.errorMessage = String(localized: "Failed to apply. Please try again.")
+                }
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    withAnimation { self.errorMessage = nil }
+                }
+                return
+            }
+            self.cachedGroups = nil
+            self.cachedSliderModes = nil
+            self.refreshSmoothWouldPrompt()
+            self.objectWillChange.send()
         }
     }
 }
@@ -826,6 +876,7 @@ struct ModeTailBlock: View {
             // steps through. External displays only (built-ins already scale via System Settings).
             if !display.isBuiltin {
                 smoothScalingSection
+                PanelResolutionOverrideSection(controller: controller)
             }
 
             if let msg = controller.errorMessage {
@@ -905,6 +956,122 @@ struct ModeTailBlock: View {
             // Adopt external truth (reconnect, another app) unless our own toggle is settling.
             if !controller.smoothBusy { controller.smoothOn = present }
         }
+    }
+}
+
+/// Compact fallback editor for panels whose EDID/native-format metadata is absent or wrong.
+/// Dimensions are panel-space (unrotated), matching the override plist and monitor spec sheet.
+private struct PanelResolutionOverrideSection: View {
+    @ObservedObject var controller: DisplayModeController
+    @State private var editing = false
+    @State private var width = ""
+    @State private var height = ""
+    @State private var validationFailed = false
+    @State private var hovered = false
+
+    private var display: DisplayInfo { controller.display }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Button {
+                guard PanelOpenGuard.allowsActivation else { return }
+                loadCurrentValues()
+                withAnimation(.panelResize) { editing.toggle() }
+            } label: {
+                HStack(spacing: 8) {
+                    MenuItemIcon(systemName: "rectangle.on.rectangle", color: .blue,
+                                 active: display.manualPanelResolution != nil)
+                        .accessibilityHidden(true)
+                    Text("Native resolution")
+                        .font(.body)
+                        .lineLimit(1)
+                    Spacer()
+                    Text(resolutionSubtitle)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                    Image(systemName: editing ? "chevron.up" : "chevron.down")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 3)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .menuRowHover(hovered)
+            .onHover { hovered = $0 }
+
+            if editing {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Use this only when the detected panel size is wrong.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(resolutionSourceLabel)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                    HStack(spacing: 5) {
+                        PanelNumericField(text: $width, placeholder: String(localized: "Width"))
+                        Text("×").foregroundColor(.secondary)
+                        PanelNumericField(text: $height, placeholder: String(localized: "Height"))
+                        Button("Save") { save() }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                    }
+                    if display.manualPanelResolution != nil {
+                        Button("Use detected resolution") {
+                            controller.clearPanelResolutionOverride()
+                            loadCurrentValues()
+                            validationFailed = false
+                        }
+                        .buttonStyle(.link)
+                        .font(.caption)
+                    }
+                    if validationFailed {
+                        Text("Enter a valid panel size from 640×480 up to 16384×16384.")
+                            .font(.caption2)
+                            .foregroundColor(.red)
+                    }
+                }
+                .padding(.horizontal, 44)
+                .padding(.bottom, 5)
+                .transition(.opacity)
+            }
+        }
+    }
+
+    private var resolutionSubtitle: String {
+        let (width, height) = display.panelNativeResolution
+        return "\(width) × \(height)"
+    }
+
+    private var resolutionSourceLabel: String {
+        switch display.panelResolutionSource {
+        case .manual: String(localized: "Manual")
+        case .edid: String(localized: "Detected from EDID")
+        case .registry: String(localized: "Detected from display metadata")
+        case .displayModes: String(localized: "Inferred from display modes")
+        case .currentPixels: String(localized: "Inferred from current mode")
+        }
+    }
+
+    private func loadCurrentValues() {
+        let resolution = display.manualPanelResolution
+            ?? PanelResolution(width: display.panelNativeResolution.width,
+                               height: display.panelNativeResolution.height)
+        width = String(resolution.width)
+        height = String(resolution.height)
+        validationFailed = false
+    }
+
+    private func save() {
+        guard let width = Int(width), let height = Int(height),
+              controller.setPanelResolutionOverride(width: width, height: height) else {
+            validationFailed = true
+            return
+        }
+        validationFailed = false
+        withAnimation(.panelResize) { editing = false }
     }
 }
 

--- a/Crisp/Views/NotchView.swift
+++ b/Crisp/Views/NotchView.swift
@@ -77,10 +77,14 @@ struct NotchView: View {
         Task { @MainActor in
             // One retry like DisplayModeController.switchTo: a transient CG
             // config failure right after another reconfig is common.
-            var success = await ResolutionService.shared.setDisplayMode(target, for: display.displayID)
+            var success = await ResolutionService.shared.setDisplayMode(
+                target, for: display.displayID,
+                expectedDisplayUUID: display.displayUUID)
             if !success {
                 try? await Task.sleep(nanoseconds: 200_000_000)
-                success = await ResolutionService.shared.setDisplayMode(target, for: display.displayID)
+                success = await ResolutionService.shared.setDisplayMode(
+                    target, for: display.displayID,
+                    expectedDisplayUUID: display.displayUUID)
             }
             if success {
                 // Optimistic, like DisplayModeController: the reconfig callback

--- a/Crisp/Views/PanelBlocks.swift
+++ b/Crisp/Views/PanelBlocks.swift
@@ -89,6 +89,31 @@ struct BlockHost<Content: View>: View {
     }
 }
 
+/// Compact numeric field shared by inline panel editors. It matches the soft
+/// fill used throughout the panel and strips non-digit input as the user types.
+struct PanelNumericField: View {
+    @Binding var text: String
+    let placeholder: String
+
+    var body: some View {
+        TextField(placeholder, text: $text)
+            .textFieldStyle(.plain)
+            .font(.body)
+            .multilineTextAlignment(.center)
+            .frame(width: 72)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.primary.opacity(0.07))
+            )
+            .onChange(of: text) { _, value in
+                let digits = value.filter(\.isNumber)
+                if digits != value { text = digits }
+            }
+    }
+}
+
 /// An ExpandableRow bound to a PanelSectionState flag. Observes the state so
 /// the chevron re-renders when the flag flips (a plain ad-hoc Binding inside
 /// a static block closure would never re-render).

--- a/Crisp/Views/ResolutionSliderView.swift
+++ b/Crisp/Views/ResolutionSliderView.swift
@@ -124,7 +124,9 @@ struct ResolutionSliderView: View {
         guard selected.id != display.currentDisplayMode?.id else { return }
         isSwitching = true
         Task { @MainActor in
-            let success = await ResolutionService.shared.setDisplayMode(selected, for: display.displayID)
+            let success = await ResolutionService.shared.setDisplayMode(
+                selected, for: display.displayID,
+                expectedDisplayUUID: display.displayUUID)
             if success {
                 display.currentDisplayMode = selected
                 errorMessage = nil

--- a/Crisp/Views/VirtualDisplayView.swift
+++ b/Crisp/Views/VirtualDisplayView.swift
@@ -399,9 +399,9 @@ struct CreateVirtualDisplayForm: View {
 
                 if selectedPreset == customTag {
                     HStack(spacing: 6) {
-                        customField(text: $customWidth, placeholder: String(localized: "Width"))
+                        PanelNumericField(text: $customWidth, placeholder: String(localized: "Width"))
                         Text("×").foregroundColor(.secondary)
-                        customField(text: $customHeight, placeholder: String(localized: "Height"))
+                        PanelNumericField(text: $customHeight, placeholder: String(localized: "Height"))
                         Spacer()
                     }
                 }
@@ -464,24 +464,6 @@ struct CreateVirtualDisplayForm: View {
         guard let w = Int(customWidth), let h = Int(customHeight),
               (640...8192).contains(w), (480...8192).contains(h) else { return nil }
         return (w, h)
-    }
-
-    private func customField(text: Binding<String>, placeholder: String) -> some View {
-        TextField(placeholder, text: text)
-            .textFieldStyle(.plain)
-            .font(.body)
-            .multilineTextAlignment(.center)
-            .frame(width: 72)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.primary.opacity(0.07))
-            )
-            .onChange(of: text.wrappedValue) { _, v in
-                let digits = v.filter(\.isNumber)
-                if digits != v { text.wrappedValue = digits }
-            }
     }
 
     private func confirm() {

--- a/CrispTests/CGHelpersTests.swift
+++ b/CrispTests/CGHelpersTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import XCTest
+
+final class CGHelpersTests: XCTestCase {
+    func testStartedMandatoryOperationReportsCompletionAfterTimeout() async {
+        let started = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        let lateCompletion = DispatchSemaphore(value: 0)
+
+        let task = Task {
+            await CGHelpers.runMandatoryWithTimeout(
+                seconds: 0.05,
+                operation: {
+                    started.signal()
+                    release.wait()
+                    return true
+                },
+                lateCompletion: { result in
+                    if result { lateCompletion.signal() }
+                })
+        }
+
+        XCTAssertEqual(started.wait(timeout: .now() + 1), .success)
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        if case .timedOut = await task.value {} else {
+            XCTFail("started mandatory operation should time out for its caller")
+        }
+
+        release.signal()
+        XCTAssertEqual(lateCompletion.wait(timeout: .now() + 1), .success)
+    }
+
+    func testTimedOutQueuedOperationIsSkippedWithoutOverlappingBlocker() async {
+        let blockerStarted = DispatchSemaphore(value: 0)
+        let releaseBlocker = DispatchSemaphore(value: 0)
+        let queuedBodyRan = DispatchSemaphore(value: 0)
+
+        let blocker = Task {
+            await CGHelpers.runWithTimeout(seconds: 0.05, fallback: false) {
+                blockerStarted.signal()
+                releaseBlocker.wait()
+                return true
+            }
+        }
+        XCTAssertEqual(blockerStarted.wait(timeout: .now() + 1), .success)
+
+        let queued = Task {
+            await CGHelpers.runWithTimeout(seconds: 0.05, fallback: false) {
+                queuedBodyRan.signal()
+                return true
+            }
+        }
+        let compensationRan = DispatchSemaphore(value: 0)
+        let lateCompletionRan = DispatchSemaphore(value: 0)
+        let compensation = Task {
+            await CGHelpers.runMandatoryWithTimeout(
+                seconds: 0.05,
+                operation: {
+                    compensationRan.signal()
+                    return true
+                },
+                lateCompletion: { result in
+                    if result { lateCompletionRan.signal() }
+                })
+        }
+
+        try? await Task.sleep(nanoseconds: 80_000_000)
+        let blockerResult = await blocker.value
+        let queuedResult = await queued.value
+        XCTAssertFalse(blockerResult)
+        XCTAssertFalse(queuedResult)
+        releaseBlocker.signal()
+
+        // Mandatory cleanup times out for its caller while queued, but cannot be
+        // skipped: once the blocker drains, it runs and reports the late result.
+        let compensationResult = await compensation.value
+        if case .timedOut = compensationResult {} else {
+            XCTFail("mandatory queued operation should time out for its caller")
+        }
+        XCTAssertEqual(compensationRan.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(lateCompletionRan.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(queuedBodyRan.wait(timeout: .now()), .timedOut)
+    }
+}

--- a/CrispTests/PanelResolutionTests.swift
+++ b/CrispTests/PanelResolutionTests.swift
@@ -1,0 +1,186 @@
+import XCTest
+
+final class PanelResolutionTests: XCTestCase {
+    func testManualOverrideWinsEveryAutomaticSource() {
+        let result = PanelResolutionResolver.resolve(
+            manual: .init(width: 5120, height: 1440),
+            edid: .init(width: 3840, height: 2160),
+            registry: .init(width: 2560, height: 1440),
+            unscaledModes: [.init(width: 1024, height: 768)],
+            currentPixels: .init(width: 720, height: 480)
+        )
+        XCTAssertEqual(result, .init(resolution: .init(width: 5120, height: 1440), source: .manual))
+    }
+
+    func testEDIDWinsIncorrectFallbackMode() {
+        let result = PanelResolutionResolver.resolve(
+            manual: nil,
+            edid: .init(width: 3840, height: 2160),
+            registry: nil,
+            unscaledModes: [.init(width: 1024, height: 768), .init(width: 720, height: 480)],
+            currentPixels: .init(width: 720, height: 480)
+        )
+        XCTAssertEqual(result.resolution, .init(width: 3840, height: 2160))
+        XCTAssertEqual(result.source, .edid)
+    }
+
+    func testRegistryNativeFormatIsUsedWhenRawEDIDIsUnavailable() {
+        let result = PanelResolutionResolver.resolve(
+            manual: nil, edid: nil,
+            registry: .init(width: 3840, height: 2160),
+            unscaledModes: [.init(width: 1024, height: 768)],
+            currentPixels: .init(width: 720, height: 480)
+        )
+        XCTAssertEqual(result.resolution, .init(width: 3840, height: 2160))
+        XCTAssertEqual(result.source, .registry)
+    }
+
+    func testBaseDetailedTimingParses4KPreferredResolution() {
+        XCTAssertEqual(
+            EDIDParser.preferredResolution(from: makeEDID(basePreferred: (3840, 2160))),
+            .init(width: 3840, height: 2160)
+        )
+    }
+
+    func testCTANative4KTimingWinsSmallerBasePreferredTiming() {
+        XCTAssertEqual(
+            EDIDParser.preferredResolution(from: makeEDID(
+                basePreferred: (1920, 1080), nativeVIC: 97
+            )),
+            .init(width: 3840, height: 2160)
+        )
+    }
+
+    func testCTA720pHighRefreshVICDoesNotPromotePanelTo1080p() {
+        for vic: UInt8 in [41, 47] {
+            XCTAssertEqual(
+                EDIDParser.preferredResolution(from: makeEDID(
+                    basePreferred: (1280, 720), nativeVIC: vic
+                )),
+                .init(width: 1280, height: 720),
+                "CTA VIC \(vic) should retain 720p active dimensions"
+            )
+        }
+    }
+
+    func testInvalidEDIDChecksumIsRejected() {
+        var bytes = [UInt8](makeEDID(basePreferred: (3840, 2160)))
+        bytes[20] ^= 0xff
+        XCTAssertNil(EDIDParser.preferredResolution(from: Data(bytes)))
+    }
+
+    func testUnreadableEDIDDoesNotEraseEarlierValidResult() {
+        var evidence = PanelResolutionEvidence()
+        evidence.recordEDID(makeEDID(basePreferred: (3840, 2160)))
+        evidence.recordEDID(Data(repeating: 0, count: 128))
+        XCTAssertEqual(evidence.edid, .init(width: 3840, height: 2160))
+    }
+
+    func test4KLadderContainsPreferredStopsAndHonors6720BackingCap() {
+        let sizes = SmoothScalingGeometry.logicalSizes(
+            nativeWidth: 3840, nativeHeight: 2160, maximumBackingWidth: 6720)
+        XCTAssertTrue(sizes.contains(.init(width: 2880, height: 1620)))
+        XCTAssertTrue(sizes.contains(.init(width: 2560, height: 1440)))
+        XCTAssertEqual(sizes.first, .init(width: 3360, height: 1890))
+        XCTAssertEqual(sizes.last, .init(width: 1920, height: 1080))
+        XCTAssertTrue(sizes.allSatisfy { $0.width * 2 <= 6720 })
+        XCTAssertTrue(sizes.allSatisfy { abs(Double($0.width) / Double($0.height) - 16.0 / 9.0) < 0.002 })
+    }
+
+    func testUncappedUltrawideLadderRetainsMirrorOnlyStops() {
+        let sizes = SmoothScalingGeometry.logicalSizes(nativeWidth: 5120, nativeHeight: 1440)
+        let beyondCap = sizes.filter { $0.width > 3360 && $0.width < 5120 }
+        XCTAssertEqual(beyondCap.count, 109)
+        XCTAssertEqual(beyondCap.first, .init(width: 5104, height: 1436))
+        XCTAssertEqual(beyondCap.last, .init(width: 3376, height: 950))
+    }
+
+    func testVeryWideMirrorGridIsWindowedBelowModeObjectCeiling() {
+        let stops = stride(from: 7184, through: 3360, by: -16).map {
+            PanelResolution(width: $0, height: Int((Double($0) * 2160 / 7680).rounded()))
+        }
+        let required = PanelResolution(width: 5600, height: 1575)
+        let bounded = MirrorModeGeometry.boundedStops(
+            stops, including: required, maximumCount: 190)
+
+        XCTAssertEqual(stops.count, 240)
+        XCTAssertEqual(bounded.count, 190)
+        XCTAssertTrue(bounded.contains(required))
+        XCTAssertLessThanOrEqual(bounded.count * 2, 380)
+    }
+
+    func testMirrorGridForceIncludesRequestedOffGridStop() {
+        let stops = (0..<240).map {
+            PanelResolution(width: 7184 - $0 * 16, height: 2021 - $0 * 4)
+        }
+        let required = PanelResolution(width: 6001, height: 1688)
+        let bounded = MirrorModeGeometry.boundedStops(
+            stops, including: required, maximumCount: 190)
+
+        XCTAssertEqual(bounded.count, 190)
+        XCTAssertTrue(bounded.contains(required))
+        XCTAssertTrue(bounded.contains(.init(width: 6016, height: 1729)))
+        XCTAssertTrue(bounded.contains(.init(width: 6000, height: 1725)))
+    }
+
+    func testMirrorGridCentersNumericallyEvenWhenCandidatesAreUnordered() {
+        let stops = (0..<240).map {
+            PanelResolution(width: 7184 - $0 * 16, height: 2021 - $0 * 4)
+        }
+        let required = stops[120]
+        let bounded = MirrorModeGeometry.boundedStops(
+            Array(stops.reversed()), including: required, maximumCount: 190)
+
+        XCTAssertEqual(bounded.first, stops[25])
+        XCTAssertEqual(bounded.last, stops[214])
+        XCTAssertEqual(bounded[95], required)
+    }
+
+    func testMirrorGridClampsWindowAtNumericEnds() {
+        let stops = (0..<240).map {
+            PanelResolution(width: 7184 - $0 * 16, height: 2021 - $0 * 4)
+        }
+
+        let upper = MirrorModeGeometry.boundedStops(
+            stops, including: stops[0], maximumCount: 190)
+        let lower = MirrorModeGeometry.boundedStops(
+            stops, including: stops[239], maximumCount: 190)
+
+        XCTAssertEqual(upper, Array(stops[0..<190]))
+        XCTAssertEqual(lower, Array(stops[50..<240]))
+    }
+
+    private func makeEDID(basePreferred: (Int, Int), nativeVIC: UInt8? = nil) -> Data {
+        var base = [UInt8](repeating: 0, count: 128)
+        base[0..<8] = [0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00]
+        base[18] = 1
+        base[19] = 4
+        base[24] = 0x02
+        encodeDetailedTiming(basePreferred, into: &base, at: 54)
+        base[126] = nativeVIC == nil ? 0 : 1
+        setChecksum(&base)
+
+        guard let nativeVIC else { return Data(base) }
+        var cta = [UInt8](repeating: 0, count: 128)
+        cta[0] = 0x02
+        cta[1] = 0x03
+        cta[2] = 6
+        cta[4] = 0x41
+        cta[5] = nativeVIC | 0x80
+        setChecksum(&cta)
+        return Data(base + cta)
+    }
+
+    private func encodeDetailedTiming(_ resolution: (Int, Int), into bytes: inout [UInt8], at offset: Int) {
+        bytes[offset] = 1
+        bytes[offset + 1] = 1
+        bytes[offset + 2] = UInt8(resolution.0 & 0xff)
+        bytes[offset + 4] = UInt8((resolution.0 >> 8) << 4)
+        bytes[offset + 5] = UInt8(resolution.1 & 0xff)
+        bytes[offset + 7] = UInt8((resolution.1 >> 8) << 4)
+    }
+
+    private func setChecksum(_ bytes: inout [UInt8]) {
+        bytes[127] = UInt8((256 - bytes[0..<127].reduce(0, { $0 + Int($1) }) % 256) % 256)
+    }
+}

--- a/CrispTests/PresetResolutionRoutingTests.swift
+++ b/CrispTests/PresetResolutionRoutingTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+final class PresetResolutionRoutingTests: XCTestCase {
+    func testBeyondCapHiDPIPresetBeatsSameSizePhysicalLoDPI() {
+        let route = PresetResolutionRouter.route(
+            width: 3840, height: 1080, isHiDPI: true,
+            candidates: [
+                .init(width: 3840, height: 1080, isHiDPI: false),
+                .init(width: 3360, height: 945, isHiDPI: true)
+            ],
+            beyondCapStops: [.init(width: 3840, height: 1080)]
+        )
+        XCTAssertEqual(route, .mirror)
+    }
+
+    func testEnumeratedHiDPIPresetUsesPhysicalMode() {
+        let route = PresetResolutionRouter.route(
+            width: 2560, height: 1440, isHiDPI: true,
+            candidates: [
+                .init(width: 2560, height: 1440, isHiDPI: false),
+                .init(width: 2560, height: 1440, isHiDPI: true)
+            ],
+            beyondCapStops: []
+        )
+        XCTAssertEqual(route, .physical(index: 1))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ xcodegen generate   # generates Crisp.xcodeproj from project.yml
 open Crisp.xcodeproj
 ```
 
+If macOS reports a compatibility mode as a display's native size, Crisp prefers
+validated EDID/native-format metadata and also offers a per-display manual fallback
+under Resolution > Native resolution. See [Native panel resolution](docs/native-resolution.md)
+for the inference order and smooth-scaling limits.
+
 For a distributable DMG (Command Line Tools only, no full Xcode) and the fast edit-compile-run dev loop, see [docs/BUILDING.md](docs/BUILDING.md).
 
 ## Contributing

--- a/docs/native-resolution.md
+++ b/docs/native-resolution.md
@@ -1,0 +1,29 @@
+# Native panel resolution
+
+Crisp needs the physical panel dimensions to filter mode families and build the
+smooth-scaling ladder. The current desktop mode and macOS's `native` mode flag are
+not reliable inputs: after a bad link negotiation or another display override,
+WindowServer can mark a compatibility timing such as 1024×768 as native even though
+the connected panel is 3840×2160.
+
+Resolution inference therefore uses this order:
+
+1. A per-display manual panel-resolution override, when the user set one.
+2. The preferred/native detailed timing from a checksum-valid EDID.
+3. `NativeFormatHorizontalPixels` and `NativeFormatVerticalPixels` from Apple's
+   EDID-derived display metadata (the raw EDID is often unavailable through DCP on
+   Apple Silicon).
+4. The largest unscaled mode, retained as a compatibility fallback.
+5. The current pixel dimensions if no other evidence exists.
+
+Manual values are stored by vendor, product, and serial identity and are always
+entered in the panel's unrotated space. They can be changed or reset under
+Resolution > Native resolution. Changing the value does not silently rewrite an
+installed `/Library/Displays` override; the Smooth scaling switch reflects that the
+old grid no longer matches, and enabling it writes the corrected grid through the
+normal administrator-authorized flow.
+
+On Apple Silicon, smooth-scaling entries are limited to a 6720-pixel backing width,
+matching the current WindowServer/DCP limit. A 3840×2160 panel therefore receives a
+dense 16:9 HiDPI ladder from 1920×1080 through 3360×1890, including 2560×1440 and
+2880×1620, plus the real 3840×2160 1× native endpoint.

--- a/project.yml
+++ b/project.yml
@@ -73,8 +73,10 @@ targets:
       - path: Crisp/Models/GammaPersistenceKey.swift
       - path: Crisp/Models/VariableRefreshModes.swift
       - path: Crisp/Models/KeyboardShortcut.swift
+      - path: Crisp/Models/PanelResolution.swift
       - path: Crisp/Models/DisplayPreset.swift
       - path: Crisp/Models/CrispControlModel.swift
+      - path: Crisp/Services/CGHelpers.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.crisp.tests


### PR DESCRIPTION
## Summary

- Detect the native panel resolution from EDID and display-registry metadata, with display modes and current pixel dimensions as fallbacks.
- Use the native dimensions and aspect ratio when generating smooth-scaling modes.
- Include `DisplayPixelDimensions` in the macOS display override so smooth scaling can activate after display reinitialization without requiring a reboot.
- Show the detected native panel resolution directly below the Smooth scaling control.
- Cache display presets outside SwiftUI view rendering to avoid layout-time preference reads and crashes.
- Add tests, localization, and documentation for native-resolution detection and overrides.

## Testing

- `make check`
- Verified native resolution detection as 3840 × 2160 on a Samsung S32B80P.
- Verified enabling Smooth scaling and reinitializing the display without rebooting.