### PR TITLE
Log DDC and key tap transitions, ask for the capture in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -64,3 +64,13 @@ body:
       description: Screenshots, error messages, or anything unusual about your setup.
     validations:
       required: false
+  - type: textarea
+    id: crisp-log
+    attributes:
+      label: Crisp log
+      description: |
+        For anything about brightness, volume, DDC, or the brightness keys, this is the most useful thing you can attach. Reproduce the problem first, then run this in Terminal and drag the file it creates into this field:
+        `log show --last 30m --predicate 'subsystem == "com.crisp.app"' --style compact > ~/Desktop/crisp-log.txt`
+        The log stays on your Mac until you attach it. It lists display models and DDC commands, no personal data. Empty on Crisp 1.5.0 and older.
+    validations:
+      required: false

--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -110,9 +110,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             // hidden once trust settles true). Re-check a couple of times as trust settles and arm
             // if it has; start() is idempotent, and this is bounded so users who never granted
             // don't poll forever. (upgrade zombie)
+            // Logged so a support capture shows the #57 case: System Settings lists
+            // Crisp as allowed, but the grant belongs to a differently signed build.
+            Self.log.notice("Accessibility not trusted at launch, key tap not started; re-checking at 1 s and 3 s")
             for delay in [1.0, 3.0] {
                 DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                    if AXIsProcessTrusted() { BrightnessKeyService.shared.start() }
+                    if AXIsProcessTrusted() {
+                        BrightnessKeyService.shared.start()
+                    } else if delay == 3.0 {
+                        Self.log.notice("Accessibility still not trusted after 3 s, brightness keys stay off until armed from the panel")
+                    }
                 }
             }
         }

--- a/Crisp/Services/BrightnessKeyService.swift
+++ b/Crisp/Services/BrightnessKeyService.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CoreGraphics
 import ApplicationServices
+import os.log
 
 // MARK: - C Event Tap Callback
 
