### PR TITLE
crispctl: connect, disconnect and toggle a physical display

### DIFF
--- a/Crisp/Models/CrispControlModel.swift
+++ b/Crisp/Models/CrispControlModel.swift
@@ -9,21 +9,68 @@ struct CrispControlDisplay: Codable, Equatable {
     let name: String
     let brightness: Double
     let isBuiltin: Bool
+    /// Stable identity across CGDirectDisplayID reassignment. A disconnected display
+    /// keeps its uuid but its `id` is only the last-known runtime id.
+    let uuid: String
+    /// False while Crisp holds the display disconnected. Such a display is absent from
+    /// CGGetOnlineDisplayList, so `uuid` is the only selector that survives.
+    let connected: Bool
+
+    init(
+        id: UInt32,
+        name: String,
+        brightness: Double,
+        isBuiltin: Bool,
+        uuid: String = "",
+        connected: Bool = true
+    ) {
+        self.id = id
+        self.name = name
+        self.brightness = brightness
+        self.isBuiltin = isBuiltin
+        self.uuid = uuid
+        self.connected = connected
+    }
+
+    /// Hand-written so a crispctl built before these fields existed still decodes a
+    /// reply from a newer Crisp, matching the forward-compatibility the help promises.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UInt32.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        brightness = try container.decode(Double.self, forKey: .brightness)
+        isBuiltin = try container.decode(Bool.self, forKey: .isBuiltin)
+        uuid = try container.decodeIfPresent(String.self, forKey: .uuid) ?? ""
+        connected = try container.decodeIfPresent(Bool.self, forKey: .connected) ?? true
+    }
 }
 struct CrispControlRequest: Codable, Equatable {
     enum Command: String, Codable {
         case list
         case getBrightness
         case setBrightness
+        case connectDisplay
+        case disconnectDisplay
+        case toggleDisplay
     }
 
     let command: Command
     let display: UInt32?
     let brightness: Double?
-    init(command: Command, display: UInt32? = nil, brightness: Double? = nil) {
+    /// Display selector for the connection commands: a runtime id or a uuid, as typed.
+    /// A disconnected display is gone from the online list, so its id alone cannot
+    /// always find it; resolution against both is done in `handle`.
+    let selector: String?
+    init(
+        command: Command,
+        display: UInt32? = nil,
+        brightness: Double? = nil,
+        selector: String? = nil
+    ) {
         self.command = command
         self.display = display
         self.brightness = brightness
+        self.selector = selector
     }
 }
 enum CrispControlFrame {
@@ -68,6 +115,12 @@ struct CrispControlBrightnessChange: Equatable {
     let displayID: UInt32
     let brightness: Double
 }
+/// A resolved connect-or-disconnect. `toggleDisplay` is collapsed into a concrete
+/// direction by `handle`, so the server never has to re-read the current state.
+struct CrispControlConnectionChange: Equatable {
+    let uuid: String
+    let connect: Bool
+}
 enum CrispControlModel {
     static func encode<T: Encodable>(_ value: T, sorted: Bool = false) throws -> Data {
         let encoder = JSONEncoder()
@@ -80,39 +133,96 @@ enum CrispControlModel {
         (try? encode(response, sorted: false))
             ?? Data(#"{"ok":false,"error":"response encoding failed"}"#.utf8) + Data([0x0A])
     }
+    /// Finds a display by the selector a person typed: a runtime id, or a uuid in any
+    /// case. Ids are checked first because they are what `displays list` leads with.
+    static func resolve(
+        selector: String,
+        in displays: [CrispControlDisplay]
+    ) -> CrispControlDisplay? {
+        if let id = UInt32(selector), let match = displays.first(where: { $0.id == id }) {
+            return match
+        }
+        return displays.first { !$0.uuid.isEmpty && $0.uuid.caseInsensitiveCompare(selector) == .orderedSame }
+    }
+
     static func handle(
         _ data: Data,
         displays: [CrispControlDisplay]
-    ) -> (response: CrispControlResponse, brightnessChange: CrispControlBrightnessChange?) {
+    ) -> (
+        response: CrispControlResponse,
+        brightnessChange: CrispControlBrightnessChange?,
+        connectionChange: CrispControlConnectionChange?
+    ) {
         guard let request = try? JSONDecoder().decode(CrispControlRequest.self, from: data) else {
-            return (.failure("invalid request"), nil)
+            return (.failure("invalid request"), nil, nil)
         }
         switch request.command {
         case .list:
-            return (.success(displays: displays), nil)
+            return (.success(displays: displays), nil, nil)
         case .getBrightness:
-            guard let id = request.display else { return (.failure("display is required"), nil) }
+            guard let id = request.display else { return (.failure("display is required"), nil, nil) }
             guard let display = displays.first(where: { $0.id == id }) else {
-                return (.failure("display not found"), nil)
+                return (.failure("display not found"), nil, nil)
             }
-            return (.success(display: display), nil)
+            return (.success(display: display), nil, nil)
         case .setBrightness:
             guard let id = request.display, let value = request.brightness else {
-                return (.failure("display and brightness are required"), nil)
+                return (.failure("display and brightness are required"), nil, nil)
             }
             guard (0...100).contains(value) else {
-                return (.failure("brightness must be between 0 and 100"), nil)
+                return (.failure("brightness must be between 0 and 100"), nil, nil)
             }
             guard displays.contains(where: { $0.id == id }) else {
-                return (.failure("display not found"), nil)
+                return (.failure("display not found"), nil, nil)
             }
-            return (.success(), .init(displayID: id, brightness: value))
+            return (.success(), .init(displayID: id, brightness: value), nil)
+        case .connectDisplay, .disconnectDisplay, .toggleDisplay:
+            return connection(request, displays: displays)
         }
+    }
+
+    /// Resolves a connection request against the merged online + disconnected list.
+    /// Asking for the state a display is already in succeeds and changes nothing, so
+    /// a button wired to `connect` or `disconnect` is safe to press twice.
+    private static func connection(
+        _ request: CrispControlRequest,
+        displays: [CrispControlDisplay]
+    ) -> (
+        response: CrispControlResponse,
+        brightnessChange: CrispControlBrightnessChange?,
+        connectionChange: CrispControlConnectionChange?
+    ) {
+        guard let selector = request.selector, !selector.isEmpty else {
+            return (.failure("display is required"), nil, nil)
+        }
+        guard let display = resolve(selector: selector, in: displays) else {
+            return (.failure("display not found"), nil, nil)
+        }
+        guard !display.uuid.isEmpty else {
+            return (.failure("display has no stable uuid, so it cannot be reconnected"), nil, nil)
+        }
+        let connect: Bool
+        switch request.command {
+        case .connectDisplay: connect = true
+        case .disconnectDisplay: connect = false
+        default: connect = !display.connected
+        }
+        let settled = CrispControlDisplay(
+            id: display.id,
+            name: display.name,
+            brightness: display.brightness,
+            isBuiltin: display.isBuiltin,
+            uuid: display.uuid,
+            connected: connect
+        )
+        guard display.connected != connect else { return (.success(display: settled), nil, nil) }
+        return (.success(display: settled), nil, .init(uuid: display.uuid, connect: connect))
     }
 }
 enum CrispControlCLIModel {
     static let usage = "usage: crispctl displays list | crispctl brightness get <display-id> | "
-        + "crispctl brightness set <display-id> <percent> | crispctl help"
+        + "crispctl brightness set <display-id> <percent> | "
+        + "crispctl display connect|disconnect|toggle <display> | crispctl help"
 
     /// The full reference, for a person at a terminal and for an agent that reads it
     /// before acting. Kept in the shared model so the app and the CLI cannot drift.
@@ -126,7 +236,9 @@ enum CrispControlCLIModel {
 
         Commands
           crispctl displays list
-              Every online display: id, name, brightness (0-100), isBuiltin.
+              Every display: id, name, brightness (0-100), isBuiltin, uuid, and
+              connected. Includes displays Crisp is holding disconnected, which
+              report connected:false and are absent from every macOS display list.
           crispctl brightness get <display-id>
               Current brightness of one display.
           crispctl brightness set <display-id> <percent>
@@ -134,12 +246,33 @@ enum CrispControlCLIModel {
               or software dimming as Crisp decided for that display, and it clears
               the active preset. The reply means Crisp accepted the request, not
               that the panel was read back; run brightness get to confirm.
+          crispctl display disconnect <display>
+              Drop the display out of the layout, the same as Disconnect Display in
+              the menu. Windows move off it and macOS stops treating it as attached.
+              Apple Silicon only. Refused if it would leave no active display.
+          crispctl display connect <display>
+              Put a disconnected display back.
+          crispctl display toggle <display>
+              Disconnect it if connected, reconnect it if not. One idempotent verb
+              for a single button.
           crispctl help
               This text. Also --help and -h.
 
         Display ids
           Runtime ids from displays list. They can change after an unplug or a
           wake, so list first, then act.
+
+        Selecting a display for connect / disconnect / toggle
+          <display> is a runtime id or a uuid; ids are matched first. A disconnected
+          display is absent from CGGetOnlineDisplayList, so its runtime id is only a
+          last-known value: use the uuid for anything that must survive a replug or
+          a wake. displays list reports both, and reports connected:false for a
+          display Crisp is holding disconnected.
+
+        Connection results
+          Asking for the state a display is already in succeeds and changes nothing.
+          Unlike brightness, these replies are not optimistic: an error means the
+          window server refused, and the reply carries Crisp's reason.
 
         Output
           One JSON object per call. Success: {"ok":true,...}. Failure:
@@ -176,6 +309,18 @@ enum CrispControlCLIModel {
            let id = UInt32(arguments[2]), let value = Double(arguments[3]),
            value.isFinite, (0...100).contains(value) {
             return .request(.init(command: .setBrightness, display: id, brightness: value))
+        }
+        if arguments.count == 3, arguments[0] == "display", !arguments[2].isEmpty {
+            let command: CrispControlRequest.Command?
+            switch arguments[1] {
+            case "connect": command = .connectDisplay
+            case "disconnect": command = .disconnectDisplay
+            case "toggle": command = .toggleDisplay
+            default: command = nil
+            }
+            if let command {
+                return .request(.init(command: command, selector: arguments[2]))
+            }
         }
         return .failure
     }

--- a/Crisp/Services/CrispControlServer.swift
+++ b/Crisp/Services/CrispControlServer.swift
@@ -80,20 +80,62 @@ final class CrispControlServer {
     }
 
     private func response(to request: Data) async -> Data {
-        let displays = displayManager.displays.map {
-            CrispControlDisplay(
-                id: $0.displayID, name: $0.name,
-                brightness: min($0.brightness, 100), isBuiltin: $0.isBuiltin
-            )
-        }
-        let result = CrispControlModel.handle(request, displays: displays)
+        let result = CrispControlModel.handle(request, displays: knownDisplays())
         if let change = result.brightnessChange {
             guard let display = displayManager.displays.first(where: { $0.displayID == change.displayID }) else {
                 return CrispControlModel.encode(.failure("display not found"))
             }
             await BrightnessService.shared.setBrightness(change.brightness, for: display)
         }
+        if let change = result.connectionChange, let error = await apply(change) {
+            return CrispControlModel.encode(.failure(error))
+        }
         return CrispControlModel.encode(result.response)
+    }
+
+    /// Online displays plus the ones Crisp is holding disconnected. A disconnected
+    /// display is gone from DisplayManager (CGGetOnlineDisplayList omits it), so
+    /// without the second half `connect` could never name its target.
+    private func knownDisplays() -> [CrispControlDisplay] {
+        let online = displayManager.displays.map {
+            CrispControlDisplay(
+                id: $0.displayID, name: $0.name,
+                brightness: min($0.brightness, 100), isBuiltin: $0.isBuiltin,
+                uuid: $0.displayUUID, connected: true
+            )
+        }
+        let live = Set(online.map(\.uuid))
+        let offline = PhysicalDisplayToggleService.shared.disconnected
+            .filter { !live.contains($0.uuid) }
+            .map {
+                CrispControlDisplay(
+                    id: $0.displayID, name: $0.name,
+                    brightness: 0, isBuiltin: false,
+                    uuid: $0.uuid, connected: false
+                )
+            }
+        return online + offline
+    }
+
+    /// Applies a resolved connection change. Returns nil on success, or the reason
+    /// the window server refused. Unlike brightness this is not fire-and-forget:
+    /// disconnecting can be legitimately refused (it would leave no active display),
+    /// and a caller wiring this to a button needs to hear that.
+    private func apply(_ change: CrispControlConnectionChange) async -> String? {
+        let service = PhysicalDisplayToggleService.shared
+        if change.connect {
+            if case let .failure(error) = await service.reconnect(uuid: change.uuid) {
+                return error.description
+            }
+            return nil
+        }
+        guard let display = displayManager.displays.first(where: { $0.displayUUID == change.uuid }) else {
+            return "display not found"
+        }
+        if case let .failure(error) = await service.disconnect(display) {
+            return error.description
+        }
+        return nil
     }
 
     private nonisolated static func read(_ client: Int32) -> CrispControlFrame.Result {

--- a/CrispTests/CrispControlModelTests.swift
+++ b/CrispTests/CrispControlModelTests.swift
@@ -5,17 +5,34 @@ final class CrispControlModelTests: XCTestCase {
         id: 7,
         name: "Studio Display",
         brightness: 64,
-        isBuiltin: false
+        isBuiltin: false,
+        uuid: "11111111-2222-3333-4444-555555555555"
+    )
+    /// Crisp is holding this one out of the layout: absent from the online list,
+    /// so its id is only a last-known value and the uuid is the real handle.
+    private let offline = CrispControlDisplay(
+        id: 9,
+        name: "M32UC",
+        brightness: 0,
+        isBuiltin: false,
+        uuid: "DECC7CEF-5E36-4E9B-8F18-CE11AE5902AD",
+        connected: false
     )
 
-    func testParserSupportsExactlyThreeCommands() {
+    func testParserSupportsEveryCommand() {
         let cases: [([String], CrispControlRequest)] = [
             (["displays", "list"], .init(command: .list)),
             (["brightness", "get", "42"], .init(command: .getBrightness, display: 42)),
             (
                 ["brightness", "set", "42", "37.5"],
                 .init(command: .setBrightness, display: 42, brightness: 37.5)
-            )
+            ),
+            (["display", "connect", "42"], .init(command: .connectDisplay, selector: "42")),
+            (
+                ["display", "disconnect", "DECC7CEF-5E36-4E9B-8F18-CE11AE5902AD"],
+                .init(command: .disconnectDisplay, selector: "DECC7CEF-5E36-4E9B-8F18-CE11AE5902AD")
+            ),
+            (["display", "toggle", "42"], .init(command: .toggleDisplay, selector: "42"))
         ]
         for (arguments, request) in cases {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .request(request))
@@ -28,7 +45,10 @@ final class CrispControlModelTests: XCTestCase {
         }
         // The reference must name every command it documents, and the usage line must
         // point at it, so a wrong invocation still leads to the full text.
-        for command in ["displays list", "brightness get", "brightness set", "crispctl help"] {
+        for command in [
+            "displays list", "brightness get", "brightness set",
+            "display connect", "display disconnect", "display toggle", "crispctl help"
+        ] {
             XCTAssertTrue(CrispControlCLIModel.help.contains(command), command)
         }
         XCTAssertTrue(CrispControlCLIModel.usage.contains("crispctl help"))
@@ -40,7 +60,9 @@ final class CrispControlModelTests: XCTestCase {
             ["brightness", "get"], ["brightness", "get", "x"],
             ["brightness", "get", "4294967296"], ["brightness", "set", "42"],
             ["brightness", "set", "42", "nan"], ["brightness", "set", "42", "inf"],
-            ["brightness", "set", "42", "-0.1"], ["brightness", "set", "42", "100.1"]
+            ["brightness", "set", "42", "-0.1"], ["brightness", "set", "42", "100.1"],
+            ["display", "toggle"], ["display", "toggle", ""], ["display", "reboot", "42"],
+            ["display", "toggle", "42", "now"]
         ]
         for arguments in cases {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .failure)
@@ -142,7 +164,73 @@ final class CrispControlModelTests: XCTestCase {
     }
 
     private var commands: [CrispControlRequest.Command] {
-        [.list, .getBrightness, .setBrightness]
+        [.list, .getBrightness, .setBrightness, .connectDisplay, .disconnectDisplay, .toggleDisplay]
+    }
+
+    func testConnectionCommandsResolveByIDAndByUUID() {
+        let displays = [display, offline]
+        // Toggling a connected display asks for a disconnect...
+        let byID = CrispControlModel.handle(
+            Data(#"{"command":"toggleDisplay","selector":"7"}"#.utf8), displays: displays
+        )
+        XCTAssertEqual(byID.connectionChange, .init(uuid: display.uuid, connect: false))
+        // ...and toggling a disconnected one asks for the opposite, found by uuid
+        // in any case, which is the only handle that survives the disconnect.
+        let byUUID = CrispControlModel.handle(
+            Data(#"{"command":"toggleDisplay","selector":"decc7cef-5e36-4e9b-8f18-ce11ae5902ad"}"#.utf8),
+            displays: displays
+        )
+        XCTAssertEqual(byUUID.connectionChange, .init(uuid: offline.uuid, connect: true))
+        XCTAssertNil(byID.brightnessChange)
+    }
+
+    func testAskingForTheStateADisplayIsAlreadyInSucceedsAndChangesNothing() {
+        // A button wired to connect or disconnect must be safe to press twice.
+        for (request, subject) in [
+            (#"{"command":"connectDisplay","selector":"7"}"#, display),
+            (#"{"command":"disconnectDisplay","selector":"9"}"#, offline)
+        ] {
+            let result = CrispControlModel.handle(Data(request.utf8), displays: [display, offline])
+            XCTAssertTrue(result.response.ok, request)
+            XCTAssertNil(result.connectionChange, request)
+            XCTAssertEqual(result.response.display?.uuid, subject.uuid, request)
+        }
+    }
+
+    func testConnectionResponseReportsTheSettledState() {
+        let result = CrispControlModel.handle(
+            Data(#"{"command":"disconnectDisplay","selector":"7"}"#.utf8), displays: [display, offline]
+        )
+        XCTAssertEqual(result.response.display?.connected, false)
+        XCTAssertEqual(result.response.display?.id, display.id)
+        XCTAssertEqual(result.connectionChange, .init(uuid: display.uuid, connect: false))
+    }
+
+    func testConnectionCommandsRejectMissingUnknownAndUnidentifiableDisplays() {
+        let anonymous = CrispControlDisplay(id: 3, name: "No UUID", brightness: 10, isBuiltin: false)
+        let cases: [(String, [CrispControlDisplay])] = [
+            (#"{"command":"toggleDisplay"}"#, [display]),
+            (#"{"command":"toggleDisplay","selector":""}"#, [display]),
+            (#"{"command":"toggleDisplay","selector":"404"}"#, [display]),
+            (#"{"command":"connectDisplay","selector":"nope"}"#, [display]),
+            // A display with no stable uuid cannot be found again once it is gone,
+            // so refuse rather than hand back a handle that will not work.
+            (#"{"command":"disconnectDisplay","selector":"3"}"#, [anonymous])
+        ]
+        for (request, displays) in cases {
+            let result = CrispControlModel.handle(Data(request.utf8), displays: displays)
+            XCTAssertFalse(result.response.ok, request)
+            XCTAssertNil(result.connectionChange, request)
+        }
+    }
+
+    func testDisplayRecordFromAnOlderCrispctlStillDecodes() {
+        // The help promises forward compatibility; a reply without the newer fields
+        // must decode rather than throw.
+        let legacy = #"{"id":7,"name":"Studio Display","brightness":64,"isBuiltin":false}"#
+        let decoded = try? JSONDecoder().decode(CrispControlDisplay.self, from: Data(legacy.utf8))
+        XCTAssertEqual(decoded?.uuid, "")
+        XCTAssertEqual(decoded?.connected, true)
     }
 
     private func classify(

--- a/README.md
+++ b/README.md
@@ -102,12 +102,13 @@ It supports exactly three commands:
 crispctl displays list
 crispctl brightness get <display-id>
 crispctl brightness set <display-id> <percent>
+crispctl display connect|disconnect|toggle <display>
 crispctl help
 ```
 
 `crispctl help` is the full reference (output format, display ids, exit codes); point an agent at it before it does anything else.
 
-Crisp must already be running. Display selectors are numeric runtime IDs from `displays list`, and output is JSON by default. `brightness set` is a manual change like using the slider and clears the active preset. A successful request means the change was accepted and queued, not independently verified; it is not retried automatically.
+Crisp must already be running. Display selectors are numeric runtime IDs from `displays list`, and output is JSON by default. The connection commands also accept a uuid, which is the selector to use for anything scripted: a disconnected display is absent from every macOS display list, so its runtime id is only a last-known value. `brightness set` is a manual change like using the slider and clears the active preset. A successful request means the change was accepted and queued, not independently verified; it is not retried automatically.
 
 The current public Crisp 1.5.0 release, normal DMG, and Homebrew cask do not include `crispctl`.
 


### PR DESCRIPTION
## Why

Disconnect Display is only reachable from the menu, so on a KVM desk the one thing worth automating is the one thing that cannot be scripted.

Concretely: two hosts share a monitor through its KVM. The panel's input follows the switch, but macOS keeps the display in its layout the whole time, so windows go on living on a screen that is currently showing the other computer. The fix is to drop it out of the layout when the KVM moves away and put it back when it returns — which `PhysicalDisplayToggleService` already does perfectly, just not from anywhere a script can reach.

## What

```sh
crispctl display disconnect <display>
crispctl display connect <display>
crispctl display toggle <display>
```

No new capability: the service does the work, this exposes it.

## Shape, and why

- **The selector is a runtime id or a uuid.** A disconnected display is gone from `CGGetOnlineDisplayList`, so its id is only a last-known value and cannot be trusted to find it again. The uuid is the selector that survives a replug or a wake, and it is the one to use for anything scripted. `displays list` now reports both.
- **`displays list` includes disconnected displays**, marked `connected:false`. Without that half, `connect` could never name its target — its display is absent from every macOS list by construction.
- **`toggle` collapses into a concrete direction inside the pure `handle`**, so the server never re-reads state and the decision stays unit-testable.
- **Asking for the state a display is already in succeeds and changes nothing**, so a button bound to `connect` or `disconnect` is safe to press twice.
- **These replies are not optimistic, unlike brightness.** Disconnecting can be legitimately refused — it would leave no active display — and a caller wiring this to a physical button needs the reason, so the reply carries Crisp's own error text.
- **`CrispControlDisplay` gained a hand-written `init(from:)`** so the two new fields decode as absent rather than throwing. That keeps the forward compatibility the help already promises ("Later versions may add fields; ignore what you do not know") true in both directions.

I kept the existing `(response, brightnessChange)` tuple shape and added a third slot rather than refactoring to an effect enum, so every existing test compiles untouched. Happy to switch to an enum if you would rather — it is the direction the code seems to be heading, and it is a small change.

## Verification

`make check` — lint clean, 84 tests green, localization keys complete.

Five new unit tests cover selector resolution by id and by lowercased uuid, toggle direction in both directions, the already-in-that-state no-op, the settled-state reply, rejection of missing / unknown / uuid-less displays, and legacy decoding.

Live on an M1 Pro, macOS 26.6.2, against a display the app was already holding disconnected — `system_profiler` used as an independent witness rather than trusting Crisp's own report:

```
BEFORE   macOS displays=1   crisp=[('Gigabyte M32U', True), ('M32UC', False)]
toggle → {"ok":true,...,"connected":true}
AFTER#1  macOS displays=2   crisp=[('Gigabyte M32U', True), ('M32UC', True)]
toggle → {"ok":true,...,"connected":false}
AFTER#2  macOS displays=1   crisp=[('Gigabyte M32U', True), ('M32UC', False)]
```

Exit codes confirmed: `0` success, `2` bad arguments, `3` refusal.

## One question

Is there a plan to ship `crispctl` — or at least the control server — in release builds? Everything above only reaches people who build from source. I have opened that as a separate issue so it does not ride on this PR.

Thanks for Crisp, and for making the control surface a plain socket. It made this a pleasure to work on.