### PR TITLE
Log the blackout restore's stand-downs

### DIFF
--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -680,14 +680,26 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// has a live screen. The settle delay rides out transient empty display lists during
     /// wake/replug storms, so a monitor that comes right back keeps the disconnect intact.
     func restoreIfNoActiveDisplay() {
-        guard isSupported, !disconnected.isEmpty, !restoreInFlight else { return }
-        guard physicalActiveDisplayCount() == 0 else { return }
+        guard isSupported, !disconnected.isEmpty else { return }
+        // With records to act on, every stand-down is worth a line: a capture of a dark
+        // desk otherwise cannot tell "never asked" from "asked and refused", and which guard
+        // refused (issue #92: a dock pulled during sleep can keep its displays in the online
+        // list until the link times out, and those count as active).
+        let active = physicalActiveDisplayCount()
+        guard !restoreInFlight, active == 0 else {
+            Self.log.notice("restore asked with \(self.disconnected.count, privacy: .public) record(s): \(active, privacy: .public) active display(s), in flight \(self.restoreInFlight, privacy: .public), standing down")
+            return
+        }
         restoreInFlight = true
         Task { [weak self] in
             try? await Task.sleep(nanoseconds: 2_000_000_000)
             guard let self else { return }
             defer { self.restoreInFlight = false }
-            guard self.physicalActiveDisplayCount() == 0 else { return }
+            let settled = self.physicalActiveDisplayCount()
+            guard settled == 0 else {
+                Self.log.notice("restore settled: \(settled, privacy: .public) active display(s) after 2 s, standing down")
+                return
+            }
             // This path acts with every screen black, so without a line here a capture
             // cannot tell a Crisp restore from macOS re-probing on its own (noted from
             // the outside in #91).


### PR DESCRIPTION
restoreIfNoActiveDisplay runs on every display refresh, and until now it returned in silence whenever a guard refused. A capture of a dark desk could not tell "never asked" from "asked and refused", let alone which guard did the refusing. ncchen99 hit exactly that on #92: built-in disconnected, dock pulled during sleep, fourteen seconds of black after wake with nothing from the restore path in the log.

With records to act on, each stand-down now logs one line in the display category: the active display count, the record count and whether a restore is already in flight. The settle check inside the restore logs the same way when the display list came back within its two seconds. Without records the path stays silent, since there is nothing it could do.

Compile, strict lint and the x86_64 typecheck are green. Not exercised live yet: the lines need a record and a dark desk, which is the #92 capture itself.