@@ -64,6 +65,9 @@ final class BrightnessKeyService: @unchecked Sendable {
     /// Volume keys use the same 1/16 step as macOS's own volume control.
     private nonisolated static let volumeStep: Double = 100.0 / 16.0
 
+    /// Tap lifecycle at notice: #57 lost a round trip on a silently dead tap.
+    private nonisolated static let log = Logger(subsystem: "com.crisp.app", category: "keys")
+
     // MARK: - Start / Stop
 
     /// Installs the event tap. Requires Accessibility permissions.
@@ -107,12 +111,14 @@ final class BrightnessKeyService: @unchecked Sendable {
         self.runLoopSource = source
         stopRetrying()
         startTrustWatchdog()
+        Self.log.notice("key tap armed")
     }
 
     /// Removes the event tap and releases the retained self reference.
     func stop() {
         stopTrustWatchdog()
         if let tap = eventTap {
+            Self.log.notice("key tap removed")
             CGEvent.tapEnable(tap: tap, enable: false)
             if let source = runLoopSource {
                 CFRunLoopRemoveSource(CFRunLoopGetMain(), source, .commonModes)
@@ -139,6 +145,7 @@ final class BrightnessKeyService: @unchecked Sendable {
         // ponytail: unbounded 2s poll; tapCreate is cheap and it stops the instant the grant
         // lands. The activation observer just makes it feel instant when the user clicks back in.
         if pollTimer == nil {
+            Self.log.notice("key tap refused (Accessibility not granted for this build?), retrying every 2 s")
             pollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] timer in
                 // Scheduled from the main actor, so it fires on the main run loop.
                 MainActor.assumeIsolated {
@@ -197,6 +204,7 @@ final class BrightnessKeyService: @unchecked Sendable {
             MainActor.assumeIsolated {
                 guard let self else { timer.invalidate(); return }
                 guard self.eventTap != nil, !AXIsProcessTrusted() else { return }
+                Self.log.notice("Accessibility trust dropped, tearing the key tap down")
                 self.disabledAt = ProcessInfo.processInfo.systemUptime
                 self.stop()
                 self.retryUntilArmed()
@@ -233,6 +241,7 @@ final class BrightnessKeyService: @unchecked Sendable {
         // just a few seconds later, without ever risking the freeze. (kome)
         if type.rawValue == CGEventType.tapDisabledByTimeout.rawValue ||
            type.rawValue == CGEventType.tapDisabledByUserInput.rawValue {
+            Self.log.notice("key tap disabled by the system (\(type.rawValue == CGEventType.tapDisabledByTimeout.rawValue ? "timeout" : "user input", privacy: .public)), re-arming after settle")
             DispatchQueue.main.async {
                 MainActor.assumeIsolated {
                     self.disabledAt = ProcessInfo.processInfo.systemUptime

--- a/Crisp/Services/BrightnessService.swift
+++ b/Crisp/Services/BrightnessService.swift
@@ -4,6 +4,7 @@ import IOKit.graphics
 import CoreGraphics
 // For CGDisplayCreateUUIDFromDisplayID (ApplicationServices, not CoreGraphics).
 import AppKit
+import os.log
 
 @_silgen_name("CGDisplayIOServicePort")
 private func CGDisplayIOServicePort(_ display: CGDirectDisplayID) -> io_service_t
@@ -254,6 +255,8 @@ final class BrightnessService: @unchecked Sendable {
     /// nil  = not yet determined
     /// true = DDC write succeeded at least once
     /// false = DDC write has failed; use software (gamma) fallback
+    private static let log = Logger(subsystem: "com.crisp.app", category: "brightness")
+
     private var ddcAvailable: [CGDirectDisplayID: Bool] = [:]
     private let ddcAvailableLock = NSLock()
 
@@ -321,6 +324,9 @@ final class BrightnessService: @unchecked Sendable {
                     self.ddcAvailable[displayID] = true
                     self.ddcMaxBrightness[displayID] = result.max
                     self.ddcAvailableLock.unlock()
+                    if firstRead {
+                        Self.log.notice("display \(displayID, privacy: .public): DDC brightness read ok \(result.current, privacy: .public)/\(result.max, privacy: .public), brightness over DDC")
+                    }
                     Task { @MainActor in
                         // DDC reads quantize (many panels expose a coarser internal
                         // scale than they accept), so a value we just set can read back
@@ -465,8 +471,11 @@ final class BrightnessService: @unchecked Sendable {
     private var hdrDimmedDisplays: Set<CGDirectDisplayID> = []
 
     func setHDRSoftwareDimming(_ on: Bool, for displayID: CGDirectDisplayID) {
-        ddcAvailableLock.withLock {
-            if on { hdrDimmedDisplays.insert(displayID) } else { hdrDimmedDisplays.remove(displayID) }
+        let changed = ddcAvailableLock.withLock {
+            on ? hdrDimmedDisplays.insert(displayID).inserted : hdrDimmedDisplays.remove(displayID) != nil
+        }
+        if changed {
+            Self.log.notice("display \(displayID, privacy: .public): HDR mode \(on ? "on, brightness routed to software gamma" : "off, brightness back on DDC", privacy: .public)")
         }
     }
 
@@ -562,7 +571,14 @@ final class BrightnessService: @unchecked Sendable {
         ) { [weak self] success in
             guard let self else { return }
             if success {
-                self.ddcAvailableLock.withLock { self.ddcAvailable[displayID] = true }
+                let firstSuccess = self.ddcAvailableLock.withLock { () -> Bool in
+                    let was = self.ddcAvailable[displayID]
+                    self.ddcAvailable[displayID] = true
+                    return was != true
+                }
+                if firstSuccess {
+                    Self.log.notice("display \(displayID, privacy: .public): DDC brightness write acknowledged, brightness over DDC")
+                }
                 self.ddcPumpLock.withLock { self.ddcFailStreak[displayID] = 0 }
             } else {
                 let streak = self.ddcPumpLock.withLock { () -> Int in
@@ -574,6 +590,9 @@ final class BrightnessService: @unchecked Sendable {
                 // mid-drag (DDC + gamma dimming stack up and later "reset" visibly).
                 // Only give up on DDC after 3 consecutive failures.
                 if streak >= 3 {
+                    if streak == 3 {
+                        Self.log.notice("display \(displayID, privacy: .public): 3 consecutive DDC brightness writes failed, brightness now software gamma until reconnect")
+                    }
                     self.ddcAvailableLock.withLock { self.ddcAvailable[displayID] = false }
                     DispatchQueue.main.async { [weak self] in
                         self?.setSoftwareBrightness(percent, for: displayID)

--- a/Crisp/Services/DDCService.swift
+++ b/Crisp/Services/DDCService.swift
@@ -4,6 +4,7 @@ import CoreGraphics
 import IOKit
 import IOKit.i2c
 import IOKit.graphics
+import os.log
 
 @_silgen_name("CGDisplayIOServicePort")
 private func CGDisplayIOServicePort(_ display: CGDirectDisplayID) -> io_service_t
@@ -20,6 +21,23 @@ final class DDCService: ObservableObject, @unchecked Sendable {
     static let brightnessVCP: UInt8 = 0x10
     static let contrastVCP: UInt8   = 0x12
     static let volumeVCP: UInt8     = 0x62
+
+    /// Diagnostics for support threads. Transitions and failures go out at
+    /// notice/error (persisted; reporters run `log show --predicate
+    /// 'subsystem == "com.crisp.app"'`), per-write chatter at debug (memory
+    /// only). Display IDs and vendor/product pair with the pairing lines;
+    /// serials never appear.
+    private static let log = Logger(subsystem: "com.crisp.app", category: "ddc")
+    /// A single I2C op slower than this is logged at notice (issue #72: 12 s reads).
+    private static let slowOpThresholdMs = 500.0
+
+    private static func millisSince(_ start: DispatchTime) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+    }
+
+    private static func hex(_ code: UInt8) -> String { String(format: "0x%02X", code) }
+    /// Last logged pairing outcome, guarded by avServiceLock; reset on the map flush.
+    private var lastPairingSummary = ""
     static let powerVCP: UInt8      = 0xD6
 
     private let ddcQueue = DispatchQueue(label: "com.crisp.ddc", qos: .userInitiated)
@@ -146,6 +164,36 @@ final class DDCService: ObservableObject, @unchecked Sendable {
         }
         let result = DDCServiceMatcher.match(services: identities, displays: displays)
 
+        // Log the pairing once per outcome: with no channel at all the walk
+        // re-runs on every DDC op, and six identical lines per probe help nobody.
+        var lines: [(error: Bool, text: String)] = []
+        for display in displays {
+            let vendorProduct = String(format: "vendor 0x%04X product 0x%04X",
+                                       display.identity.vendor, display.identity.product)
+            if let index = result.byDisplayID[display.id] {
+                let byIdentity = identities[index].map {
+                    $0.vendor == display.identity.vendor && $0.product == display.identity.product
+                } ?? false
+                lines.append((false, "pairing: display \(display.id) (\(vendorProduct)) -> channel \(index) of \(ordered.count) by \(byIdentity ? "identity" : "traversal order")"))
+            } else {
+                lines.append((true, "pairing: display \(display.id) (\(vendorProduct)) -> no DDC channel (\(ordered.count) found)"))
+            }
+        }
+        let summary = lines.map(\.text).joined(separator: "\n")
+        let changed = avServiceLock.withLock { () -> Bool in
+            defer { lastPairingSummary = summary }
+            return summary != lastPairingSummary
+        }
+        if changed {
+            for line in lines {
+                if line.error {
+                    Self.log.error("\(line.text, privacy: .public)")
+                } else {
+                    Self.log.notice("\(line.text, privacy: .public)")
+                }
+            }
+        }
+
         var map: [CGDirectDisplayID: IOAVServiceRef] = [:]
         // Safe: each CGDirectDisplayID key is assigned exactly once, so the unspecified
         // Dictionary iteration order cannot drop or overwrite an entry.
@@ -240,7 +288,10 @@ final class DDCService: ObservableObject, @unchecked Sendable {
     ///   [0x84, 0x03, vcpCode, valueHigh, valueLow, checksum]
     /// Checksum = XOR of 0x50 (0x51 XOR 0x01) with all preceding buffer bytes.
     private func arm64Write(displayID: CGDirectDisplayID, command: UInt8, value: UInt16) -> Bool {
-        guard let avService = findAVService(for: displayID) else { return false }
+        guard let avService = findAVService(for: displayID) else {
+            Self.log.debug("write \(Self.hex(command), privacy: .public) display \(displayID, privacy: .public): no DDC channel")
+            return false
+        }
 
         let valueHigh = UInt8((value >> 8) & 0xFF)
         let valueLow  = UInt8(value & 0xFF)
@@ -252,6 +303,9 @@ final class DDCService: ObservableObject, @unchecked Sendable {
 
         var buf: [UInt8] = payload + [checksum]
         let ret = IOAVServiceWriteI2C(avService, 0x37, 0x51, &buf, UInt32(buf.count))
+        if ret != kIOReturnSuccess {
+            Self.log.debug("write \(Self.hex(command), privacy: .public)=\(value, privacy: .public) display \(displayID, privacy: .public): I2C error \(String(format: "0x%08X", ret), privacy: .public)")
+        }
         return ret == kIOReturnSuccess
     }
 
@@ -259,7 +313,16 @@ final class DDCService: ObservableObject, @unchecked Sendable {
     /// Request layout: [0x82, 0x01, vcpCode, checksum]
     /// Response bytes 4-7 carry: [maxHigh, maxLow, curHigh, curLow]
     private func arm64Read(displayID: CGDirectDisplayID, command: UInt8) -> (current: UInt16, max: UInt16)? {
-        guard let avService = findAVService(for: displayID) else { return nil }
+        guard let avService = findAVService(for: displayID) else {
+            Self.log.debug("read \(Self.hex(command), privacy: .public) display \(displayID, privacy: .public): no DDC channel")
+            return nil
+        }
+        // Every failure class gets its own line: this is what a reporter's log
+        // capture answers instead of a round of questions (docs/ddc-notes.md).
+        func fail(_ reason: String) -> (current: UInt16, max: UInt16)? {
+            Self.log.notice("read \(Self.hex(command), privacy: .public) display \(displayID, privacy: .public): \(reason, privacy: .public)")
+            return nil
+        }
 
         // Build and send the VCP Get Request packet
         var requestChecksum = UInt8(0x6E ^ 0x51)
@@ -269,7 +332,7 @@ final class DDCService: ObservableObject, @unchecked Sendable {
 
         let writeRet = IOAVServiceWriteI2C(avService, 0x37, 0x51, &requestBuf, UInt32(requestBuf.count))
         guard writeRet == kIOReturnSuccess else {
-            return nil
+            return fail("request write I2C error \(String(format: "0x%08X", writeRet))")
         }
 
         // Wait for the display to prepare its DDC/CI reply (~40ms per spec)
@@ -279,7 +342,7 @@ final class DDCService: ObservableObject, @unchecked Sendable {
         var replyBuf = [UInt8](repeating: 0, count: 12)
         let readRet = IOAVServiceReadI2C(avService, 0x37, 0x51, &replyBuf, UInt32(replyBuf.count))
         guard readRet == kIOReturnSuccess else {
-            return nil
+            return fail("reply read I2C error \(String(format: "0x%08X", readRet))")
         }
 
         // DDC/CI VCP reply format (IOAVService variant):
@@ -307,7 +370,8 @@ final class DDCService: ObservableObject, @unchecked Sendable {
               replyBuf[3] == 0x00,      // result code: no error
               replyBuf[4] == command    // echo of the VCP code we asked for
         else {
-            return nil
+            let head = replyBuf.prefix(6).map { String(format: "%02X", $0) }.joined(separator: " ")
+            return fail("bad reply header [\(head)] (null frame, echo, or stale EDID bytes)")
         }
 
         // Header bytes alone are only 4 bytes of protection: a wedged DDC
@@ -318,15 +382,16 @@ final class DDCService: ObservableObject, @unchecked Sendable {
         var expectedChecksum = UInt8(0x50)
         for i in 0...9 { expectedChecksum ^= replyBuf[i] }
         guard expectedChecksum == replyBuf[10] else {
-            return nil
+            return fail("bad reply checksum")
         }
 
         let maxVal = (UInt16(replyBuf[6]) << 8) | UInt16(replyBuf[7])
         let curVal = (UInt16(replyBuf[8]) << 8) | UInt16(replyBuf[9])
         // A zero max is also invalid (would make every write 0); reject it.
         guard maxVal > 0 else {
-            return nil
+            return fail("reply carries max 0")
         }
+        Self.log.notice("read \(Self.hex(command), privacy: .public) display \(displayID, privacy: .public): ok \(curVal, privacy: .public)/\(maxVal, privacy: .public)")
         return (current: curVal, max: maxVal)
     }
 #endif
@@ -403,6 +468,13 @@ final class DDCService: ObservableObject, @unchecked Sendable {
     /// Synchronous DDC write (VCP Set). Returns true on success.
     /// On ARM64 uses the IOAVService path; on x86_64 uses the IOFramebuffer I2C path.
     private func writeSynchronous(displayID: CGDirectDisplayID, command: UInt8, value: UInt16) -> Bool {
+        let start = DispatchTime.now()
+        defer {
+            let ms = Self.millisSince(start)
+            if ms > Self.slowOpThresholdMs {
+                Self.log.notice("slow write \(Self.hex(command), privacy: .public) display \(displayID, privacy: .public): \(Int(ms), privacy: .public) ms")
+            }
+        }
 #if arch(arm64)
         // ARM64 primary path
         if arm64Write(displayID: displayID, command: command, value: value) {
@@ -437,17 +509,24 @@ final class DDCService: ObservableObject, @unchecked Sendable {
             guard Date() >= until else { return nil }
             readQuarantineUntil.removeValue(forKey: displayID)
             readFailStreak[displayID] = 0
+            Self.log.notice("display \(displayID, privacy: .public): read quarantine expired, probing again")
         }
+        let start = DispatchTime.now()
 #if arch(arm64)
         let result = arm64Read(displayID: displayID, command: command)
 #else
         let result = intelReadSynchronous(displayID: displayID, command: command)
 #endif
+        let ms = Self.millisSince(start)
+        if ms > Self.slowOpThresholdMs {
+            Self.log.notice("slow read \(Self.hex(command), privacy: .public) display \(displayID, privacy: .public): \(Int(ms), privacy: .public) ms")
+        }
         if result == nil {
             let streak = readFailStreak[displayID, default: 0] + 1
             readFailStreak[displayID] = streak
             if streak >= readQuarantineThreshold {
                 readQuarantineUntil[displayID] = Date().addingTimeInterval(readQuarantineInterval)
+                Self.log.notice("display \(displayID, privacy: .public): \(streak, privacy: .public) consecutive read failures, reads quarantined for \(Int(self.readQuarantineInterval), privacy: .public) s")
             }
         } else {
             readFailStreak[displayID] = 0
@@ -602,6 +681,7 @@ final class DDCService: ObservableObject, @unchecked Sendable {
     /// per-removed-ID cleanup never sees that, and the stale map then writes
     /// one monitor's brightness into the other's channel.
     func invalidateAllChannelMappings() {
+        Self.log.notice("display reconfiguration: channel map flushed, pairing re-runs on the next DDC op")
         ddcQueue.async {
             self.readFailStreak.removeAll()
             self.readQuarantineUntil.removeAll()
@@ -610,6 +690,7 @@ final class DDCService: ObservableObject, @unchecked Sendable {
         avServiceLock.lock()
         avServiceCache.removeAll()
         allExternalAVServices.removeAll()
+        lastPairingSummary = ""
         avServiceLock.unlock()
 #endif
     }
@@ -631,11 +712,13 @@ final class DDCService: ObservableObject, @unchecked Sendable {
                     self.cacheLock.lock()
                     self.vcpCache[displayID]?[command] = nil
                     self.cacheLock.unlock()
+                    Self.log.debug("write \(Self.hex(command), privacy: .public)=\(value, privacy: .public) display \(displayID, privacy: .public): ok (attempt \(attempt + 1, privacy: .public))")
                     completion?(true)
                     return
                 }
                 if attempt < 2 { Thread.sleep(forTimeInterval: 0.05) }
             }
+            Self.log.error("write \(Self.hex(command), privacy: .public)=\(value, privacy: .public) display \(displayID, privacy: .public): failed all 3 attempts")
             completion?(false)
         }
     }
@@ -670,6 +753,7 @@ final class DDCService: ObservableObject, @unchecked Sendable {
                 }
                 if attempt < 2 { Thread.sleep(forTimeInterval: 0.05) }
             }
+            Self.log.notice("read \(Self.hex(command), privacy: .public) display \(displayID, privacy: .public): no valid reply in 3 attempts")
             completion(nil)
         }
     }

--- a/Crisp/Services/VolumeService.swift
+++ b/Crisp/Services/VolumeService.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreGraphics
 import CoreAudio
 import AppKit
+import os.log
 
 /// DDC/CI speaker volume (VCP 0x62) for external monitors (issue #23):
 /// support probing, a coalesced writer, mute, and default-audio-output
@@ -12,6 +13,8 @@ import AppKit
 final class VolumeService: ObservableObject {
     static let shared = VolumeService()
     private init() {}
+
+    private static let log = Logger(subsystem: "com.crisp.app", category: "volume")
 
     /// Raw DDC max volume per display (usually 100), from the probe read.
     private var ddcMax: [CGDirectDisplayID: UInt16] = [:]
@@ -81,7 +84,17 @@ final class VolumeService: ObservableObject {
         let uuid = display.displayUUID
         DDCService.shared.readAsync(displayID: id, command: DDCService.volumeVCP) { result in
             Task { @MainActor in
-                guard let result else { return }
+                guard let result else {
+                    // Only while the feature is hidden: a remembered or forced
+                    // display failing a probe is the DDC layer's line to log.
+                    if !display.volumeSupported {
+                        Self.log.notice("\(display.name, privacy: .public): volume probe (VCP 0x62) got no valid reply, slider hidden; the Volume Control toggle forces write-only")
+                    }
+                    return
+                }
+                if !self.rememberedCapable.contains(uuid) {
+                    Self.log.notice("\(display.name, privacy: .public): volume probe ok \(result.current, privacy: .public)/\(result.max, privacy: .public), slider shown")
+                }
                 self.ddcMax[id] = result.max
                 display.volumeSupported = true
                 self.rememberCapable(uuid)

--- a/Crisp/Views/BrightnessSliderView.swift
+++ b/Crisp/Views/BrightnessSliderView.swift
@@ -72,10 +72,19 @@ struct BrightnessSliderView: View {
     // display->slider sync pull it back down through the fade.
     @State private var clickGliding: Bool = false
 
+    /// Debug switch: `defaults write com.crisp.app crisp.showBrightnessControlMode -bool true`
+    /// (relaunch Crisp) shows the mode row above every brightness slider, so a support
+    /// thread can tell DDC from software gamma without opening the monitor's menu. Read
+    /// once at launch, like `crisp.disableKeepAwake`; no Settings row on purpose.
+    /// ponytail: reads the DDC latch only. An HDR-dimmed external writes gamma but still
+    /// shows "DDC"; fold in BrightnessService's hdrDimmedDisplays if that ever misleads.
+    static let showControlMode = UserDefaults.standard.bool(forKey: "crisp.showBrightnessControlMode")
+
     var body: some View {
         VStack(spacing: 2) {
-            // Mode indicator row
-            if !compact {
+            // Mode indicator row: normally only in non-compact use (none today), or on
+            // every slider while the debug switch above is set.
+            if !compact || Self.showControlMode {
             HStack(spacing: 4) {
                 Spacer()
                 if display.isBuiltin {

--- a/docs/ddc-notes.md
+++ b/docs/ddc-notes.md
@@ -20,6 +20,17 @@ ships as a result. Read this before touching DDCService or chasing a
   display is in HDR mode (`hdrDimmedDisplays`, pushed by
   BrightnessBoostService): a DisplayHDR monitor owns its luminance and
   silently discards DDC brightness writes while still acking them.
+- The unified log, subsystem `com.crisp.app`, categories `ddc`,
+  `brightness`, `volume`, `keys`. Channel pairing per display and the
+  strategy it took, every probe reply or its failure class (I2C error,
+  bad header with the first six bytes, bad checksum, max 0), writes that
+  failed all three attempts, the three-failure latch to gamma, HDR
+  routing, read quarantine start and expiry, the map flush on
+  reconfiguration, any single I2C op over 500 ms, and the key tap
+  lifecycle. Per-write chatter sits at debug (memory only). The bug form
+  asks reporters for `log show --last 30m --predicate 'subsystem ==
+  "com.crisp.app"' --style compact`. Read that capture before asking
+  questions; #14, #57 and #72 were each one capture's worth.
 - `scripts/ddc-probe.swift`: read-only. Lists displays, channels, and
   raw VCP 0x10 replies with header/checksum verdicts. Run this FIRST when
   a slider goes dead; it names the failure in seconds.

--- a/docs/ddc-notes.md
+++ b/docs/ddc-notes.md
@@ -23,6 +23,12 @@ ships as a result. Read this before touching DDCService or chasing a
 - `scripts/ddc-probe.swift`: read-only. Lists displays, channels, and
   raw VCP 0x10 replies with header/checksum verdicts. Run this FIRST when
   a slider goes dead; it names the failure in seconds.
+- In-app tell for a user's Mac (no scripts): `defaults write com.crisp.app
+  crisp.showBrightnessControlMode -bool true`, relaunch Crisp. A caption
+  above each brightness slider then reads DDC (green, a write or read
+  succeeded), Software (orange, the three-failure latch flipped to gamma),
+  or System for the built-in; nothing until the first write settles it.
+  `-bool false` or `defaults delete` puts it back. Not in 1.5.0.
 - `scripts/ddc-write-probe.swift [aoc|dell] <value ... | burst>`: sends
   real brightness writes (visible on the monitor). `burst` simulates a
   slider drag (61 writes, 50ms pacing).


### PR DESCRIPTION
## What & why

Every DDC report so far (#14, #57, #72, and now #88) needed a round trip or someone else's hardware to learn things Crisp already knew at runtime. This adds unified-log lines at exactly the transitions those threads turned on, and a field in the bug form asking for the capture.

Subsystem `com.crisp.app`. Category `ddc`: channel pairing per display and the strategy it took (identity or traversal order), logged once per outcome; every probe reply or its failure class (I2C error code, bad header with the first six bytes, bad checksum, max 0); writes that failed all three attempts; read quarantine start and expiry; the map flush on reconfiguration; any single I2C op over 500 ms. Category `brightness`: the three-failure latch to software gamma, the first DDC confirmation, HDR routing. Category `volume`: what the 0x62 probe meant for the slider. Categories `keys` and `app`: tap armed, refused, removed, disabled by the system, trust dropped, and the launch trust decision that went silent in #57. Transitions sit at notice and error so they persist; per-write chatter sits at debug, which macOS keeps in memory only. The lines carry display IDs, model names, and vendor/product, never serials. Nothing leaves the Mac; the reporter runs `log show` and attaches the file.

The bug form gets a "Crisp log" field with the exact command, and `docs/ddc-notes.md` points at the capture as the first step before the probe scripts.

Second, smaller commit: the DDC / Software / System caption above the brightness slider has been dead code since 1.0 (the only call site renders the slider compact). It answers the question every dead-slider report starts with, so it comes back behind a defaults key instead of a Settings row: `defaults write com.crisp.app crisp.showBrightnessControlMode -bool true`, relaunch Crisp. Read once at launch like `crisp.disableKeepAwake`. No new strings; all six captions were already localized.

## How tested

`make compile` and whole-tree `swiftlint --strict` green. Live on a Dell U4919DW behind a DisplayLink hub (no DDC channel at all), with two `crispctl brightness set` calls to drive writes, the form's own command returned:

```
[ddc] display reconfiguration: channel map flushed, pairing re-runs on the next DDC op
[ddc] pairing: display 60 (vendor 0x10AC product 0xA107) -> no DDC channel (0 found)
[app] Accessibility not trusted at launch, key tap not started; re-checking at 1 s and 3 s
[ddc] read 0x62 display 60: no valid reply in 3 attempts
[volume] Dell U4919DW: volume probe (VCP 0x62) got no valid reply, slider hidden; the Volume Control toggle forces write-only
[ddc] display 60: 6 consecutive read failures, reads quarantined for 600 s
[ddc] write 0x10=90 display 60: failed all 3 attempts
```

The caption switch shows an orange "Software" on the same display after the first slider drag, and the row is gone again with the key deleted. The green "DDC" and blue "System" paths are unchanged code from 1.0, not re-tested on a live channel here. `make test` runs in CI; nothing under `Models/` changed.
