### PR TITLE
Re-read the count before the blackout rescue commits

### DIFF
--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -846,6 +846,15 @@ final class PhysicalDisplayToggleService: ObservableObject {
         }
     }
 
+    /// How many times the settle check re-reads the count before committing to a restore,
+    /// and how long it waits between reads. The count is per-process and refreshed by
+    /// reconfiguration callback delivery, so the read taken the instant the timer expires
+    /// can trail the truth (issue #117). Ten reads at 100 ms covers the margins measured
+    /// there without becoming a standing watch -- see the comment in the settle Task for
+    /// why the bound matters.
+    private static let settleRepolls = 10
+    private static let settleRepollInterval: UInt64 = 100_000_000
+
     /// Guards against overlapping restore attempts from reconfiguration-callback bursts.
     private var restoreInFlight = false
 
@@ -871,9 +880,35 @@ final class PhysicalDisplayToggleService: ObservableObject {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
             guard let self else { return }
             defer { self.restoreInFlight = false }
-            let settled = self.physicalActiveDisplayCount()
+            // One sample here is not enough. The count comes from this process's own copy
+            // of the display configuration, and that copy is only as fresh as the last
+            // reconfiguration callback delivered to it: on #117 the external was back in
+            // the active list for 284 ms, visible to any other process, while this read
+            // still returned 0 and the callback that would have said so arrived 37 ms
+            // after the decision. Measured three times on two builds, the margins were
+            // 37 ms, 37 ms and 158 ms, so a few hundred milliseconds of re-reading covers
+            // it where a longer sleep does not -- a single sample is stale whenever it
+            // lands, and Task.sleep above already overruns by 418-1254 ms on a wake.
+            //
+            // Bounded to settleRepolls deliberately, rather than made a watch. The
+            // margins being answered are 37-158 ms, so ten reads already carry an order
+            // of magnitude of headroom, and what the count does during a display sleep is
+            // not something to lean on: measured on this desk it stayed at 1 through a
+            // 35 s sleep with Crisp running, and read 0 for 2 min 57 s on the same desk
+            // with Crisp quit. A poll outliving the settle window could therefore sit on
+            // a zero-count desk that is only asleep. What keeps this guard clear of that
+            // state is that it runs from reconfiguration callbacks, and none arrive while
+            // the displays are down.
+            var settled = self.physicalActiveDisplayCount()
+            var repolls = 0
+            while settled == 0, repolls < Self.settleRepolls {
+                try? await Task.sleep(nanoseconds: Self.settleRepollInterval)
+                guard !Task.isCancelled else { return }
+                settled = self.physicalActiveDisplayCount()
+                repolls += 1
+            }
             guard settled == 0 else {
-                Self.log.notice("restore settled: \(settled, privacy: .public) active display(s) after 2 s, standing down")
+                Self.log.notice("restore settled: \(settled, privacy: .public) active display(s) after 2 s and \(repolls, privacy: .public) re-poll(s), standing down")
                 return
             }
             // This path acts with every screen black, so without a line here a capture

--- a/scripts/settle-probe.swift
+++ b/scripts/settle-probe.swift
@@ -1,0 +1,121 @@
+// Settle-window probe: does the display come back before or after
+// restoreIfNoActiveDisplay's 2 s settle check, and by how much.
+//
+// Run: swift scripts/settle-probe.swift     (Ctrl-C to stop)
+//
+// phantom-probe.swift samples every 200 ms, which is the right resolution for a
+// phantom that lives for 12-104 s. It cannot resolve this one: the margin between
+// the display returning and the settle check firing is tens of milliseconds. This
+// samples every 20 ms and reports the zero-window directly.
+//
+// ACTIVE is physicalActiveDisplayCount's own arithmetic: CGGetActiveDisplayList
+// filtered by the 16-bit EDID shape check from #106. (The VirtualDisplayService
+// exclusion is not reproducible outside the app; with no Crisp virtual display on
+// the desk the two agree.) ONLINE is phantom-probe's form -- CGGetOnlineDisplayList
+// filtered by CGDisplayIsActive -- kept so the two can be cross-checked the way
+// they were on #112.
+//
+// On every 1+ -> 0 transition the probe opens a window and on the way back out
+// prints how long the desk was actually empty. The nominal 2.000 s in the verdict is
+// the optimistic end: Crisp's check is Task.sleep(2s) plus scheduling, which on a
+// wake was measured landing 418-1254 ms late, so a window "over" 2.000 s can still
+// stand down. Read it with the app's own `restore settled` / `no active display`
+// line, which is what the check actually decided.
+//
+// It prints on any change to the per-display detail too, not just the counts. A
+// display can enter CGGetActiveDisplayList before its EDID is populated, and #106's
+// shape filter reads vendor/model 0 as "no panel" -- so that window leaves the count
+// at 0 and is invisible to a counts-only probe. Lines showing a real display id
+// marked `nopanel` are that state.
+import CoreGraphics
+import Foundation
+
+let fmt = DateFormatter()
+fmt.dateFormat = "HH:mm:ss.SSS"
+
+/// physicalActiveDisplayCount's arithmetic, minus the VirtualDisplayService
+/// exclusion, which cannot be reached from outside the app.
+func activeCount() -> (n: Int, detail: String) {
+    var count: UInt32 = 0
+    guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return (0, "") }
+    var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
+    guard CGGetActiveDisplayList(count, &ids, &count) == .success else { return (0, "") }
+    var n = 0
+    var parts: [String] = []
+    for id in ids.prefix(Int(count)) {
+        let vendor = CGDisplayVendorNumber(id), model = CGDisplayModelNumber(id)
+        let hasNoPanel = vendor == 0 || model == 0 || vendor > 0xFFFF || model > 0xFFFF
+        if !hasNoPanel { n += 1 }
+        parts.append("\(id)[\(String(vendor, radix: 16))/\(String(model, radix: 16))\(hasNoPanel ? " nopanel" : "")]")
+    }
+    return (n, parts.joined(separator: " "))
+}
+
+/// phantom-probe's COUNTED, for the cross-check.
+func onlineCount() -> Int {
+    var ids = [CGDirectDisplayID](repeating: 0, count: 16)
+    var n: UInt32 = 0
+    CGGetOnlineDisplayList(16, &ids, &n)
+    var counted = 0
+    for id in ids.prefix(Int(n)) where CGDisplayIsActive(id) == 1 {
+        let v = CGDisplayVendorNumber(id), m = CGDisplayModelNumber(id)
+        if v != 0 && m != 0 && v <= 0xFFFF && m <= 0xFFFF { counted += 1 }
+    }
+    return counted
+}
+
+let settleWindow: TimeInterval = 2.0
+let sample: TimeInterval = 0.02
+let heartbeat: TimeInterval = 2.0
+
+var lastActive = -1
+var lastOnline = -1
+var lastDetail = ""
+var darkSince: Date?
+var lastBeat = Date.distantPast
+
+setvbuf(stdout, nil, _IOLBF, 0)
+print("settle-probe: sampling every \(Int(sample * 1000)) ms, settle window \(settleWindow) s")
+print("ACTIVE = physicalActiveDisplayCount (CGGetActiveDisplayList + #106 shape filter)")
+print("ONLINE = phantom-probe COUNTED (CGGetOnlineDisplayList + CGDisplayIsActive)")
+
+while true {
+    let now = Date()
+    let (a, detail) = activeCount()
+    let o = onlineCount()
+
+    // Print on any change to the per-display detail, not just the counts. A display
+    // that has entered the active list but whose EDID is not populated yet reads as
+    // "nopanel" to #106's shape filter and leaves ACTIVE unchanged at 0, so keying
+    // the print on the counts alone hides exactly the window this probe is for.
+    if a != lastActive || o != lastOnline || detail != lastDetail {
+        print("\(fmt.string(from: now))  * ACTIVE=\(a) ONLINE=\(o) | \(detail)")
+        if a == 0, lastActive > 0 {
+            darkSince = now
+            let deadline = now.addingTimeInterval(settleWindow)
+            print("\(fmt.string(from: now))    -> desk empty; a settle check started now would fire at \(fmt.string(from: deadline))")
+        }
+        if a > 0, let since = darkSince {
+            let dark = now.timeIntervalSince(since)
+            let margin = settleWindow - dark
+            // Crisp's check is Task.sleep(2s) + scheduling, and on a wake that
+            // overran by 418-1254 ms in run 5, so a nominal 2.000 s deadline is the
+            // optimistic end of the range, not the real one. Report against both.
+            let verdict = margin >= 0
+                ? String(format: "under the nominal 2.000 s by %.0f ms", margin * 1000)
+                : String(format: "OVER the nominal 2.000 s by %.0f ms (still safe if the check overran by more)", -margin * 1000)
+            print(String(format: "\(fmt.string(from: now))    -> back after %.3f s -- \(verdict)", dark))
+            darkSince = nil
+        }
+        lastActive = a
+        lastOnline = o
+        lastDetail = detail
+        lastBeat = now
+    } else if now.timeIntervalSince(lastBeat) >= heartbeat {
+        // A gap in the dots means the sampler was frozen (deep sleep), not that
+        // nothing happened -- the lesson from run 1 on #92.
+        print("\(fmt.string(from: now))  . ACTIVE=\(a) ONLINE=\(o)")
+        lastBeat = now
+    }
+    Thread.sleep(forTimeInterval: sample)
+}


