### PR TITLE
Count only displays with a real panel behind them

### DIFF
--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -158,14 +158,20 @@ final class PhysicalDisplayToggleService: ObservableObject {
         let virtual = VirtualDisplayService.shared
         return ids.prefix(Int(count)).filter { id in
             guard !virtual.isVirtualDisplay(id) else { return false }
-            // Once the last real display is gone macOS spawns a placeholder
-            // display (vendor 'unkn' 0x756E6B6E, model 'virt' 0x76697274,
-            // fingerprinted live on macOS 26). It is not a viewable screen, and
-            // counting it kept restoreIfNoActiveDisplay from ever firing in the
-            // all-screens-black state it exists to fix.
-            let isPlaceholder = CGDisplayVendorNumber(id) == 0x756E6B6E
-                && CGDisplayModelNumber(id) == 0x76697274
-            return !isPlaceholder
+            // Real panels carry 16-bit EDID vendor and product codes. Two kinds of
+            // entry enumerate as active without a screen behind them, and both fail
+            // that shape: the placeholder macOS spawns once the last real display is
+            // gone (vendor 'unkn' 0x756E6B6E, model 'virt' 0x76697274, four-character
+            // tags that cannot fit in 16 bits; fingerprinted live on macOS 26), and the
+            // stub a re-enabled record leaves when its hardware is no longer attached
+            // (vendor 0, model 0; observed live by @ncchen99 on #91, online and active,
+            // showing nothing). Counting either kept restoreIfNoActiveDisplay from
+            // firing, or let it stop, in the all-screens-black state it exists to fix.
+            // Matching by shape rather than by the one fingerprint also survives a
+            // future macOS renaming the placeholder.
+            let vendor = CGDisplayVendorNumber(id), model = CGDisplayModelNumber(id)
+            let hasNoPanel = vendor == 0 || model == 0 || vendor > 0xFFFF || model > 0xFFFF
+            return !hasNoPanel
         }.count
     }
 


### PR DESCRIPTION
`physicalActiveDisplayCount` decides when `restoreIfNoActiveDisplay` is done. @ncchen99 found on #91 that re-enabling a remembered display whose hardware is gone can leave an online, active entry with vendor 0 and model 0, and the count took it for a screen, so the #99 poll could stop with every display still dark. Real panels carry 16-bit EDID vendor and product codes; the macOS placeholder uses four-character tags wider than that, and the detached stub reports zero. The count now drops anything with a zero or out-of-range code instead of matching the placeholder's exact fingerprint. Checked against the three panels here (built-in, U2412M, Q27G3XMN behind a hub) plus both bad shapes. Compile and strict lint green; no unit test, this is display enumeration.

Fixes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NDzD18GySiCwEGfWJiT4J
