### PR TITLE
Say what a disconnect costs, where the choice is made

### DIFF
--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -120,6 +120,16 @@
     "%lld%%" : {
       "shouldTranslate" : false
     },
+    "Stays disconnected until you reconnect it here." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将保持断开，直到你在这里重新连接。"
+          }
+        }
+      }
+    },
     "×" : {
       "shouldTranslate" : false
     },

--- a/Crisp/Views/PhysicalDisplayToggleView.swift
+++ b/Crisp/Views/PhysicalDisplayToggleView.swift
@@ -49,6 +49,17 @@ struct DisconnectDisplayRow: View {
                     }
                 }
 
+                // The disconnect outlives a replug and a reboot (see
+                // PhysicalDisplayToggleService.reconcile), and a display that is switched off
+                // at the window server shows no signal and is absent from System Settings, so
+                // there is nothing outside this menu to say what happened to it. Said here,
+                // where the choice is made, rather than left to be rediscovered later.
+                Text("Stays disconnected until you reconnect it here.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 4)
+
                 if let msg = errorMessage {
                     Text(msg)
                         .font(.caption)


### PR DESCRIPTION
The caption commit from #104, by @ncchen99, taken as it is: one line under the Disconnect Display row, "Stays disconnected until you reconnect it here.", with its zh-Hans string. Since #101 a disconnect outlives a replug and a reboot, and a display that is switched off at the window server shows no signal and is missing from System Settings, so this is the one place that can say so, at the moment the choice is made.

The menu bar dot and the notification from #104 stay out, as decided there.