### PR DESCRIPTION
Closes #117.

`restoreIfNoActiveDisplay` waits 2 s and then decides on **one** read of
`physicalActiveDisplayCount`. Re-read up to ten times at 100 ms instead, and stand down on
the first non-zero.

## Why one sample is not enough

The count comes from this process's own copy of the display configuration, and that copy is
only as fresh as the last reconfiguration callback delivered to it. On #117 the external
was back in the active list for **284 ms**, visible to a separate process polling the same
call, while this read still returned 0; the callback that would have said so arrived 37 ms
after the decision. Three firings across two builds lost by 37 ms, 37 ms and 158 ms.

A longer settle does not fix it. `Task.sleep(2s)` on a wake already overruns by 418-1254 ms
— two measured cycles had empty-desk windows *longer* than 2 s and stood down correctly
because the display returned inside the overrun. One sample is stale whenever it lands.

## The bound is the point

Ten reads, not a watch. During a display sleep `CGGetActiveDisplayList` reports zero
displays for as long as the screens are down — 2 min 57 s of it measured on #112 — with
nothing wrong and nothing to rescue. The only thing keeping this guard out of that state is
that it runs from reconfiguration callbacks, and none arrive while the displays are asleep.
An unbounded poll here would walk straight into it. (I have that mistake in a branch of my
own: a 1 Hz blackout watch, caught rescuing 13 s into a display sleep with `enable 1` then
failing at exactly 10000 ms.)

