### PR TITLE
Make the brightness and volume keys behave like the system's

### DIFF
--- a/Crisp/Models/BrightnessKeySteps.swift
+++ b/Crisp/Models/BrightnessKeySteps.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// The stops the brightness and volume keys move between: the same sixteen
+/// macOS itself uses, and the ones the OSD banner's tick dots mark.
+///
+/// The keys used to add or subtract a sixteenth of the range from wherever the
+/// value happened to be, so a display sitting at 79 percent went to 86, 92 and
+/// 98 and never touched a stop. The system's own keys land on one every time,
+/// which is what makes its dots mean anything.
+enum BrightnessKeySteps {
+    static let stops = 16.0
+    static let step = 100.0 / stops
+
+    /// The next stop above or below `value`, on the 0...100 scale the keys and
+    /// the banner both use. The grid carries on past 100 for displays with
+    /// Extra Brightness; clamping to the display's maximum is the caller's.
+    static func next(from value: Double, up: Bool) -> Double {
+        let index = value / step
+        // A value already on a stop has to move a whole step, and one a hair
+        // off it, which a rounded readback gives, must not move only the hair.
+        let epsilon = 0.001
+        let target = up ? (index + epsilon).rounded(.down) + 1 : (index - epsilon).rounded(.up) - 1
+        return target * step
+    }
+}

