### PR TITLE
Make a held-disconnected display discoverable (caption, menu bar mark, notice)

### DIFF
--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -157,6 +157,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
         setupStartupBehavior()
         setupStatusItem()
+        DisconnectNoticeService.shared.start()
 
         // Re-anchor the open panel when screens change: switching the main
         // display re-origins global coordinates, which would otherwise leave

--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -282,9 +282,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 // Give WindowServer 2 seconds to stabilize after wake before
                 // touching display state.
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
-                dm.refreshDisplays()
-                // Re-disconnect any physical displays macOS re-enabled on wake.
-                await PhysicalDisplayToggleService.shared.reapplyOnWake()
+                // The refresh also re-disconnects any display macOS re-enabled on wake:
+                // it runs reconcile, which puts a remembered disconnect back.
                 dm.refreshDisplays()
                 try? await Task.sleep(nanoseconds: 500_000_000)
                 // WindowServer keeps settling for several seconds after wake: ICC

--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -47,6 +47,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// Drives the menu-bar Keep Awake indicator (keep-awake indicator).
     private var keepAwakeCancellable: AnyCancellable?
     private var keepAwakeBadge: NSView?
+    private var disconnectedCancellable: AnyCancellable?
+    private var disconnectedBadge: NSView?
     private var panel: MenuPanel?
     /// The panel is NEVER ordered out once warmed: taking the backdrop surface
     /// off screen makes WindowServer replay its materialize bloom (the growing
@@ -344,6 +346,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         updateStatusIcon(active: KeepAwakeService.shared.isActive, animated: false)
         keepAwakeCancellable = KeepAwakeService.shared.$isActive
             .sink { [weak self] active in self?.updateStatusIcon(active: active, animated: true) }
+
+        // And a second dot, opposite corner, while any display is disconnected. A disconnected
+        // display shows no signal and does not appear in System Settings > Displays, so with
+        // the disconnect now outliving a replug and a reboot, this is the only thing on screen
+        // that says a display is being held off — and it is the thing a puzzled user clicks,
+        // which is where the Reconnect row is.
+        updateDisconnectedIcon(any: !PhysicalDisplayToggleService.shared.disconnected.isEmpty, animated: false)
+        disconnectedCancellable = PhysicalDisplayToggleService.shared.$disconnected
+            .map { !$0.isEmpty }
+            .removeDuplicates()
+            .sink { [weak self] any in self?.updateDisconnectedIcon(any: any, animated: true) }
     }
 
     /// Renders the status-bar icon for the given Keep Awake state. A hidden default
@@ -353,9 +366,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// Only the dot animates; the base symbol stays put. (keep-awake indicator)
     private func updateStatusIcon(active: Bool, animated: Bool) {
         guard let button = statusItem?.button else { return }
-        let badge = keepAwakeBadge ?? makeKeepAwakeBadge(on: button)
+        let badge = keepAwakeBadge ?? makeBadge(on: button, color: .systemOrange, trailing: true)
         keepAwakeBadge = badge
-        let target: CGFloat = active ? 1 : 0
+        fade(badge, to: active ? 1 : 0, animated: animated)
+    }
+
+    /// The same treatment for "a display is disconnected", in the opposite corner and a
+    /// different colour so the two states can be told apart, and read at once.
+    private func updateDisconnectedIcon(any: Bool, animated: Bool) {
+        guard let button = statusItem?.button else { return }
+        let badge = disconnectedBadge ?? makeBadge(on: button, color: .systemBlue, trailing: false)
+        disconnectedBadge = badge
+        fade(badge, to: any ? 1 : 0, animated: animated)
+    }
+
+    private func fade(_ badge: NSView, to target: CGFloat, animated: Bool) {
         guard animated else { badge.alphaValue = target; return }
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = 0.25
@@ -364,22 +389,25 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
     }
 
