### PR TITLE
crispctl: connect, disconnect and toggle a physical display

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -40,6 +40,7 @@ SOFTWARE.
 - [@Juns-g](https://github.com/Juns-g) ([#75](https://github.com/didriksg/Crisp/pull/75), [#81](https://github.com/didriksg/Crisp/pull/81), [#102](https://github.com/didriksg/Crisp/pull/102), [#116](https://github.com/didriksg/Crisp/pull/116))
 - [@dboleslawski](https://github.com/dboleslawski) ([#87](https://github.com/didriksg/Crisp/pull/87))
 - [@ncchen99](https://github.com/ncchen99) ([#101](https://github.com/didriksg/Crisp/pull/101), [#104](https://github.com/didriksg/Crisp/pull/104))
+- [@celsinho17](https://github.com/celsinho17) ([#97](https://github.com/didriksg/Crisp/pull/97))
 
 ## Translations
 

--- a/Crisp/Models/CrispControlModel.swift
+++ b/Crisp/Models/CrispControlModel.swift
@@ -27,6 +27,10 @@ struct CrispControlDisplay: Codable, Equatable {
     let uuid: String?
     let resolution: CrispControlResolution?
     let brightnessBackend: CrispControlBrightnessBackend?
+    /// False while Crisp holds the display disconnected. Such a display is absent
+    /// from every macOS display list, so its `id` is only the last-known value and
+    /// `uuid` is the selector that finds it again. Absent from replies of older Crisps.
+    let connected: Bool?
 
     init(
         id: UInt32,
@@ -36,7 +40,8 @@ struct CrispControlDisplay: Codable, Equatable {
         isBuiltin: Bool,
         uuid: String? = nil,
         resolution: CrispControlResolution? = nil,
-        brightnessBackend: CrispControlBrightnessBackend? = nil
+        brightnessBackend: CrispControlBrightnessBackend? = nil,
+        connected: Bool? = nil
     ) {
         self.id = id
         self.name = name
@@ -46,6 +51,7 @@ struct CrispControlDisplay: Codable, Equatable {
         self.uuid = uuid
         self.resolution = resolution
         self.brightnessBackend = brightnessBackend
+        self.connected = connected
     }
 }
 struct CrispControlBrightnessBoostState: Codable, Equatable {
@@ -66,6 +72,9 @@ struct CrispControlRequest: Codable, Equatable {
         case setBrightnessBoost
         case getHDR
         case setHDR
+        case connectDisplay
+        case disconnectDisplay
+        case toggleDisplay
     }
 
     let command: Command
@@ -150,22 +159,31 @@ struct CrispControlHDRChange: Equatable {
     let displayUUID: String
     let enabled: Bool
 }
+/// A resolved connect or disconnect. `toggleDisplay` is collapsed into a concrete
+/// direction by `handle`, so the server never has to re-read the current state.
+struct CrispControlConnectionChange: Equatable {
+    let uuid: String
+    let connect: Bool
+}
 struct CrispControlResult {
     let response: CrispControlResponse
     let brightnessChange: CrispControlBrightnessChange?
     let brightnessBoostChange: CrispControlBrightnessBoostChange?
     let hdrChange: CrispControlHDRChange?
+    let connectionChange: CrispControlConnectionChange?
 
     init(
         _ response: CrispControlResponse,
         _ brightnessChange: CrispControlBrightnessChange?,
         _ brightnessBoostChange: CrispControlBrightnessBoostChange?,
-        _ hdrChange: CrispControlHDRChange?
+        _ hdrChange: CrispControlHDRChange?,
+        _ connectionChange: CrispControlConnectionChange? = nil
     ) {
         self.response = response
         self.brightnessChange = brightnessChange
         self.brightnessBoostChange = brightnessBoostChange
         self.hdrChange = hdrChange
+        self.connectionChange = connectionChange
     }
 }
 enum CrispControlModel {
@@ -260,7 +278,44 @@ enum CrispControlModel {
                 request, displays: displays, hdrState: hdrState,
                 hdrMutationUUID: hdrMutationUUID
             )
+        case .connectDisplay, .disconnectDisplay, .toggleDisplay:
+            return handleConnection(request, displays: displays)
         }
+    }
+
+    /// Resolves a connection request against the online list plus the displays Crisp
+    /// is holding disconnected. Asking for the state a display is already in succeeds
+    /// and changes nothing, so a button wired to `connect` or `disconnect` is safe to
+    /// press twice.
+    private static func handleConnection(
+        _ request: CrispControlRequest, displays: [CrispControlDisplay]
+    ) -> CrispControlResult {
+        guard hasDisplaySelector(request) else {
+            return .init(.failure("display is required"), nil, nil, nil)
+        }
+        guard let display = target(of: request, in: displays) else {
+            return .init(.failure("display not found"), nil, nil, nil)
+        }
+        // A display with no stable uuid cannot be found again once it is gone, so
+        // refuse rather than hand back a handle that will not work.
+        guard let uuid = display.uuid, !uuid.isEmpty else {
+            return .init(.failure("display has no stable uuid, so it could not be reconnected"), nil, nil, nil)
+        }
+        let connected = display.connected ?? true
+        let connect: Bool
+        switch request.command {
+        case .connectDisplay: connect = true
+        case .disconnectDisplay: connect = false
+        default: connect = !connected
+        }
+        let settled = CrispControlDisplay(
+            id: display.id, name: display.name, brightness: display.brightness,
+            maxBrightness: display.maxBrightness, isBuiltin: display.isBuiltin, uuid: uuid,
+            resolution: display.resolution, brightnessBackend: display.brightnessBackend,
+            connected: connect
+        )
+        let change = connected == connect ? nil : CrispControlConnectionChange(uuid: uuid, connect: connect)
+        return .init(.success(display: settled), nil, nil, nil, change)
     }
 
     private static func handleHDR(
@@ -366,9 +421,9 @@ enum CrispControlCLIModel {
         same user; crispctl talks to it over a local socket and never launches it.
 
         Commands:
-          display list                           Online displays as JSON: id, uuid, name,
-                                                 resolution, brightness, maxBrightness,
-                                                 brightnessBackend
+          display list                           Displays as JSON: id, uuid, name, resolution,
+                                                 brightness, maxBrightness, brightnessBackend,
+                                                 connected (false while Crisp holds it off)
           brightness get <display>               Read logical brightness and its live maximum
           brightness set <display> <pct>         Set 0-100, or up to maxBrightness while Extra
                                                  Brightness is enabled and eligible; clears preset
@@ -376,10 +431,18 @@ enum CrispControlCLIModel {
           brightness boost set <display> on|off  Enable or disable Extra Brightness
           hdr get <display>                      Read live HDR state for an eligible external display
           hdr set <display> on|off               Set HDR on an eligible external and verify live state
+          display disconnect <display>           Take the display out of the layout, as the menu's
+                                                 Disconnect Display does; refused if it would leave
+                                                 no active display. Apple Silicon only
+          display connect <display>              Put a disconnected display back
+          display toggle <display>               Disconnect if connected, connect if not
           help                                   Show this help (also -h, --help)
 
         <display> is a runtime id or a uuid from 'display list'. Ids can change after
-        an unplug or a wake; uuids do not.
+        an unplug or a wake; uuids do not. A disconnected display is gone from every
+        macOS display list, so its id is only a last-known value: use the uuid for it.
+        Asking for the connection state a display is already in succeeds and changes
+        nothing. A connection reply comes after the window server has answered.
 
         Output is one JSON object per call: {"ok":true,...} or {"ok":false,"error":"..."}.
         Exit codes: 0 ok, 1 Crisp unreachable, 2 bad arguments, 3 Crisp refused.
@@ -434,7 +497,16 @@ enum CrispControlCLIModel {
             default: break
             }
         }
-        return .failure
+        return connectionRequest(arguments) ?? .failure
+    }
+    private static func connectionRequest(_ arguments: [String]) -> ParseResult? {
+        guard arguments.count == 3, arguments[0] == "display", !arguments[2].isEmpty else { return nil }
+        switch arguments[1] {
+        case "connect": return .request(.init(command: .connectDisplay, selector: arguments[2]))
+        case "disconnect": return .request(.init(command: .disconnectDisplay, selector: arguments[2]))
+        case "toggle": return .request(.init(command: .toggleDisplay, selector: arguments[2]))
+        default: return nil
+        }
     }
     static func classify(_ data: Data, for _: CrispControlRequest.Command) -> ResponseResult {
         guard let response = try? JSONDecoder().decode(CrispControlResponse.self, from: data) else {

--- a/Crisp/Models/CrispControlModel.swift
+++ b/Crisp/Models/CrispControlModel.swift
@@ -458,6 +458,9 @@ enum CrispControlCLIModel {
         switch command {
         case .setBrightnessBoost: return 5
         case .setHDR: return 6
+        // The window server answers inside the app's 10 s wrapper, but the DDC hold
+        // ahead of the transaction can wait 15 s and the mode restore after it 3 s.
+        case .connectDisplay, .disconnectDisplay, .toggleDisplay: return 30
         default: return 2
         }
     }

--- a/Crisp/Services/CrispControlServer.swift
+++ b/Crisp/Services/CrispControlServer.swift
@@ -101,12 +101,24 @@ final class CrispControlServer {
                 isBuiltin: display.isBuiltin,
                 uuid: display.displayUUID,
                 resolution: resolution,
-                brightnessBackend: BrightnessService.shared.brightnessBackend(for: display)
+                brightnessBackend: BrightnessService.shared.brightnessBackend(for: display),
+                connected: true
             )
         }
+        // Plus the displays Crisp is holding disconnected. They are gone from
+        // DisplayManager (CGGetOnlineDisplayList omits them), and without this half
+        // `connect` could never name its target.
+        let held = PhysicalDisplayToggleService.shared.disconnected
+            .filter { record in !managedDisplays.contains { $0.displayUUID == record.uuid } }
+            .map { record in
+                CrispControlDisplay(
+                    id: record.displayID, name: record.name, brightness: 0,
+                    isBuiltin: record.isBuiltin ?? false, uuid: record.uuid, connected: false
+                )
+            }
         let result = CrispControlModel.handle(
             request,
-            displays: displays,
+            displays: displays + held,
             hdrState: { id in
                 guard let display = managedDisplays.first(where: { $0.displayID == id }),
                       let enabled = boostService.hdrState(for: display, expectedUUID: display.displayUUID)
@@ -152,50 +164,78 @@ final class CrispControlServer {
             )
         }
         if let change = result.hdrChange {
-            guard let display = currentHDRTarget(for: change, using: boostService) else {
-                return CrispControlModel.encode(
-                    CrispControlModel.hdrSetResponse(
-                        displayID: change.displayID,
-                        enabled: change.enabled,
-                        accepted: false,
-                        liveEnabled: nil
-                    )
-                )
-            }
-            let accepted = await boostService.setHDRPreference(
-                change.enabled, for: display, expectedUUID: change.displayUUID
-            )
-            var liveEnabled = currentHDRTarget(for: change, using: boostService).flatMap {
-                boostService.hdrState(for: $0, expectedUUID: change.displayUUID)
-            }
-            if accepted {
-                for _ in 0..<20 {
-                    guard liveEnabled != change.enabled else { break }
-                    try? await Task.sleep(nanoseconds: 100_000_000)
-                    guard let current = currentHDRTarget(for: change, using: boostService) else {
-                        liveEnabled = nil
-                        break
-                    }
-                    liveEnabled = boostService.hdrState(
-                        for: current, expectedUUID: change.displayUUID
-                    )
-                }
-            }
-            if liveEnabled == change.enabled {
-                liveEnabled = currentHDRTarget(for: change, using: boostService).flatMap {
-                    boostService.hdrState(for: $0, expectedUUID: change.displayUUID)
-                }
-            }
+            return await hdrResponse(for: change, using: boostService)
+        }
+        if let change = result.connectionChange, let error = await apply(change, among: managedDisplays) {
+            return CrispControlModel.encode(.failure(error))
+        }
+        return CrispControlModel.encode(result.response)
+    }
+
+    private func hdrResponse(
+        for change: CrispControlHDRChange, using boostService: BrightnessBoostService
+    ) async -> Data {
+        guard let display = currentHDRTarget(for: change, using: boostService) else {
             return CrispControlModel.encode(
                 CrispControlModel.hdrSetResponse(
                     displayID: change.displayID,
                     enabled: change.enabled,
-                    accepted: accepted,
-                    liveEnabled: liveEnabled
+                    accepted: false,
+                    liveEnabled: nil
                 )
             )
         }
-        return CrispControlModel.encode(result.response)
+        let accepted = await boostService.setHDRPreference(
+            change.enabled, for: display, expectedUUID: change.displayUUID
+        )
+        var liveEnabled = currentHDRTarget(for: change, using: boostService).flatMap {
+            boostService.hdrState(for: $0, expectedUUID: change.displayUUID)
+        }
+        if accepted {
+            for _ in 0..<20 {
+                guard liveEnabled != change.enabled else { break }
+                try? await Task.sleep(nanoseconds: 100_000_000)
+                guard let current = currentHDRTarget(for: change, using: boostService) else {
+                    liveEnabled = nil
+                    break
+                }
+                liveEnabled = boostService.hdrState(
+                    for: current, expectedUUID: change.displayUUID
+                )
+            }
+        }
+        if liveEnabled == change.enabled {
+            liveEnabled = currentHDRTarget(for: change, using: boostService).flatMap {
+                boostService.hdrState(for: $0, expectedUUID: change.displayUUID)
+            }
+        }
+        return CrispControlModel.encode(
+            CrispControlModel.hdrSetResponse(
+                displayID: change.displayID,
+                enabled: change.enabled,
+                accepted: accepted,
+                liveEnabled: liveEnabled
+            )
+        )
+    }
+
+    /// Applies a resolved connection change and returns nil, or the reason it was
+    /// refused. Not fire-and-forget like brightness: a disconnect can be legitimately
+    /// refused (it would leave no active display) and a caller wiring this to a
+    /// button needs to hear that, so the reply carries Crisp's own reason.
+    private func apply(_ change: CrispControlConnectionChange, among managedDisplays: [DisplayInfo]) async -> String? {
+        let service = PhysicalDisplayToggleService.shared
+        let outcome: Result<Void, PhysicalDisplayToggleService.ToggleError>
+        if change.connect {
+            outcome = await service.reconnect(uuid: change.uuid)
+        } else if let display = managedDisplays.first(where: { $0.displayUUID == change.uuid }) {
+            outcome = await service.disconnect(display)
+        } else {
+            return "display not found"
+        }
+        displayManager.refreshDisplays()
+        if case let .failure(error) = outcome { return error.description }
+        return nil
     }
 
     private func currentHDRTarget(

--- a/Crisp/Services/CrispControlServer.swift
+++ b/Crisp/Services/CrispControlServer.swift
@@ -79,7 +79,33 @@ final class CrispControlServer {
         Self.write(data, to: client)
     }
 
+    /// Connection changes run one at a time. Each connection is served in its own
+    /// task and disconnect() checks the last-screen guard before it awaits the
+    /// transaction, so two disconnects fired together for the last two displays
+    /// both passed the guard and every screen went dark (measured on two sockets
+    /// on 2026-09-02: both reported success, 387 and 1155 ms). Brightness and HDR
+    /// stay concurrent, since a reconnect can hold the line for seconds.
+    private var connectionChain: Task<Void, Never>?
+
     private func response(to request: Data) async -> Data {
+        guard Self.changesConnection(request) else { return await reply(to: request) }
+        let previous = connectionChain
+        let task = Task { @MainActor in
+            await previous?.value
+            return await self.reply(to: request)
+        }
+        connectionChain = Task { _ = await task.value }
+        return await task.value
+    }
+
+    private nonisolated static func changesConnection(_ request: Data) -> Bool {
+        switch (try? JSONDecoder().decode(CrispControlRequest.self, from: request))?.command {
+        case .connectDisplay, .disconnectDisplay, .toggleDisplay: return true
+        default: return false
+        }
+    }
+
+    private func reply(to request: Data) async -> Data {
         let managedDisplays = displayManager.displays
         let boostService = BrightnessBoostService.shared
         let displays = managedDisplays.map { display in

--- a/CrispTests/CrispControlModelTests.swift
+++ b/CrispTests/CrispControlModelTests.swift
@@ -130,6 +130,9 @@ final class CrispControlModelTests: XCTestCase {
     func testOnlyBoundedTransitionCommandsGetLongerReceiveTimeouts() {
         XCTAssertEqual(CrispControlCLIModel.receiveTimeoutSeconds(for: .setBrightnessBoost), 5)
         XCTAssertEqual(CrispControlCLIModel.receiveTimeoutSeconds(for: .setHDR), 6)
+        for command in [CrispControlRequest.Command.connectDisplay, .disconnectDisplay, .toggleDisplay] {
+            XCTAssertEqual(CrispControlCLIModel.receiveTimeoutSeconds(for: command), 30)
+        }
         for command in [
             CrispControlRequest.Command.list, .getBrightness, .setBrightness, .getBrightnessBoost, .getHDR
         ] {

--- a/CrispTests/CrispControlModelTests.swift
+++ b/CrispTests/CrispControlModelTests.swift
@@ -18,8 +18,18 @@ final class CrispControlModelTests: XCTestCase {
         ),
         brightnessBackend: .ddc
     )
+    /// Crisp is holding this one out of the layout: absent from the online list,
+    /// so its id is only a last-known value and the uuid is the real handle.
+    private let held = CrispControlDisplay(
+        id: 9,
+        name: "M32UC",
+        brightness: 0,
+        isBuiltin: false,
+        uuid: "DECC7CEF-5E36-4E9B-8F18-CE11AE5902AD",
+        connected: false
+    )
 
-    func testParserSupportsSevenControlCommandsByIDAndUUID() {
+    func testParserSupportsEveryControlCommandByIDAndUUID() {
         let cases: [([String], CrispControlRequest)] = [
             (["display", "list"], .init(command: .list)),
             (["brightness", "get", "42"], .init(command: .getBrightness, selector: "42")),
@@ -57,7 +67,13 @@ final class CrispControlModelTests: XCTestCase {
             (
                 ["hdr", "set", "37D8832A-2D66-02CA-B9F7-8F30A301B230", "off"],
                 .init(command: .setHDR, selector: "37D8832A-2D66-02CA-B9F7-8F30A301B230", enabled: false)
-            )
+            ),
+            (["display", "connect", "42"], .init(command: .connectDisplay, selector: "42")),
+            (
+                ["display", "disconnect", "DECC7CEF-5E36-4E9B-8F18-CE11AE5902AD"],
+                .init(command: .disconnectDisplay, selector: "DECC7CEF-5E36-4E9B-8F18-CE11AE5902AD")
+            ),
+            (["display", "toggle", "42"], .init(command: .toggleDisplay, selector: "42"))
         ]
         for (arguments, request) in cases {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .request(request))
@@ -73,7 +89,8 @@ final class CrispControlModelTests: XCTestCase {
         for command in [
             "display list", "brightness get <display>", "brightness set <display>",
             "brightness boost get <display>", "brightness boost set <display>",
-            "hdr get <display>", "hdr set <display>", "help"
+            "hdr get <display>", "hdr set <display>",
+            "display connect <display>", "display disconnect <display>", "display toggle <display>", "help"
         ] {
             XCTAssertTrue(CrispControlCLIModel.help.contains(command), command)
         }
@@ -95,7 +112,9 @@ final class CrispControlModelTests: XCTestCase {
             ["hdr", "get"], ["hdr", "get", ""], ["hdr", "get", "42", "extra"],
             ["hdr", "set", "42"], ["hdr", "set", "", "on"],
             ["hdr", "set", "42", "true"], ["hdr", "set", "42", "ON"],
-            ["hdr", "set", "42", "on", "extra"]
+            ["hdr", "set", "42", "on", "extra"],
+            ["display", "toggle"], ["display", "toggle", ""], ["display", "reboot", "42"],
+            ["display", "toggle", "42", "now"]
         ]
         for arguments in cases {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .failure)
@@ -580,7 +599,88 @@ final class CrispControlModelTests: XCTestCase {
     }
 
     private var commands: [CrispControlRequest.Command] {
-        [.list, .getBrightness, .setBrightness, .getBrightnessBoost, .setBrightnessBoost, .getHDR, .setHDR]
+        [
+            .list, .getBrightness, .setBrightness, .getBrightnessBoost, .setBrightnessBoost, .getHDR, .setHDR,
+            .connectDisplay, .disconnectDisplay, .toggleDisplay
+        ]
+    }
+
+    func testConnectionCommandsResolveByIDAndByUUIDAndToggleCollapsesToADirection() {
+        let displays = [display, held]
+        // Toggling a connected display asks for a disconnect...
+        let byID = CrispControlModel.handle(
+            Data(#"{"command":"toggleDisplay","selector":"7"}"#.utf8), displays: displays
+        )
+        XCTAssertEqual(byID.connectionChange, .init(uuid: display.uuid!, connect: false))
+        // ...and toggling a held one asks for the opposite, found by uuid in any
+        // case, which is the only handle that survives the disconnect.
+        let byUUID = CrispControlModel.handle(
+            Data(#"{"command":"toggleDisplay","selector":"decc7cef-5e36-4e9b-8f18-ce11ae5902ad"}"#.utf8),
+            displays: displays
+        )
+        XCTAssertEqual(byUUID.connectionChange, .init(uuid: held.uuid!, connect: true))
+        XCTAssertNil(byID.brightnessChange)
+        XCTAssertNil(byID.hdrChange)
+        // The legacy numeric field still selects.
+        let legacy = CrispControlModel.handle(
+            Data(#"{"command":"disconnectDisplay","display":7}"#.utf8), displays: displays
+        )
+        XCTAssertEqual(legacy.connectionChange, .init(uuid: display.uuid!, connect: false))
+    }
+
+    func testAskingForTheConnectionStateADisplayIsAlreadyInSucceedsAndChangesNothing() {
+        // A button wired to connect or disconnect must be safe to press twice.
+        for (request, subject) in [
+            (#"{"command":"connectDisplay","selector":"7"}"#, display),
+            (#"{"command":"disconnectDisplay","selector":"9"}"#, held)
+        ] {
+            let result = CrispControlModel.handle(Data(request.utf8), displays: [display, held])
+            XCTAssertTrue(result.response.ok, request)
+            XCTAssertNil(result.connectionChange, request)
+            XCTAssertEqual(result.response.display?.uuid, subject.uuid, request)
+        }
+    }
+
+    func testConnectionResponseReportsTheSettledState() throws {
+        let result = CrispControlModel.handle(
+            Data(#"{"command":"disconnectDisplay","selector":"7"}"#.utf8), displays: [display, held]
+        )
+        XCTAssertEqual(result.response.display?.connected, false)
+        XCTAssertEqual(result.response.display?.id, display.id)
+        XCTAssertEqual(result.response.display?.resolution, display.resolution)
+        XCTAssertEqual(result.connectionChange, .init(uuid: display.uuid!, connect: false))
+        let encoded = try XCTUnwrap(String(data: CrispControlModel.encode(result.response, sorted: true), encoding: .utf8))
+        XCTAssertTrue(encoded.contains(#""connected":false"#), encoded)
+    }
+
+    func testConnectionCommandsRejectMissingUnknownAndUnidentifiableDisplays() {
+        let anonymous = CrispControlDisplay(id: 3, name: "No UUID", brightness: 10, isBuiltin: false)
+        let cases: [(String, [CrispControlDisplay])] = [
+            (#"{"command":"toggleDisplay"}"#, [display]),
+            (#"{"command":"toggleDisplay","selector":""}"#, [display]),
+            (#"{"command":"toggleDisplay","selector":"404"}"#, [display]),
+            (#"{"command":"connectDisplay","selector":"nope"}"#, [display]),
+            // A display with no stable uuid cannot be found again once it is gone,
+            // so refuse rather than hand back a handle that will not work.
+            (#"{"command":"disconnectDisplay","selector":"3"}"#, [anonymous])
+        ]
+        for (request, displays) in cases {
+            let result = CrispControlModel.handle(Data(request.utf8), displays: displays)
+            XCTAssertFalse(result.response.ok, request)
+            XCTAssertNil(result.connectionChange, request)
+        }
+    }
+
+    func testDisplayRecordWithoutConnectedStillDecodesAsConnected() throws {
+        // A reply from a Crisp older than the connection commands carries no
+        // `connected`; it must decode, and the model must read it as online.
+        let legacy = #"{"id":7,"name":"Studio Display","brightness":64,"isBuiltin":false,"uuid":"A"}"#
+        let decoded = try JSONDecoder().decode(CrispControlDisplay.self, from: Data(legacy.utf8))
+        XCTAssertNil(decoded.connected)
+        let result = CrispControlModel.handle(
+            Data(#"{"command":"toggleDisplay","selector":"a"}"#.utf8), displays: [decoded]
+        )
+        XCTAssertEqual(result.connectionChange, .init(uuid: "A", connect: false))
     }
 
     private func classify(

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Source builds include a minimal `crispctl` target:
 xcodegen generate && xcodebuild -scheme crispctl -configuration Release
 ```
 
-It supports seven control commands:
+It supports ten control commands:
 
 ```sh
 crispctl display list
@@ -106,6 +106,9 @@ crispctl brightness boost get <display>
 crispctl brightness boost set <display> on|off
 crispctl hdr get <display>
 crispctl hdr set <display> on|off
+crispctl display disconnect <display>
+crispctl display connect <display>
+crispctl display toggle <display>
 crispctl help
 ```
 
@@ -116,6 +119,8 @@ crispctl help
 Crisp must already be running; crispctl never launches it. `brightness set` accepts 0...100 normally. Values above 100 require Extra Brightness to be enabled and currently eligible for that display, and must not exceed its live `maxBrightness`; invalid boosted values are refused rather than clamped. A set is a manual change like using the slider and clears the active preset. The reply means Crisp accepted the request, not that the panel was read back; it is not retried automatically.
 
 For example, `brightness boost get` returns `{"ok":true,"brightnessBoost":{"displayID":7,"eligible":true,"enabled":false}}`. `eligible` is the running Extra Brightness service's current eligibility result; `enabled` is its persisted per-display toggle state, so the two can differ while capability has collapsed and cleanup or auto-disable is pending. `brightness boost set` uses that existing service: `on` is refused when currently ineligible or when enabling fails, while `off` remains available for a connected display regardless of current eligibility. Enabling an external display may wait while the service settles HDR mode. Success means the service returned `true`, not that hardware, EDR headroom, or luminance was independently verified. A transport timeout does not prove the change was not applied; do not retry automatically—run `brightness boost get` first.
+
+`display disconnect`, `connect` and `toggle` are the menu's Disconnect Display and Reconnect from a script, for a KVM desk or a button: Apple Silicon only, and a disconnect is refused when it would leave no active display. A display Crisp is holding disconnected is absent from every macOS display list, so `display list` still shows it with `connected:false` and its last-known id; use the uuid for it. Asking for the state a display is already in succeeds and changes nothing, and the reply comes after the window server has answered, which can take a few seconds.
 
 `hdr get` and `hdr set` work on the external displays Crisp shows its HDR toggle for; the built-in panel and externals without HDR modes are refused. `get` reads the live state. `set` writes once through the same path as the toggle and reports success only when the read-back agrees; when it cannot tell (a timeout, or the display going away mid-way) it says so and does not retry, so run `hdr get` before retrying. Exit codes are unchanged.
 


### PR DESCRIPTION
This is #97 by @celsinho17, ported onto main with his author line on the commit, plus the two fixes the review asked for as a second commit and his credit line. #97 has been waiting on a rebase since 2026-09-02 and it conflicts with everything crispctl gained since, so I took it over.

What it adds: `display disconnect`, `display connect` and `display toggle`, taking a runtime id or a uuid. `display list` now includes the displays Crisp is holding disconnected, marked `connected:false` with their last-known id, so a script can name a target that is absent from every macOS display list. Asking for the state a display is already in succeeds and changes nothing, and the replies carry Crisp's own reason when the window server refuses.

The port: `uuid` and `connected` are optional fields like the rest of the record, so an older crispctl decodes a newer reply and the other way round without a hand-written decoder; the selector goes through the shared resolver from #107; and the HDR reply moved into its own method to stay under the lint limit.

The fixes: connection changes run one at a time in the server, because each connection is served in its own task and the last-screen guard runs before the transaction is awaited, so two disconnects fired together for the last two displays both passed it and every screen went dark (measured on 2026-09-02). And crispctl waits 30 s for these three replies instead of 2, since the DDC hold ahead of the transaction can wait 15 s and the mode restore after it 3 s.

Driven live on the desk here, off the socket and through the binary:

- disconnect, connect and toggle on the Dell by id and by uuid in both cases, disables 86 ms to 4 s (the long ones waiting for DDC to go idle), enables 570 to 850 ms
- a repeated disconnect is a no-op with ok:true, unknown selectors exit 3, bad arguments exit 2
- the race: with the Dell held off, disconnects for the built-in and the AOC on two sockets at the same instant; the first landed in 551 ms and the second came back refused 562 ms later with "it would leave no active display", nothing went dark
- one enable hit the 10 s wrapper timeout when the connect went out 660 ms after a disconnect whose mode restore was still landing; the reply said so, the record was kept, and the next toggle brought the display back in 786 ms. Four more cycles with 0.7 s and 5 s gaps on both externals did not reproduce it

Closes #97.