### PR TITLE
Keep restoring displays until a screen is actually back

### DIFF
--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -31,6 +31,9 @@ final class PhysicalDisplayToggleService: ObservableObject {
         var name: String
         var width: Int
         var height: Int
+        /// Whether this was the built-in panel, captured at disconnect time. Optional so
+        /// records written before this field decode instead of throwing away the whole list.
+        var isBuiltin: Bool?
         var id: String { uuid }
     }
 
@@ -174,7 +177,8 @@ final class PhysicalDisplayToggleService: ObservableObject {
             displayID: displayID,
             name: display.name,
             width: display.pixelWidth,
-            height: display.pixelHeight
+            height: display.pixelHeight,
+            isBuiltin: display.isBuiltin
         )
 
         let result = await setEnabled(false, displayID: displayID)
@@ -201,6 +205,15 @@ final class PhysicalDisplayToggleService: ObservableObject {
             saveDesired()
         }
         return result
+    }
+
+    /// Built-in test for a disconnect record. Prefers the flag captured at disconnect time,
+    /// while the ID still answered truthfully: in the all-black state this matters in,
+    /// SLSGetDisplayList has collapsed to the placeholder display and CGDisplayIsBuiltin
+    /// answers with garbage for the stale IDs left over. Records written before that flag
+    /// existed fall back to the live query, which is no worse than before.
+    private func wasBuiltin(_ record: DisconnectedDisplay, id: CGDirectDisplayID) -> Bool {
+        record.isBuiltin ?? (CGDisplayIsBuiltin(id) == 1)
     }
 
     /// Finds the current CGDirectDisplayID for a disconnected record by matching its UUID
@@ -574,13 +587,24 @@ final class PhysicalDisplayToggleService: ObservableObject {
             // SLSConfigureDisplayEnabled still honors a stale ID for attached
             // hardware, while detached hardware fails at
             // CGCompleteDisplayConfiguration (error 1001) and the loop moves on.
-            // Prefer the built-in panel when the ID still classifies; stale IDs
-            // answer CGDisplayIsBuiltin with garbage, which sorts as non-builtin.
+            // Prefer the built-in panel, from the flag captured at disconnect time
+            // (see wasBuiltin): the IDs here are stale, so a live query is unreliable.
             let candidates = self.disconnected
                 .map { record in (record, self.resolveCurrentID(for: record) ?? record.displayID) }
-                .sorted { CGDisplayIsBuiltin($0.1) == 1 && CGDisplayIsBuiltin($1.1) != 1 }
+                .sorted { self.wasBuiltin($0.0, id: $0.1) && !self.wasBuiltin($1.0, id: $1.1) }
             for (record, _) in candidates {
-                if case .success = await self.reconnect(uuid: record.uuid) { return }
+                // macOS re-probes displays by itself in this state and often wins the race;
+                // stop as soon as anything viewable is back, whoever brought it back.
+                guard self.physicalActiveDisplayCount() == 0 else { return }
+                guard case .success = await self.reconnect(uuid: record.uuid) else { continue }
+                // A successful transaction is NOT proof of recovery (see verifyBackOnline):
+                // around sleep transitions it reports success while the display stays
+                // disabled, and that lie used to end the restore with every screen still
+                // black. Only enumeration ends it; otherwise move on to the next record.
+                for _ in 0..<20 {
+                    if self.physicalActiveDisplayCount() > 0 { return }
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                }
             }
         }
     }


### PR DESCRIPTION
Addresses the two observations in #91.

`restoreIfNoActiveDisplay` stopped at the first record whose `reconnect` returned `.success`. This file already documents twice that such a transaction proves nothing: `verifyBackOnline`'s doc comment says a success "is NOT proof of recovery", and `softReconnect` ignores the result and waits for enumeration instead. The restore path was the one place still trusting it, and it is the path that runs when there is no screen left to notice with. It now polls `physicalActiveDisplayCount` after each reconnect and stops only once something viewable is actually back, otherwise it moves on to the next record. It also re-checks that count at the top of each iteration, so when macOS wins the race with its own re-probe, which is what the reporter observed on 1.5.0, Crisp stops instead of enabling a second display nobody asked for.

Built-in first was unreliable for the reason the old comment admitted in place: once the last display leaves, `SLSGetDisplayList` collapses to the placeholder and `CGDisplayIsBuiltin` answers with garbage for the stale IDs left over, which sorts as non-builtin. The flag is now captured into the disconnect record at disconnect time, while the ID still answers truthfully. It is optional so records written by 1.5.0 decode with it nil and fall back to the live query, rather than throwing and taking the whole stored list down with them through `loadDesired`'s `try?`.

Scope, since it is narrower than the issue title suggests: this only changes behaviour with two or more displays disconnected at once, which is also why it is hard to reach on two-display hardware, the last-screen guard means two attached displays can only ever produce one record. With a single record a lying success still drops it, because `reconnect` clears the record on success and the empty-list guard then stops `restoreIfNoActiveDisplay` from running again. Covering that means falling back to the disabled-display sweep `softReconnect` uses when its retries run out, and in that state the sweep would also re-enable displays another app turned off deliberately. That question is left open on #91 rather than decided here.

Verification: `make compile` and whole-tree `swiftlint --strict` are green locally. `make test` needs full Xcode, so CI is the first place it runs. A standalone check confirmed that 1.5.0 records decode with the flag nil, new records carry it, and the fallback resolves both ways. The restore path itself is not verified live: reaching it means blacking out every screen, and macOS's own re-probe usually gets there first, which is exactly why the reporter could not reproduce a user-visible failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NDzD18GySiCwEGfWJiT4J