-    /// A small orange dot pinned to the icon's bottom-right corner, layer-backed so its alpha can
-    /// animate. Starts hidden (alpha 0); updateStatusIcon fades it in when Keep Awake turns on.
-    /// (keep-awake indicator)
-    private func makeKeepAwakeBadge(on button: NSStatusBarButton) -> NSView {
+    /// A small dot pinned to one bottom corner of the icon, layer-backed so its alpha can
+    /// animate. Starts hidden (alpha 0); the update methods above fade it in. Trailing/orange is
+    /// Keep Awake (keep-awake indicator), leading/blue is "a display is disconnected".
+    private func makeBadge(on button: NSStatusBarButton, color: NSColor, trailing: Bool) -> NSView {
         let d: CGFloat = 6
         let dot = NSView()
         dot.wantsLayer = true
-        dot.layer?.backgroundColor = NSColor.systemOrange.cgColor
+        dot.layer?.backgroundColor = color.cgColor
         dot.layer?.cornerRadius = d / 2
         dot.alphaValue = 0
         dot.translatesAutoresizingMaskIntoConstraints = false
         button.addSubview(dot)
+        let side = trailing
+            ? dot.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -1)
+            : dot.leadingAnchor.constraint(equalTo: button.leadingAnchor, constant: 1)
         NSLayoutConstraint.activate([
             dot.widthAnchor.constraint(equalToConstant: d),
             dot.heightAnchor.constraint(equalToConstant: d),
-            dot.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -1),
+            side,
             dot.bottomAnchor.constraint(equalTo: button.bottomAnchor, constant: -2)
         ])
         return dot

--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -120,6 +120,16 @@
     "%lld%%" : {
       "shouldTranslate" : false
     },
+    "Crisp is keeping this display disconnected. Choose Reconnect to bring it back." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Crisp 正在让这台显示器保持断开。选择「重新连接」即可恢复。"
+          }
+        }
+      }
+    },
     "Stays disconnected until you reconnect it here." : {
       "localizations" : {
         "zh-Hans" : {

--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -120,6 +120,16 @@
     "%lld%%" : {
       "shouldTranslate" : false
     },
+    "Stays disconnected until you reconnect it here." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将保持断开，直到你在这里重新连接。"
+          }
+        }
+      }
+    },
     "×" : {
       "shouldTranslate" : false
     },

