### PR TITLE
Keep the menu panel at the level it asks for

### DIFF
--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -1019,8 +1019,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             backing: .buffered,
             defer: false
         )
-        p.level = .popUpMenu
+        // Order matters: isFloatingPanel assigns the window level (.floating,
+        // 3), so setting it after the level silently threw the level away and
+        // the panel ran below every other app's utility windows instead of at
+        // the level the system's own menu bar popovers use.
         p.isFloatingPanel = true
+        p.level = .popUpMenu
         p.hidesOnDeactivate = false
         p.isMovable = false
         p.isOpaque = false


### PR DESCRIPTION
`isFloatingPanel` is not an independent flag, it assigns the window level. Setting it after `p.level = .popUpMenu` overwrote the level, so the menu panel ran at `.floating`, level 3, instead of the 101 the system's own menu bar popovers use. At level 3 it shares a level with every other app's utility and floating windows, any of which can end up drawn over it.

Swapping the two lines is the whole fix. This came out of reviewing the OSD banner branch and has nothing to do with it. Nobody has reported it, so it is a latent ordering bug rather than a visible one.

I checked both halves rather than trusting the docs. A scratch `NSPanel` reads level 101 after `.popUpMenu`, 3 after `isFloatingPanel = true`, and 101 with the two lines the other way round. The running app agreed: its panel window read layer 3 before this change and 101 after.

Verified live on macOS 26.5.1: the panel opens under the menu bar exactly where it did and covers none of it, a second click on the status item closes it, and the OSD banner (level 2005) still draws above it.