## Measured, on this branch

Eight display-sleep/wake cycles, clean main plus this commit, scratch bundle, the settle
task armed in all eight:

```
13:07:28.444  restore settled: 1 active display(s) after 2 s and 0 re-poll(s), standing down
13:08:04.745  restore settled: 1 active display(s) after 2 s and 2 re-poll(s), standing down
13:08:40.932  restore settled: 1 active display(s) after 2 s and 2 re-poll(s), standing down
13:09:17.186  restore settled: 1 active display(s) after 2 s and 2 re-poll(s), standing down
13:09:53.380  restore settled: 1 active display(s) after 2 s and 1 re-poll(s), standing down
13:10:29.644  restore settled: 1 active display(s) after 2 s and 2 re-poll(s), standing down
13:11:05.899  restore settled: 1 active display(s) after 2 s and 2 re-poll(s), standing down
13:11:42.150  restore settled: 1 active display(s) after 2 s and 2 re-poll(s), standing down
```

**Seven of the eight needed a re-poll**, i.e. the first read after the 2 s sleep still said
zero and one or two further reads 100 ms apart found the display. Those seven are exactly
the decision the old code would have made on the stale sample, and it would have restored.
One or two re-polls is 100-200 ms; the ten-read bound leaves nine tenths of a second of
headroom over the worst margin measured.

The one cost is on the path the rescue exists for: a genuinely dark desk now pays up to
1 s more before the built-in comes back, on top of the 2 s that was already there.

## Also in here

`scripts/settle-probe.swift`, next to `phantom-probe.swift`. It samples the same arithmetic
every 20 ms from outside the app and prints how long the desk was actually empty and which
side of the deadline the return landed on. `phantom-probe.swift`'s 200 ms is right for a
phantom that lives 12-104 s and cannot resolve a 37 ms margin.

`make check` green. Not driven: the genuinely-dark path — nothing here was unplugged, and
#112 is the run that exercises it.