--- a/Crisp/Services/DisconnectNoticeService.swift
+++ b/Crisp/Services/DisconnectNoticeService.swift
@@ -1,0 +1,258 @@
+import AppKit
+import Foundation
+import IOKit
+import UserNotifications
+import os
+
+/// Tells the user, once, when a display they disconnected has been plugged back in and Crisp is
+/// keeping it off.
+///
+/// A disconnected display is switched off at the window server: it shows no signal, System
+/// Settings does not list it, and replugging the cable does not undo it, because the window
+/// server holds that state and not the cable. Since the choice now outlives a replug and a
+/// reboot (`PhysicalDisplayToggleService.reconcile`), someone who comes back to that monitor
+/// months later has every reason to think it died. This is the one moment worth interrupting
+/// them for, and the banner carries the way out with it.
+///
+/// It tells; it never decides. Crisp does not take the disconnect back on its own: a physical
+/// replug cannot be told apart from a dock re-enumerating everything on it, or from a
+/// DisplayPort monitor being switched off and on, so acting on it would undo a deliberate choice
+/// at times the user never asked for. Reconnecting stays the user's action, from here or from
+/// the menu.
+@MainActor
+final class DisconnectNoticeService: NSObject {
+    static let shared = DisconnectNoticeService()
+    private override init() { super.init() }
+
+    private nonisolated static let log = Logger(subsystem: "com.crisp.app", category: "notice")
+
+    private static let categoryID = "crisp.display.keptDisconnected"
+    private static let reconnectAction = "crisp.display.keptDisconnected.reconnect"
+    private static let lastNoticeKey = "crisp.keptDisconnected.lastNotice"
+    /// A display that turns up at login or straight after a wake is the feature working, not
+    /// somebody standing at the machine wondering why it is dark. Only one that arrives
+    /// mid-session is worth a banner — which is also exactly the case this exists for: walking
+    /// up to the monitor, plugging it in, and getting nothing.
+    private static let settleWindow: TimeInterval = 60
+    /// At most one banner per display per day, so a marginal cable that re-enumerates every few
+    /// minutes cannot turn this into a stream.
+    private static let quietPeriod: TimeInterval = 24 * 60 * 60
+
+    private var quietUntil: Date = .distantFuture
+    private var attachPort: IONotificationPortRef?
+    private var attachIterator: io_iterator_t = 0
+    /// False until the initial drain below has consumed the displays that were already attached.
+    private var armed = false
+
+    /// Called once at launch. Registers the category so the banner can carry a Reconnect button,
+    /// and starts the post-launch quiet window. Authorization is deliberately NOT requested
+    /// here; see `displayKeptDisconnected`.
+    func start() {
+        quietUntil = Date().addingTimeInterval(Self.settleWindow)
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        let action = UNNotificationAction(
+            identifier: Self.reconnectAction,
+            title: String(localized: "Reconnect"),
+            options: []
+        )
+        center.setNotificationCategories([
+            UNNotificationCategory(identifier: Self.categoryID, actions: [action], intentIdentifiers: [])
+        ])
+        for name in [NSWorkspace.didWakeNotification, NSWorkspace.screensDidWakeNotification] {
+            NSWorkspace.shared.notificationCenter.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.quietUntil = Date().addingTimeInterval(Self.settleWindow)
+                }
+            }
+        }
+        startWatchingAttachments()
+    }
+
+    // MARK: - Watching the cable
+
+    /// Watches IOKit for a display arriving on a cable, because above IOKit nothing happens at
+    /// all. Measured live, unplugging and replugging the HDMI cable of a display Crisp was
+    /// holding disconnected (registry entry IDs, and the service events as they fired):
+    ///
+    ///     [03:24:15] EVENT terminate id=4294977625        <- cable out
+    ///     [03:24:15] framebuffer 4294969518:-             ...same object, name cleared
+    ///     [03:24:23] EVENT publish   id=4294978031        <- cable back in
+    ///     [03:24:24] framebuffer 4294969518:E241Y G0      ...same object, name restored
+    ///
+    /// Two things that decide the shape of this. The window server never moves: a disabled
+    /// display does not leave `SLSGetDisplayList` and never re-enters the online list, so there
+    /// is no reconfiguration callback and no CoreGraphics event to hang this on — which is the
+    /// same reason the user is standing there puzzled, replugging changes nothing they can see.
+    /// And the framebuffer service is the wrong thing to watch: its object outlives the cable
+    /// and only its properties change, so it publishes nothing. The AV service proxy is the one
+    /// that is actually created and destroyed with the cable.
+    ///
+    /// It carries no EDID of its own, so it is the trigger and the framebuffer is the identity:
+    /// the display's name comes back about 0.4s after the event, hence the delayed reads below.
+    private func startWatchingAttachments() {
+        guard attachPort == nil else { return }
+        let port = IONotificationPortCreate(kIOMainPortDefault)
+        IONotificationPortSetDispatchQueue(port, .main)
+        attachPort = port
+        let callback: IOServiceMatchingCallback = { refcon, iterator in
+            guard let refcon else { return }
+            let service = Unmanaged<DisconnectNoticeService>.fromOpaque(refcon).takeUnretainedValue()
+            var arrived = false
+            var entry = IOIteratorNext(iterator)
+            while entry != 0 {
+                arrived = true
+                IOObjectRelease(entry)
+                entry = IOIteratorNext(iterator)
+            }
+            guard arrived else { return }
+            MainActor.assumeIsolated { service.cableArrived() }
+        }
+        IOServiceAddMatchingNotification(
+            port, kIOFirstMatchNotification, IOServiceMatching("DCPAVServiceProxy"),
+            callback, Unmanaged.passUnretained(self).toOpaque(), &attachIterator
+        )
+        // The first drain is every display already attached, which is not news. It is also what
+        // arms the notification, so it has to happen either way.
+        var entry = IOIteratorNext(attachIterator)
+        while entry != 0 {
+            IOObjectRelease(entry)
+            entry = IOIteratorNext(attachIterator)
+        }
+        armed = true
+    }
+
+    /// A cable arrived. The display behind it names itself a moment later, so look a few times
+    /// rather than once; anything already notified today is dropped by the limiter anyway.
+    private func cableArrived() {
+        guard armed else { return }
+        for delay in [0.5, 1.5, 3.0] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.notifyHeldDisplaysPresent()
+            }
+        }
+    }
+
+    /// Every display currently naming itself in the registry, by the name in its own EDID.
+    private func attachedProductNames() -> Set<String> {
+        var iterator: io_iterator_t = 0
+        guard IOServiceGetMatchingServices(
+            kIOMainPortDefault, IOServiceMatching("IOMobileFramebufferShim"), &iterator
+        ) == KERN_SUCCESS else { return [] }
+        defer { IOObjectRelease(iterator) }
+        var names: Set<String> = []
+        var entry = IOIteratorNext(iterator)
+        while entry != 0 {
+            if let name = Self.productName(of: entry) { names.insert(name) }
+            IOObjectRelease(entry)
+            entry = IOIteratorNext(iterator)
+        }
+        return names
+    }
+
+    /// The monitor's own name, as the display reports it in its EDID.
+    private nonisolated static func productName(of entry: io_registry_entry_t) -> String? {
+        guard let attributes = IORegistryEntryCreateCFProperty(
+            entry, "DisplayAttributes" as CFString, kCFAllocatorDefault, 0
+        )?.takeRetainedValue() as? [String: Any],
+            let product = attributes["ProductAttributes"] as? [String: Any]
+        else { return nil }
+        return product["ProductName"] as? String
+    }
+
+    /// Say something for any display Crisp is holding off that is attached right now. Matched by
+    /// the name the display reports: two identical monitors would share one, so the banner can
+    /// name the right model on the wrong unit — acceptable for a message whose only action is to
+    /// reconnect a record the user made themselves.
+    private func notifyHeldDisplaysPresent() {
+        let attached = attachedProductNames()
+        guard !attached.isEmpty else { return }
+        for record in PhysicalDisplayToggleService.shared.disconnected where attached.contains(record.name) {
+            displayKeptDisconnected(record)
+        }
+    }
+
+    /// Say it: a display the user disconnected is here and Crisp is keeping it off. Reached
+    /// from the cable watcher above, and from the display-list path (macOS re-enabling a
+    /// remembered display mid-session), which is why the day limiter below is per display rather
+    /// than per event.
+    func displayKeptDisconnected(_ record: PhysicalDisplayToggleService.DisconnectedDisplay) {
+        guard Date() >= quietUntil, !recentlyNotified(record.uuid) else { return }
+        markNotified(record.uuid)
+
+        // Only plain strings cross into the callback below: the notification objects are not
+        // Sendable, so they are built on the other side of it.
+        let title = record.name
+        let body = String(localized: "Crisp is keeping this display disconnected. Choose Reconnect to bring it back.")
+        let displayUUID = record.uuid
+        let category = Self.categoryID
+
+        // Authorization is asked here rather than at launch, on purpose: the prompt then arrives
+        // at the one moment it can be answered from experience, and someone who never reaches
+        // this state is never asked at all. Repeat calls do not re-prompt, they return the
+        // standing answer.
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert]) { granted, error in
+            if let error {
+                Self.log.error("Notification authorization failed: \(error.localizedDescription, privacy: .public)")
+                return
+            }
+            guard granted else { return }
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = body
+            content.categoryIdentifier = category
+            content.userInfo = ["uuid": displayUUID]
+            let request = UNNotificationRequest(
+                identifier: "crisp.keptDisconnected.\(displayUUID)",
+                content: content,
+                trigger: nil
+            )
+            UNUserNotificationCenter.current().add(request) { addError in
+                if let addError {
+                    Self.log.error("Could not post the kept-disconnected notice: \(addError.localizedDescription, privacy: .public)")
+                }
+            }
+        }
+    }
+
+    private func recentlyNotified(_ displayUUID: String) -> Bool {
+        let map = UserDefaults.standard.dictionary(forKey: Self.lastNoticeKey) as? [String: Double] ?? [:]
+        guard let last = map[displayUUID] else { return false }
+        return Date().timeIntervalSinceReferenceDate - last < Self.quietPeriod
+    }
+
+    private func markNotified(_ displayUUID: String) {
+        var map = UserDefaults.standard.dictionary(forKey: Self.lastNoticeKey) as? [String: Double] ?? [:]
+        map[displayUUID] = Date().timeIntervalSinceReferenceDate
+        UserDefaults.standard.set(map, forKey: Self.lastNoticeKey)
+    }
+}
+
+extension DisconnectNoticeService: UNUserNotificationCenterDelegate {
+    /// The Reconnect button. The default action (clicking the banner itself) deliberately does
+    /// nothing: bringing a display back is not what someone means by dismissing a banner.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let actionID = response.actionIdentifier
+        let displayUUID = response.notification.request.content.userInfo["uuid"] as? String
+        Task { @MainActor in
+            if actionID == Self.reconnectAction, let displayUUID {
+                _ = await PhysicalDisplayToggleService.shared.reconnect(uuid: displayUUID)
+            }
+            completionHandler()
+        }
+    }
+
+    /// Crisp is a menu bar app, so it can be frontmost with nothing on screen; show the banner
+    /// either way.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner])
+    }
+}

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -541,6 +541,7 @@ final class PhysicalDisplayToggleService: ObservableObject {
             // display with no way back through the UI, and replugging cannot undo it because
             // the window server holds the state, not the cable.
             disconnected[idx].displayID = liveID
+            DisconnectNoticeService.shared.displayKeptDisconnected(disconnected[idx])
         }
         saveDesired()
     }

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -479,9 +479,9 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// had to be redone by hand every time (issue #93); re-applying it here is what makes
     /// the choice stick. It only ever touches displays the user disconnected themselves, and
     /// only while it is safe to: `wouldLeaveNoActiveDisplay` refuses to take the last screen