--- a/Crisp/Services/BrightnessKeyService.swift
+++ b/Crisp/Services/BrightnessKeyService.swift
@@ -60,11 +60,6 @@ final class BrightnessKeyService: @unchecked Sendable {
     private nonisolated static let nxKeytypeSoundDown: Int = 1
     private nonisolated static let nxKeytypeMute: Int = 7
 
-    /// Each key press moves brightness by 1/16 (≈ 6.25 %), matching macOS native behaviour.
-    private nonisolated static let brightnessStep: Double = 100.0 / 16.0
-    /// Volume keys use the same 1/16 step as macOS's own volume control.
-    private nonisolated static let volumeStep: Double = 100.0 / 16.0
-
     /// Tap lifecycle at notice: #57 lost a round trip on a silently dead tap.
     private nonisolated static let log = Logger(subsystem: "com.crisp.app", category: "keys")
 
@@ -306,13 +301,11 @@ final class BrightnessKeyService: @unchecked Sendable {
     /// not also bump the built-in), or a pass-through of `event` when we did not handle it (target
     /// not attached / cursor on built-in / no controllable external).
     nonisolated private func routeBrightnessPress(up: Bool, event: CGEvent) -> Unmanaged<CGEvent>? {
-        let step = up ? Self.brightnessStep : -Self.brightnessStep
-
         // Route by user preference. Read on the main actor, this callback runs on
         // the main run loop (see class docs), so assumeIsolated is safe here.
         switch MainActor.assumeIsolated({ SettingsService.shared.brightnessKeyTarget }) {
         case .allDisplays:
-            Task { @MainActor in self.adjustDisplays(DisplayManagerAccessor.shared.displays, step: step) }
+            Task { @MainActor in self.adjustDisplays(DisplayManagerAccessor.shared.displays, up: up) }
             // Consume: we adjust every display (built-in included) ourselves, so
             // macOS must not also bump the built-in on top.
             return nil
@@ -327,7 +320,7 @@ final class BrightnessKeyService: @unchecked Sendable {
             if anyAttached {
                 Task { @MainActor in
                     let targets = DisplayManagerAccessor.shared.displays.filter { selected.contains($0.displayUUID) }
-                    self.adjustDisplays(targets, step: step)
+                    self.adjustDisplays(targets, up: up)
                 }
                 return nil
             }
@@ -369,7 +362,8 @@ final class BrightnessKeyService: @unchecked Sendable {
         Task { @MainActor in
             let displays = DisplayManagerAccessor.shared.displays
             guard let display = displays.first(where: { $0.displayID == displayID }) else { return }
-            let newBrightness = max(0.0, min(display.maxBrightness, display.brightness + step))
+            let newBrightness = max(0.0, min(display.maxBrightness,
+                                             BrightnessKeySteps.next(from: display.brightness, up: up)))
             // Use smooth animation, cancels any in-progress animation automatically.
             BrightnessService.shared.setBrightnessSmooth(newBrightness, for: display)
 
@@ -403,9 +397,9 @@ final class BrightnessKeyService: @unchecked Sendable {
             case Self.nxKeytypeMute:
                 service.toggleMute(for: target)
             case Self.nxKeytypeSoundUp:
-                service.setVolume(target.volume + Self.volumeStep, for: target)
+                service.setVolume(BrightnessKeySteps.next(from: target.volume, up: true), for: target)
             default:
-                service.setVolume(target.volume - Self.volumeStep, for: target)
+                service.setVolume(BrightnessKeySteps.next(from: target.volume, up: false), for: target)
             }
             if let screen = NSScreen.screens.first(where: {
                 ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) == target.displayID
@@ -421,15 +415,16 @@ final class BrightnessKeyService: @unchecked Sendable {
         return nil
     }
 
-    /// Applies the same relative step to each given display (built-in or external),
+    /// Moves each given display (built-in or external) to its next stop,
     /// through BrightnessService's smooth fade (reusing its DDC/gamma/IOKit paths +
     /// coalescing), and shows the brightness HUD on each display's own screen.
     /// Backs the `.allDisplays` and `.selected` brightness-key modes.
     @MainActor
-    private func adjustDisplays(_ displays: [DisplayInfo], step: Double) {
+    private func adjustDisplays(_ displays: [DisplayInfo], up: Bool) {
         let screens = NSScreen.screens
         for display in displays {
-            let newBrightness = max(0.0, min(display.maxBrightness, display.brightness + step))
+            let newBrightness = max(0.0, min(display.maxBrightness,
+                                             BrightnessKeySteps.next(from: display.brightness, up: up)))
             BrightnessService.shared.setBrightnessSmooth(newBrightness, for: display)
             if let screen = screens.first(where: {
                 ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) == display.displayID

--- a/Crisp/Services/BrightnessKeyService.swift
+++ b/Crisp/Services/BrightnessKeyService.swift
@@ -362,8 +362,11 @@ final class BrightnessKeyService: @unchecked Sendable {
         Task { @MainActor in
             let displays = DisplayManagerAccessor.shared.displays
             guard let display = displays.first(where: { $0.displayID == displayID }) else { return }
+            // Step from the fade's target while one is running, not from the value
+            // it is passing through, or a held key never gets past the first stop.
+            let from = BrightnessService.shared.inFlightTarget(for: displayID) ?? display.brightness
             let newBrightness = max(0.0, min(display.maxBrightness,
-                                             BrightnessKeySteps.next(from: display.brightness, up: up)))
+                                             BrightnessKeySteps.next(from: from, up: up)))
             // Use smooth animation, cancels any in-progress animation automatically.
             BrightnessService.shared.setBrightnessSmooth(newBrightness, for: display)
 
@@ -423,8 +426,9 @@ final class BrightnessKeyService: @unchecked Sendable {
     private func adjustDisplays(_ displays: [DisplayInfo], up: Bool) {
         let screens = NSScreen.screens
         for display in displays {
+            let from = BrightnessService.shared.inFlightTarget(for: display.displayID) ?? display.brightness
             let newBrightness = max(0.0, min(display.maxBrightness,
-                                             BrightnessKeySteps.next(from: display.brightness, up: up)))
+                                             BrightnessKeySteps.next(from: from, up: up)))
             BrightnessService.shared.setBrightnessSmooth(newBrightness, for: display)
             if let screen = screens.first(where: {
                 ($0.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID) == display.displayID

--- a/Crisp/Services/BrightnessService.swift
+++ b/Crisp/Services/BrightnessService.swift
@@ -103,6 +103,12 @@ final class BrightnessAnimator: @unchecked Sendable {
         timer = nil
     }
 
+    /// The value a running fade is heading for, nil while idle. A key repeat has
+    /// to step from this and not from the value mid-fade: the fade crosses the
+    /// stop it is going to, so a press part way through computes the same stop
+    /// again and the level only creeps toward it. See BrightnessKeyService.
+    var pendingTarget: Double? { timer == nil ? nil : targetValue }
+
     /// Animate from `from` to `to` over `duration` seconds using `steps` discrete steps.
     /// `handler(value, isLast)` is called once per step on the main thread.
     /// Calling this cancels any previously running animation.
@@ -177,6 +183,14 @@ final class BrightnessService: @unchecked Sendable {
     @MainActor
     func cancelAnimation(for displayID: CGDirectDisplayID) {
         animators[displayID]?.cancel()
+    }
+
+    /// The brightness a display is fading toward, nil when no fade is running.
+    /// The brightness keys step from this so a repeat lands on the next stop
+    /// instead of re-aiming at the one the fade has not reached yet.
+    @MainActor
+    func inFlightTarget(for displayID: CGDirectDisplayID) -> Double? {
+        animators[displayID]?.pendingTarget
     }
 
     // MARK: - Manual Adjust Cooldown

--- a/CrispTests/BrightnessKeyStepsTests.swift
+++ b/CrispTests/BrightnessKeyStepsTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+
+/// Headless tests for the stops the brightness and volume keys move between.
+///
+/// `BrightnessKeySteps` is compiled directly into this test target (see `project.yml`
+/// sources, same route as `DisplayModeGeometry`), so no `@testable import Crisp` is
+/// needed.
+final class BrightnessKeyStepsTests: XCTestCase {
+
+    /// A value already on a stop moves a whole step, not a hair.
+    func testOnAStopMovesOneWholeStep() {
+        XCTAssertEqual(BrightnessKeySteps.next(from: 50, up: true), 56.25, accuracy: 0.0001)
+        XCTAssertEqual(BrightnessKeySteps.next(from: 50, up: false), 43.75, accuracy: 0.0001)
+    }
+
+    /// A value off the grid, which is where every display Crisp has never touched starts,
+    /// lands on the next stop rather than carrying its offset along.
+    /// Kills mutation: "add or subtract the step instead of snapping".
+    func testOffTheGridSnapsToTheNextStop() {
+        XCTAssertEqual(BrightnessKeySteps.next(from: 79, up: true), 81.25, accuracy: 0.0001)
+        XCTAssertEqual(BrightnessKeySteps.next(from: 79, up: false), 75, accuracy: 0.0001)
+    }
+
+    /// A readback a hair off a stop (DDC and gamma both round) still moves a whole step,
+    /// or holding the key would creep by fractions.
+    func testNearlyOnAStopStillMovesAWholeStep() {
+        XCTAssertEqual(BrightnessKeySteps.next(from: 56.2499, up: true), 62.5, accuracy: 0.0001)
+        XCTAssertEqual(BrightnessKeySteps.next(from: 56.2501, up: false), 50, accuracy: 0.0001)
+    }
+
+    /// The grid carries on past 100 for displays with Extra Brightness; clamping to the
+    /// display's own maximum belongs to the caller.
+    func testGridContinuesAboveOneHundred() {
+        XCTAssertEqual(BrightnessKeySteps.next(from: 100, up: true), 106.25, accuracy: 0.0001)
+    }
+
+    /// Below zero is the caller's to clamp too, so the step itself keeps counting down.
+    func testBelowZeroIsLeftToTheCaller() {
+        XCTAssertEqual(BrightnessKeySteps.next(from: 0, up: false), -6.25, accuracy: 0.0001)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -56,6 +56,7 @@ targets:
     sources:
       - path: Sources/crispctl
       - path: Crisp/Models/CrispControlModel.swift
+      - path: Crisp/Models/BrightnessKeySteps.swift
     settings:
       base:
         PRODUCT_NAME: crispctl
@@ -75,6 +76,7 @@ targets:
       - path: Crisp/Models/KeyboardShortcut.swift
       - path: Crisp/Models/DisplayPreset.swift
       - path: Crisp/Models/CrispControlModel.swift
+      - path: Crisp/Models/BrightnessKeySteps.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.crisp.tests


### PR DESCRIPTION
Two things about the brightness and volume keys, both measured against the system's own keys on the same desk. This is split out of the OSD banner work, where the tick dots under the track are what made the first one visible; the banner comes separately.

**The keys never landed on a stop.** They added or subtracted a sixteenth of the range from wherever the value happened to be, so a display found at 79 percent went to 85.25, 91.5 and 97.75 and never touched one of the sixteen stops macOS moves its own brightness and volume between. A new pure model, `BrightnessKeySteps`, returns the next stop above or below a value, and both key paths use it. Clamping stays at the call sites, so Extra Brightness carries the grid past 100.

**A held key crawled.** Each press worked out its next stop from the level the display was showing, but the 200 ms fade is still crossing the stop it is heading for, so a press part way through aimed at that same stop again and restarted the fade from wherever it had got to. The level converged on the first stop instead of moving on to the next one. Measured with 16 presses 90 ms apart, the system's own repeat rate, on an external against the built-in: the built-in went 50 to 100 in eight steps, one per press, while the external took all sixteen presses to reach 68.75, three steps, creeping 52.25, 54.51, 55.50, 55.92, 56.10 on the way to the first. `BrightnessAnimator` now reports the level a running fade is aiming for, and the keys step from that, falling back to the live level when nothing is running. A direct write cancels the animator, so the fallback cannot go stale.

## Verified

On the built-in and an external with the lid open, plus five unit tests on the new model:

- 16 presses 90 ms apart give 16 steps, and 8 presses at 33 ms give 8.
- Single presses 600 ms apart land exactly on 56.25, 62.50, 68.75 and 75.
- All-displays mode steps both panels once per press.
- The volume keys were measured the same way and needed no change: they commit the new level at once, so eight presses give eight steps at 90 ms and at 33 ms.

`make check` green.
