### PR TITLE
Avoid preset reads during SwiftUI layout

### DIFF
--- a/Crisp/Views/DisplayDetailView.swift
+++ b/Crisp/Views/DisplayDetailView.swift
@@ -13,6 +13,8 @@ import SwiftUI
 final class DisplayProfileController: ObservableObject {
     let display: DisplayInfo
     @Published var presetName: String = ""
+    @Published var presets: [DisplayPresetService.Preset] = []
+    @Published var activePresetIndex: Int?
     @Published var activeProfileName: String = ""
 
     init(display: DisplayInfo) {
@@ -22,12 +24,17 @@ final class DisplayProfileController: ObservableObject {
     func reload() {
         activeProfileName = ColorProfileService.shared.currentColorSpaceName(for: display.displayID)
         let svc = DisplayPresetService.shared
-        if let idx = svc.activePresetIndex(for: display.displayID) {
-            presetName = svc.presets(for: display.displayID)
-                .first(where: { $0.index == idx })?.name ?? ""
-        } else {
-            presetName = ""
-        }
+        // MonitorPanel's KVC getters can spin the main run loop. Never invoke
+        // them from a SwiftUI body: a screen-parameter notification delivered
+        // by that nested run loop re-enters AttributeGraph mid-update and macOS
+        // aborts on its value_set precondition. Cache one snapshot here instead.
+        let newPresets = svc.presets(for: display.displayID)
+        let newActiveIndex = svc.activePresetIndex(for: display.displayID)
+        presets = newPresets
+        activePresetIndex = newActiveIndex
+        presetName = newActiveIndex.flatMap { idx in
+            newPresets.first(where: { $0.index == idx })?.name
+        } ?? ""
     }
 
     func refreshActiveProfileName() {
@@ -85,7 +92,7 @@ struct ProfileBodyBlock: View {
 
     var body: some View {
         if !controller.presetName.isEmpty {
-            DisplayPresetView(displayID: controller.display.displayID, activeName: $controller.presetName)
+            DisplayPresetView(controller: controller)
         } else {
             ColorProfileView(display: controller.display, activeProfileName: $controller.activeProfileName)
         }

--- a/Crisp/Views/DisplayPresetView.swift
+++ b/Crisp/Views/DisplayPresetView.swift
@@ -4,29 +4,14 @@ import SwiftUI
 /// for displays that have presets (XDR builtin panels). A native checkmarked
 /// list (same style as the resolution list), not a nested popup.
 struct DisplayPresetView: View {
-    let displayID: CGDirectDisplayID
-    /// The parent row's subtitle; updated here so it refreshes on switch.
-    @Binding var activeName: String
-    /// Optimistic override set on tap; nil means "use the live active index".
-    @State private var selectedIndex: Int?
-
-    // Computed (not loaded in .onAppear) so the list is full-height on the first
-    // frame, letting this section's expand animation match Resolution/Refresh,
-    // which also compute their list. Loading in .onAppear grew the height
-    // mid-spring, so the open animation looked different.
-    private var presets: [DisplayPresetService.Preset] {
-        DisplayPresetService.shared.presets(for: displayID)
-    }
-    private var activeIndex: Int? {
-        selectedIndex ?? DisplayPresetService.shared.activePresetIndex(for: displayID)
-    }
+    @ObservedObject var controller: DisplayProfileController
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ForEach(presets) { preset in
+            ForEach(controller.presets) { preset in
                 CheckmarkRow(
                     label: preset.name,
-                    isSelected: preset.index == activeIndex
+                    isSelected: preset.index == controller.activePresetIndex
                 ) {
                     select(preset)
                 }
@@ -35,10 +20,13 @@ struct DisplayPresetView: View {
     }
 
     private func select(_ preset: DisplayPresetService.Preset) {
-        guard preset.index != activeIndex else { return }
-        if DisplayPresetService.shared.setActivePreset(index: preset.index, for: displayID) {
-            selectedIndex = preset.index
-            activeName = preset.name
+        guard preset.index != controller.activePresetIndex else { return }
+        if DisplayPresetService.shared.setActivePreset(
+            index: preset.index,
+            for: controller.display.displayID
+        ) {
+            controller.activePresetIndex = preset.index
+            controller.presetName = preset.name
         }
     }
 }


### PR DESCRIPTION
## Summary

- Cache display presets and the active preset index in `DisplayProfileController.reload()`.
- Render `DisplayPresetView` from the cached controller state and update that state after a successful selection.
- Avoid MonitorPanel KVC reads from SwiftUI view bodies, where nested screen-parameter notifications can re-enter AttributeGraph and trigger a precondition crash.

Split from #86 at reviewer request so the crash fix can land independently.

## Testing

- `make check`