-    /// and `restoreIfNoActiveDisplay` stays underneath as the backstop. A re-apply that is
-    /// refused, fails, or does not verifiably land drops the record exactly as before, so
-    /// the list never claims a display is disconnected while it is lit.
+    /// and `restoreIfNoActiveDisplay` stays underneath as the backstop. A display still lit
+    /// after the attempt drops its record exactly as before, so the list never claims a
+    /// display is disconnected while it is on screen.
     func reconcile() {
         guard !disconnected.isEmpty else { return }
         let onlineUUIDs = Set(onlineDisplayIDs().map { uuid(for: $0) })
@@ -519,22 +519,28 @@ final class PhysicalDisplayToggleService: ObservableObject {
         guard !reconnectInFlight.contains(recordUUID) else { return }
         guard let liveID = onlineDisplayIDs().first(where: { uuid(for: $0) == recordUUID })
         else { return }  // gone again by itself; the record still stands for next time
-        var applied = false
-        if !wouldLeaveNoActiveDisplay(liveID),
-           case .success = await setEnabled(false, displayID: liveID) {
-            // The API's own answer is not proof (see verifyBackOnline for the same problem
-            // in the other direction), and a display still lit behind a lying success would
-            // have this run again at every refresh. Enumeration is the proof.
+        if !wouldLeaveNoActiveDisplay(liveID) {
+            _ = await setEnabled(false, displayID: liveID)
+            // The API's own answer is not proof, in either direction (see verifyBackOnline),
+            // so the record's fate is settled by enumeration below, not by the result.
             for _ in 0..<10 {
-                if !onlineDisplayIDs().contains(liveID) { applied = true; break }
+                if !onlineDisplayIDs().contains(liveID) { break }
                 try? await Task.sleep(nanoseconds: 100_000_000)
             }
         }
         guard let idx = disconnected.firstIndex(where: { $0.uuid == recordUUID }) else { return }
-        if applied {
-            disconnected[idx].displayID = liveID
-        } else {
+        if onlineDisplayIDs().contains(liveID) {
+            // Still lit and we could not take it off, a refusal included: forget it, so the
+            // list never claims a display is disconnected while the user is looking at it.
             disconnected.remove(at: idx)
+        } else {
+            // Off, whether or not the transaction said so — and that difference is the whole
+            // reason this is decided by enumeration. A disable that reports an error and takes
+            // anyway leaves the display switched off at the window server, where the record is
+            // the only handle the Reconnect row has on it. Dropping it there strands the
+            // display with no way back through the UI, and replugging cannot undo it because
+            // the window server holds the state, not the cable.
+            disconnected[idx].displayID = liveID
         }
         saveDesired()
     }

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -72,6 +72,12 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// this keeps the recovery path and the sweep from re-enabling a display out from under
     /// its own retry loop. Per-display, so concurrent blinks don't mask each other.
     private var softReconnectInFlight: Set<String> = []
+    /// UUIDs whose reconnect is running right now. `reconnect` only clears the record once
+    /// `setEnabled(true)` returns, and a reconfiguration callback inside that window runs
+    /// `refreshDisplays`, and therefore `reconcile`, which would find the display online with
+    /// its record still in place and switch it straight back off: the user clicks Reconnect
+    /// and nothing happens. The record is the wrong thing to read there, so read this instead.
+    private var reconnectInFlight: Set<String> = []
 
     private func pendingSoftReconnectUUIDs() -> [String] {
         UserDefaults.standard.stringArray(forKey: softReconnectPendingKey) ?? []
@@ -195,6 +201,8 @@ final class PhysicalDisplayToggleService: ObservableObject {
         }
         // The CGDirectDisplayID can be reassigned; re-resolve by UUID against the full list.
         let targetID = resolveCurrentID(for: record) ?? record.displayID
+        reconnectInFlight.insert(uuid)
+        defer { reconnectInFlight.remove(uuid) }
         let result = await setEnabled(true, displayID: targetID)
         if case .success = result {
             disconnected.removeAll { $0.uuid == uuid }
@@ -461,19 +469,74 @@ final class PhysicalDisplayToggleService: ObservableObject {
 
     // MARK: - Reconcile / Wake restore
 
-    /// Drops records for displays that are back online (e.g. physically re-plugged, or macOS
-    /// re-enabled them). Called from DisplayManager.refreshDisplays so the UI stays honest.
+    /// Re-applies the disconnect for records whose display is back online (a reboot, a
+    /// relaunch, a replug, or macOS re-enabling it), and drops the record when that does not
+    /// take. Called from DisplayManager.refreshDisplays.
+    ///
+    /// A disconnect is a choice about one specific display, already stored by UUID, and it
+    /// used to last only until that display next showed up. A monitor kept switched off but
+    /// still cabled enumerates as an ordinary display at every boot, so the same disconnect
+    /// had to be redone by hand every time (issue #93); re-applying it here is what makes
+    /// the choice stick. It only ever touches displays the user disconnected themselves, and
+    /// only while it is safe to: `wouldLeaveNoActiveDisplay` refuses to take the last screen
+    /// and `restoreIfNoActiveDisplay` stays underneath as the backstop. A re-apply that is
+    /// refused, fails, or does not verifiably land drops the record exactly as before, so
+    /// the list never claims a display is disconnected while it is lit.
     func reconcile() {
         guard !disconnected.isEmpty else { return }
-        var onlineCount: UInt32 = 0
-        CGGetOnlineDisplayList(0, nil, &onlineCount)
-        var onlineIDs = [CGDirectDisplayID](repeating: 0, count: Int(onlineCount))
-        CGGetOnlineDisplayList(onlineCount, &onlineIDs, &onlineCount)
-        let onlineUUIDs = Set(onlineIDs.prefix(Int(onlineCount)).map { uuid(for: $0) })
+        let onlineUUIDs = Set(onlineDisplayIDs().map { uuid(for: $0) })
+        let resurfaced = disconnected.filter { onlineUUIDs.contains($0.uuid) }
+        guard !resurfaced.isEmpty else { return }
+        // Intel has no working disconnect to re-apply, so there the old behaviour is all
+        // that is available: forget the record and keep the UI honest.
+        guard isSupported else {
+            disconnected.removeAll { onlineUUIDs.contains($0.uuid) }
+            saveDesired()
+            return
+        }
+        for record in resurfaced {
+            // A blink (softReconnect) puts its own display back online on purpose, and a
+            // reconnect in flight is the user (or the restore path) asking for exactly that.
+            guard !reapplyInFlight.contains(record.uuid),
+                  !softReconnectInFlight.contains(record.uuid),
+                  !reconnectInFlight.contains(record.uuid) else { continue }
+            reapplyInFlight.insert(record.uuid)
+            Task { [weak self] in
+                guard let self else { return }
+                await self.reapplyRemembered(record.uuid)
+                self.reapplyInFlight.remove(record.uuid)
+            }
+        }
+    }
 
-        let before = disconnected.count
-        disconnected.removeAll { onlineUUIDs.contains($0.uuid) }
-        if disconnected.count != before { saveDesired() }
+    /// Displays whose remembered disconnect is being re-applied right now. A reconfiguration
+    /// burst refreshes the display list several times over, and each refresh must not stack
+    /// another attempt on the same display.
+    private var reapplyInFlight: Set<String> = []
+
+    /// One display's half of reconcile: put it back the way the user left it, or forget it.
+    private func reapplyRemembered(_ recordUUID: String) async {
+        guard !reconnectInFlight.contains(recordUUID) else { return }
+        guard let liveID = onlineDisplayIDs().first(where: { uuid(for: $0) == recordUUID })
+        else { return }  // gone again by itself; the record still stands for next time
+        var applied = false
+        if !wouldLeaveNoActiveDisplay(liveID),
+           case .success = await setEnabled(false, displayID: liveID) {
+            // The API's own answer is not proof (see verifyBackOnline for the same problem
+            // in the other direction), and a display still lit behind a lying success would
+            // have this run again at every refresh. Enumeration is the proof.
+            for _ in 0..<10 {
+                if !onlineDisplayIDs().contains(liveID) { applied = true; break }
+                try? await Task.sleep(nanoseconds: 100_000_000)
+            }
+        }
+        guard let idx = disconnected.firstIndex(where: { $0.uuid == recordUUID }) else { return }
+        if applied {
+            disconnected[idx].displayID = liveID
+        } else {
+            disconnected.remove(at: idx)
+        }
+        saveDesired()
     }
 
     /// Guards against overlapping recovery runs from reconfiguration-callback bursts, same
@@ -585,25 +648,6 @@ final class PhysicalDisplayToggleService: ObservableObject {
         }
     }
 
-    /// Re-applies disconnect for displays macOS re-enabled after wake-from-sleep. Called from
-    /// AppDelegate.onWake after WindowServer settles.
-    func reapplyOnWake() async {
-        guard isSupported, !disconnected.isEmpty else { return }
-        var onlineCount: UInt32 = 0
-        CGGetOnlineDisplayList(0, nil, &onlineCount)
-        var onlineIDs = [CGDirectDisplayID](repeating: 0, count: Int(onlineCount))
-        CGGetOnlineDisplayList(onlineCount, &onlineIDs, &onlineCount)
-        let onlineByUUID = Dictionary(uniqueKeysWithValues:
-            onlineIDs.prefix(Int(onlineCount)).map { (uuid(for: $0), $0) })
-
-        for record in disconnected {
-            // Only re-disconnect ones macOS brought back online, and never the last screen.
-            guard let liveID = onlineByUUID[record.uuid] else { continue }
-            guard !wouldLeaveNoActiveDisplay(liveID) else { continue }
-            _ = await setEnabled(false, displayID: liveID)
-        }
-    }
-
     // MARK: - Persistence
 
     private func saveDesired() {
@@ -616,9 +660,10 @@ final class PhysicalDisplayToggleService: ObservableObject {
               let decoded = try? JSONDecoder().decode([DisconnectedDisplay].self, from: data)
         else { return }
         disconnected = decoded
-        // By design we do NOT auto-disconnect on launch, restarting the app must never
-        // black out a screen on its own. The loaded list only populates the "Disconnected"
-        // UI so the user can reconnect (or ignore) at their choice. Only the sleep/wake path
-        // re-applies disconnect, via reapplyOnWake().
+        // Nothing is disconnected from here: the loaded list only populates the
+        // "Disconnected" UI. The first display-list refresh after launch re-applies it
+        // through reconcile(), which is where the safety rails are (it never takes the last
+        // screen, and forgets any record it cannot honour). Wake goes through the same
+        // path: the wake chain's refresh runs reconcile like any other.
     }
 }

--- a/Crisp/Views/PhysicalDisplayToggleView.swift
+++ b/Crisp/Views/PhysicalDisplayToggleView.swift
@@ -49,6 +49,17 @@ struct DisconnectDisplayRow: View {
                     }
                 }
 
+                // The disconnect outlives a replug and a reboot (see
+                // PhysicalDisplayToggleService.reconcile), and a display that is switched off
+                // at the window server shows no signal and is absent from System Settings, so
+                // there is nothing outside this menu to say what happened to it. Said here,
+                // where the choice is made, rather than left to be rediscovered later.
+                Text("Stays disconnected until you reconnect it here.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 4)
+
                 if let msg = errorMessage {
                     Text(msg)
                         .font(.caption)


### PR DESCRIPTION
## What & why

Follow-up to #93 / #101, and a question rather than a merge request: I'd like your read on whether you want any of this, and which parts.

Thank you for the review on #93 — the Reconnect race you caught was real, and the point about `reconcile` being where the choice becomes durable is what made the patch small. #99 and #100 were both better than what I would have sent.

**Stacked on #101.** The first two commits here are that PR; only the last three are new. Happy to rebase once #101 lands, or to close this and reopen it as separate PRs.

The problem is one #101 creates. A disconnected display is switched off at the window server: it shows no signal, System Settings does not list it, and replugging the cable changes nothing, because the window server holds that state and not the cable. While the choice only lasted until the display next enumerated, that was survivable. Now that it lasts, someone who comes back to a monitor they disconnected months ago gets a black screen, replugs the cable, power-cycles the monitor, and has every reason to conclude the hardware died. The choice was theirs, but nothing on the machine can tell them so.

Three independent commits, each of which stands alone — take any subset:

**1. A caption under the Disconnect row** (`65a5c07`). One line, at the moment the choice is made: "Stays disconnected until you reconnect it here." The cheapest of the three, and the one I would keep if you only wanted one.

**2. A dot on the menu bar icon while any display is held off** (`84e0463`). Opposite corner and a different colour from the Keep Awake one, so both can be read at once; the badge factory is now shared rather than duplicated. Deliberately small — it is not an alert, it is the thing a puzzled user clicks, and clicking it is what shows the Reconnect row.

**3. A notification with a Reconnect button** (`45d710e`). The one I am least sure you want, since it is a new framework and a new permission. Two things that I hope make it defensible: authorization is requested at the first banner rather than at launch, so no prompt appears for anyone who never reaches this state; and it tells without deciding — Crisp never takes the disconnect back on its own.

## Why it does not auto-reconnect on a replug

That was my first instinct and I think it is wrong. A cable arriving cannot be told apart from a dock re-enumerating everything on it (my second monitor is on the same dock, so every dock replug would resurrect it), nor from a DisplayPort monitor being switched off and on at the wall, where the link drops entirely and HDMI's does not — so the same rule would behave differently per connector, in a feature whose value is being predictable. And any signal that resurrects displays automatically can resurrect one that is not really there. So: tell, never decide.

## How tested

On a MacBook Pro (M5, macOS 26.6.1), Developer ID signed build, with an Acer E241Y on HDMI through a j5create dock, held disconnected by Crisp.

Finding the trigger took measuring, and the result was not what I assumed. Unplugging and replugging that cable, registry entry IDs beside the service events as they fired:

```
[03:24:15] EVENT terminate id=4294977625        <- cable out
[03:24:15] framebuffer 4294969518:-             ...same object, name cleared
[03:24:23] EVENT publish   id=4294978031        <- cable back in
[03:24:24] framebuffer 4294969518:E241Y G0      ...same object, name restored
```

Two things follow. The window server never moves: a disabled display does not leave `SLSGetDisplayList` and never re-enters the online list, so there is no reconfiguration callback and no CoreGraphics event to hang this on — which is exactly why the user sees nothing either. And `IOMobileFramebufferShim` is the wrong service to watch: its object outlives the cable and only its properties change, so it publishes nothing (I shipped that version to myself first and it stayed silent through four replugs). `DCPAVServiceProxy` is the one actually created and destroyed with the cable. It carries no EDID, so it is the trigger and the framebuffer is the identity; the name returns about 0.4s after the event, hence the delayed reads.

End to end, on the build with the corrected trigger:

```
[03:30:32.340] EVENT publish            <- cable back in
   03:30:32     notice posted for "E241Y G0"; the Reconnect button brings it back
[03:31:03] and [03:33:02] replugs       <- no further notice: the per-day limit holding
```

`make check` is green (SwiftLint strict, tests, localization keys; both new strings carry zh-Hans). `UserNotifications` autolinks — no build-script change needed, verified with `otool -L` on the swiftc path that `dev.sh` and `release.sh` use.

One note if the dock-switching rule from #92 ever lands: the notification's Reconnect should also tell that rule the user asked for the panel, the same way the menu's Reconnect does, or the rule will take it away again seconds later. I have that line locally but left it out here, since the service it calls does not exist on this branch.

## Checklist
- [x] Builds locally (`./scripts/release.sh`, Developer ID signed)
- [x] `Crisp/Resources/Localizable.xcstrings` updated for both new strings
- [ ] Screenshot — happy to add one for the caption and the badge if you want the change at all
