### PR TITLE
Stop the HDR toggle echoing a live change back as a request

### DIFF
--- a/Crisp/Views/HDRToggleView.swift
+++ b/Crisp/Views/HDRToggleView.swift
@@ -32,7 +32,8 @@ struct HDRToggleView: View {
                     .labelsHidden()
                     .controlSize(.small)
                     .onChange(of: isOn) { _, newValue in
-                        guard !isProgrammaticChange else { return }
+                        guard !isProgrammaticChange,
+                              newValue != BrightnessBoostService.shared.isHDREnabled(for: display) else { return }
                         requestInFlight = true
                         Task { @MainActor in
                             _ = await BrightnessBoostService.shared.setHDRPreference(newValue, for: display)


### PR DESCRIPTION
HDRToggleView resyncs its switch from the live state on every screen-parameters notification, and every HDR flip fires one. The programmatic-change guard around that write does not hold, because SwiftUI runs onChange after the view update, by which time the flag is already reset, so each resync re-sent the value it had just read as a fresh setHDRPreference. Harmless while the toggle was the only writer, but each echo replaces the request token, and a request from anywhere else waiting out its settle at that moment is refused. Measured with crispctl's hdr set from #116: an off 0.3 s after an on was refused 4 times in 16, and 0 in 16 with this guard, which sends a request only when the switch differs from the live state. The panel toggle itself was clicked on and off with the fix in and sent exactly one request each way.