### PR TITLE
Give crispctl a conventional help screen and uuid selectors

### DIFF
--- a/Crisp/Models/CrispControlModel.swift
+++ b/Crisp/Models/CrispControlModel.swift
@@ -55,10 +55,14 @@ struct CrispControlRequest: Codable, Equatable {
     let command: Command
     let display: UInt32?
     let brightness: Double?
-    init(command: Command, display: UInt32? = nil, brightness: Double? = nil) {
+    /// A display as a person typed it: a runtime id or a uuid. Takes precedence over
+    /// `display`, which stays for clients that already send the numeric id.
+    let selector: String?
+    init(command: Command, display: UInt32? = nil, brightness: Double? = nil, selector: String? = nil) {
         self.command = command
         self.display = display
         self.brightness = brightness
+        self.selector = selector
     }
 }
 enum CrispControlFrame {
@@ -140,73 +144,65 @@ enum CrispControlModel {
         case .list:
             return (.success(displays: displays), nil)
         case .getBrightness:
-            guard let id = request.display else { return (.failure("display is required"), nil) }
-            guard let display = displays.first(where: { $0.id == id }) else {
+            guard request.selector != nil || request.display != nil else {
+                return (.failure("display is required"), nil)
+            }
+            guard let display = target(of: request, in: displays) else {
                 return (.failure("display not found"), nil)
             }
             return (.success(display: display), nil)
         case .setBrightness:
-            guard let id = request.display, let value = request.brightness else {
+            guard request.selector != nil || request.display != nil, let value = request.brightness else {
                 return (.failure("display and brightness are required"), nil)
             }
             guard (0...100).contains(value) else {
                 return (.failure("brightness must be between 0 and 100"), nil)
             }
-            guard displays.contains(where: { $0.id == id }) else {
+            guard let display = target(of: request, in: displays) else {
                 return (.failure("display not found"), nil)
             }
-            return (.success(), .init(displayID: id, brightness: value))
+            return (.success(), .init(displayID: display.id, brightness: value))
         }
+    }
+
+    /// Finds a display by the selector a person typed: a runtime id, or a uuid in any
+    /// case. Ids win, so a uuid that happens to be all digits still needs the uuid form.
+    static func resolve(selector: String, in displays: [CrispControlDisplay]) -> CrispControlDisplay? {
+        if let id = UInt32(selector), let match = displays.first(where: { $0.id == id }) {
+            return match
+        }
+        return displays.first { $0.uuid?.caseInsensitiveCompare(selector) == .orderedSame }
+    }
+    private static func target(
+        of request: CrispControlRequest, in displays: [CrispControlDisplay]
+    ) -> CrispControlDisplay? {
+        if let selector = request.selector { return resolve(selector: selector, in: displays) }
+        return request.display.flatMap { id in displays.first { $0.id == id } }
     }
 }
 enum CrispControlCLIModel {
-    static let usage = "usage: crispctl displays list | crispctl brightness get <display-id> | "
-        + "crispctl brightness set <display-id> <percent> | crispctl help"
+    static let usage = "usage: crispctl <command> [<args>]; run 'crispctl help' for the commands"
 
     /// The full reference, for a person at a terminal and for an agent that reads it
     /// before acting. Kept in the shared model so the app and the CLI cannot drift.
     static let help = """
-        crispctl: control a running Crisp from the command line.
+        Usage: crispctl <command> [<args>]
 
-        Crisp must be running on this Mac under the same user. crispctl talks to it
-        over a local Unix socket (mode 0600 in the per-user temp dir) and never
-        launches the app. Source builds only for now; the DMG and the Homebrew cask
-        do not ship crispctl.
+        Control a running Crisp from the command line. Crisp must be running for the
+        same user; crispctl talks to it over a local socket and never launches it.
 
-        Commands
-          crispctl displays list
-              Every online display: id, name, brightness (0-100), isBuiltin,
-              plus uuid, current resolution, and brightnessBackend metadata.
-          crispctl brightness get <display-id>
-              Current brightness of one display.
-          crispctl brightness set <display-id> <percent>
-              Set brightness, 0-100. Same path as the panel slider: hardware (DDC)
-              or software dimming as Crisp decided for that display, and it clears
-              the active preset. The reply means Crisp accepted the request, not
-              that the panel was read back; run brightness get to confirm.
-          crispctl help
-              This text. Also --help and -h.
+        Commands:
+          display list                    Online displays as JSON: id, uuid, name,
+                                          resolution, brightness, brightnessBackend
+          brightness get <display>        Read brightness, 0-100
+          brightness set <display> <pct>  Set brightness, 0-100; clears the active preset
+          help                            Show this help (also -h, --help)
 
-        Display ids
-          UUID is stable across reconnects and identifies the display. Commands
-          still require the numeric runtime id, which can change after an unplug
-          or a wake, so run a fresh displays list before acting.
+        <display> is a runtime id or a uuid from 'display list'. Ids can change after
+        an unplug or a wake; uuids do not.
 
-        Output
-          One JSON object per call. Success: {"ok":true,...}. Failure:
-          {"ok":false,"error":"..."}. Later versions may add fields; ignore
-          what you do not know. Crisp's own refusals come back on stdout,
-          crispctl's own errors (no socket, bad arguments) go to stderr.
-          brightnessBackend is Crisp's current route: builtin, ddc, software,
-          or unknown while external DDC availability is undetermined. An HDR
-          software-dimming override reports software.
-
-        Exit codes
-          0  ok
-          1  could not reach Crisp: not running, socket missing, another user,
-             or an unreadable reply
-          2  bad arguments
-          3  Crisp refused the request: unknown display, value out of range
+        Output is one JSON object per call: {"ok":true,...} or {"ok":false,"error":"..."}.
+        Exit codes: 0 ok, 1 Crisp unreachable, 2 bad arguments, 3 Crisp refused.
         """
 
     enum ParseResult: Equatable {
@@ -219,17 +215,15 @@ enum CrispControlCLIModel {
         if arguments.isEmpty || arguments == ["help"] || arguments == ["--help"] || arguments == ["-h"] {
             return .help
         }
-        if arguments == ["displays", "list"] {
+        if arguments == ["display", "list"] {
             return .request(.init(command: .list))
         }
-        if arguments.count == 3, arguments[0...1] == ["brightness", "get"],
-           let id = UInt32(arguments[2]) {
-            return .request(.init(command: .getBrightness, display: id))
+        if arguments.count == 3, arguments[0...1] == ["brightness", "get"], !arguments[2].isEmpty {
+            return .request(.init(command: .getBrightness, selector: arguments[2]))
         }
-        if arguments.count == 4, arguments[0...1] == ["brightness", "set"],
-           let id = UInt32(arguments[2]), let value = Double(arguments[3]),
-           value.isFinite, (0...100).contains(value) {
-            return .request(.init(command: .setBrightness, display: id, brightness: value))
+        if arguments.count == 4, arguments[0...1] == ["brightness", "set"], !arguments[2].isEmpty,
+           let value = Double(arguments[3]), value.isFinite, (0...100).contains(value) {
+            return .request(.init(command: .setBrightness, brightness: value, selector: arguments[2]))
         }
         return .failure
     }

--- a/CrispTests/CrispControlModelTests.swift
+++ b/CrispTests/CrispControlModelTests.swift
@@ -20,11 +20,15 @@ final class CrispControlModelTests: XCTestCase {
 
     func testParserSupportsExactlyThreeCommands() {
         let cases: [([String], CrispControlRequest)] = [
-            (["displays", "list"], .init(command: .list)),
-            (["brightness", "get", "42"], .init(command: .getBrightness, display: 42)),
+            (["display", "list"], .init(command: .list)),
+            (["brightness", "get", "42"], .init(command: .getBrightness, selector: "42")),
+            (
+                ["brightness", "get", "37D8832A-2D66-02CA-B9F7-8F30A301B230"],
+                .init(command: .getBrightness, selector: "37D8832A-2D66-02CA-B9F7-8F30A301B230")
+            ),
             (
                 ["brightness", "set", "42", "37.5"],
-                .init(command: .setBrightness, display: 42, brightness: 37.5)
+                .init(command: .setBrightness, brightness: 37.5, selector: "42")
             )
         ]
         for (arguments, request) in cases {
@@ -38,7 +42,7 @@ final class CrispControlModelTests: XCTestCase {
         }
         // The reference must name every command it documents, and the usage line must
         // point at it, so a wrong invocation still leads to the full text.
-        for command in ["displays list", "brightness get", "brightness set", "crispctl help"] {
+        for command in ["display list", "brightness get <display>", "brightness set <display>", "help"] {
             XCTAssertTrue(CrispControlCLIModel.help.contains(command), command)
         }
         XCTAssertTrue(CrispControlCLIModel.usage.contains("crispctl help"))
@@ -46,9 +50,8 @@ final class CrispControlModelTests: XCTestCase {
 
     func testParserRejectsInvalidArityIDsOptionsAndPercent() {
         let cases = [
-            ["help", "me"], ["displays"], ["displays", "list", "--json"],
-            ["brightness", "get"], ["brightness", "get", "x"],
-            ["brightness", "get", "4294967296"], ["brightness", "set", "42"],
+            ["help", "me"], ["display"], ["displays", "list"], ["display", "list", "--json"],
+            ["brightness", "get"], ["brightness", "get", ""], ["brightness", "set", "42"],
             ["brightness", "set", "42", "nan"], ["brightness", "set", "42", "inf"],
             ["brightness", "set", "42", "-0.1"], ["brightness", "set", "42", "100.1"]
         ]
@@ -112,6 +115,29 @@ final class CrispControlModelTests: XCTestCase {
         XCTAssertEqual(returnedDisplay["uuid"] as? String, display.uuid)
         XCTAssertEqual(returnedDisplay["brightnessBackend"] as? String, "ddc")
         XCTAssertEqual((returnedDisplay["resolution"] as? [String: Any])?["pixelWidth"] as? Int, 5120)
+
+        // The CLI sends what was typed as a selector: an id, or a uuid in any case.
+        for selector in ["7", "37d8832a-2d66-02ca-b9f7-8f30a301b230"] {
+            let bySelector = CrispControlModel.handle(
+                Data(#"{"command":"getBrightness","selector":"\#(selector)"}"#.utf8),
+                displays: [display]
+            )
+            XCTAssertEqual(bySelector.response, .success(display: display), selector)
+        }
+    }
+
+    func testResolvePrefersIDThenUUIDCaseInsensitive() {
+        let other = CrispControlDisplay(id: 9, name: "Other", brightness: 1, isBuiltin: true, uuid: "9")
+        let displays = [display, other]
+        XCTAssertEqual(CrispControlModel.resolve(selector: "7", in: displays), display)
+        // An all-digit uuid still resolves as an id first.
+        XCTAssertEqual(CrispControlModel.resolve(selector: "9", in: displays), other)
+        XCTAssertEqual(
+            CrispControlModel.resolve(selector: "37d8832a-2d66-02ca-b9f7-8f30a301b230", in: displays),
+            display
+        )
+        XCTAssertNil(CrispControlModel.resolve(selector: "8", in: displays))
+        XCTAssertNil(CrispControlModel.resolve(selector: "", in: displays))
     }
 
     func testDisplayMetadataAllowsMissingCurrentResolutionAndLegacyResponses() throws {
@@ -176,6 +202,11 @@ final class CrispControlModelTests: XCTestCase {
         )
         XCTAssertEqual(result.response, .success())
         XCTAssertEqual(result.brightnessChange, .init(displayID: 7, brightness: 35))
+        let bySelector = CrispControlModel.handle(
+            Data(#"{"command":"setBrightness","selector":"37D8832A-2D66-02CA-B9F7-8F30A301B230","brightness":35}"#.utf8),
+            displays: [display]
+        )
+        XCTAssertEqual(bySelector.brightnessChange, .init(displayID: 7, brightness: 35))
         XCTAssertEqual(
             CrispControlModel.encode(result.response),
             Data(#"{"ok":true}"#.utf8) + Data([0x0A])
@@ -187,6 +218,8 @@ final class CrispControlModelTests: XCTestCase {
             #"{"command":"list""#,
             #"{"command":"getBrightness"}"#,
             #"{"command":"getBrightness","display":8}"#,
+            #"{"command":"getBrightness","selector":"nope"}"#,
+            #"{"command":"setBrightness","selector":"","brightness":35}"#,
             #"{"command":"setBrightness","display":7}"#,
             #"{"command":"setBrightness","display":7,"brightness":101}"#,
             #"{"command":"unknown"}"#

--- a/README.md
+++ b/README.md
@@ -99,15 +99,17 @@ xcodegen generate && xcodebuild -scheme crispctl -configuration Release
 It supports exactly three commands:
 
 ```sh
-crispctl displays list
-crispctl brightness get <display-id>
-crispctl brightness set <display-id> <percent>
+crispctl display list
+crispctl brightness get <display>
+crispctl brightness set <display> <percent>
 crispctl help
 ```
 
-`crispctl help` is the full reference (output format, display ids, exit codes); point an agent at it before it does anything else. `displays list` includes additive UUID, current-resolution, and brightness-backend metadata. The backend is Crisp's current route (`builtin`, `ddc`, `software`, or `unknown` while external DDC availability is undetermined); HDR software dimming reports `software`.
+`<display>` is a runtime id or a uuid from `display list`. Ids can change after an unplug or a wake; uuids do not, so scripts should prefer them. `crispctl help` prints the reference (commands, output format, exit codes); point an agent at it before it does anything else.
 
-Crisp must already be running. A display UUID is stable across reconnects for identification, but commands still require the numeric runtime display ID from a fresh `displays list`; output is JSON by default. `brightness set` is a manual change like using the slider and clears the active preset. A successful request means the change was accepted and queued, not independently verified; it is not retried automatically.
+`display list` reports each display's uuid, current resolution and brightness backend. The backend is Crisp's current route (`builtin`, `ddc`, `software`, or `unknown` while external DDC availability is undetermined); HDR software dimming reports `software`. Output is one JSON object per call.
+
+Crisp must already be running; crispctl never launches it. `brightness set` is a manual change like using the slider and clears the active preset. The reply means Crisp accepted the request, not that the panel was read back; it is not retried automatically.
 
 The current public Crisp 1.5.0 release, normal DMG, and Homebrew cask do not include `crispctl`.
 


### PR DESCRIPTION
The help text read like a man page pasted into a terminal: full invocations under a heading, then four paragraphs. It now prints what every comparable tool prints: a usage line, an aligned command table with one-line descriptions, and a short footer with the output format and exit codes. The long explanations live in the README section, which already said most of it.

Two changes ride along, both cheap while nothing has shipped. `displays list` becomes `display list`, so every command uses the same singular noun as the display commands in #97. And `brightness get` and `brightness set` take a uuid as well as a runtime id, through a `selector` field the app resolves id first, then uuid in any case. The numeric `display` field still works for clients that already send it. The resolver matches the one in #97 so that PR can adopt it on rebase.

Verified live on the Dell U2412M: get and set by id and by uuid in both cases, unknown selectors refused with exit 3, the old command name rejected with the usage line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016NDzD18GySiCwEGfWJiT4J
