### PR TITLE
Cap the active display count at what the ports can be carrying

### DIFF
--- a/ACKNOWLEDGMENTS.md
+++ b/ACKNOWLEDGMENTS.md
@@ -39,7 +39,7 @@ SOFTWARE.
 - [@crayonlu](https://github.com/crayonlu) ([#53](https://github.com/didriksg/Crisp/pull/53))
 - [@Juns-g](https://github.com/Juns-g) ([#75](https://github.com/didriksg/Crisp/pull/75), [#81](https://github.com/didriksg/Crisp/pull/81), [#102](https://github.com/didriksg/Crisp/pull/102), [#116](https://github.com/didriksg/Crisp/pull/116))
 - [@dboleslawski](https://github.com/dboleslawski) ([#87](https://github.com/didriksg/Crisp/pull/87))
-- [@ncchen99](https://github.com/ncchen99) ([#101](https://github.com/didriksg/Crisp/pull/101), [#104](https://github.com/didriksg/Crisp/pull/104))
+- [@ncchen99](https://github.com/ncchen99) ([#101](https://github.com/didriksg/Crisp/pull/101), [#104](https://github.com/didriksg/Crisp/pull/104), [#132](https://github.com/didriksg/Crisp/pull/132), [#133](https://github.com/didriksg/Crisp/pull/133))
 - [@celsinho17](https://github.com/celsinho17) ([#97](https://github.com/didriksg/Crisp/pull/97))
 - [@alexlee2046](https://github.com/alexlee2046) ([#83](https://github.com/didriksg/Crisp/pull/83))
 - [@DEOWL-kan](https://github.com/DEOWL-kan) ([#71](https://github.com/didriksg/Crisp/pull/71))

--- a/Crisp/Models/PhantomPortCap.swift
+++ b/Crisp/Models/PhantomPortCap.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// How many active displays have something behind them, given what the ports say.
+///
+/// `physicalActiveDisplayCount`'s shape filter rejects an entry with no panel behind it,
+/// but it cannot reject the third kind, from #112: after an undock while asleep,
+/// WindowServer re-enumerates the absent externals at the full wake with their EDID
+/// identities intact, so they are active, 16-bit and completely real-looking, and stay
+/// that way until the dock goes back in. What actually left with the cable is the port's
+/// transport node, so the count of externals is capped at the number of ports that can be
+/// carrying one.
+enum PhantomPortCap {
+    /// - Parameters:
+    ///   - builtin: active displays that are the built-in panel. Never capped: the panel
+    ///     is not on a port, so what the ports say has nothing to do with it.
+    ///   - external: active displays that arrived through a port.
+    ///   - portCap: ports with a DisplayPort or Thunderbolt transport node and hot-plug
+    ///     detect asserted, or nil when the machine exposes no transport nodes at all.
+    ///     nil is "the signal is not available here", not "nothing is plugged in":
+    ///     capping on it would black out a desk this rule has never seen. A machine that
+    ///     does expose the nodes and reports none asserted is the #112 state, and 0 is
+    ///     the right answer there.
+    ///
+    /// The cap is an upper bound. It never adds a display, so a dock with a spare socket
+    /// reads the same as one without.
+    static func activeCount(builtin: Int, external: Int, portCap: Int?) -> Int {
+        guard let portCap else { return builtin + external }
+        return builtin + min(external, portCap)
+    }
+}

--- a/Crisp/Models/PhantomPortCap.swift
+++ b/Crisp/Models/PhantomPortCap.swift
@@ -11,9 +11,13 @@ import Foundation
 /// carrying one.
 enum PhantomPortCap {
     /// - Parameters:
-    ///   - builtin: active displays that are the built-in panel. Never capped: the panel
-    ///     is not on a port, so what the ports say has nothing to do with it.
-    ///   - external: active displays that arrived through a port.
+    ///   - offPort: active displays that no port carries: the built-in panel, and a
+    ///     display WindowServer draws for a virtual device (a DisplayLink dock's USB
+    ///     framebuffer, marked kCGDisplayIsVirtualDevice). Never capped: what the ports
+    ///     say has nothing to do with them. Measured on a DisplayLink dock with the lid
+    ///     closed: the machine exposes a transport node for its own HDMI port only, so
+    ///     capping that display read 0 with the screen lit.
+    ///   - onPort: active displays that arrived through a port.
     ///   - portCap: ports with a DisplayPort or Thunderbolt transport node and hot-plug
     ///     detect asserted, or nil when the machine exposes no transport nodes at all.
     ///     nil is "the signal is not available here", not "nothing is plugged in":
@@ -23,8 +27,8 @@ enum PhantomPortCap {
     ///
     /// The cap is an upper bound. It never adds a display, so a dock with a spare socket
     /// reads the same as one without.
-    static func activeCount(builtin: Int, external: Int, portCap: Int?) -> Int {
-        guard let portCap else { return builtin + external }
-        return builtin + min(external, portCap)
+    static func activeCount(offPort: Int, onPort: Int, portCap: Int?) -> Int {
+        guard let portCap else { return offPort + onPort }
+        return offPort + min(onPort, portCap)
     }
 }

--- a/Crisp/Models/PhantomPortCap.swift
+++ b/Crisp/Models/PhantomPortCap.swift
@@ -11,12 +11,12 @@ import Foundation
 /// carrying one.
 enum PhantomPortCap {
     /// - Parameters:
-    ///   - offPort: active displays that no port carries: the built-in panel, and a
-    ///     display WindowServer draws for a virtual device (a DisplayLink dock's USB
-    ///     framebuffer, marked kCGDisplayIsVirtualDevice). Never capped: what the ports
-    ///     say has nothing to do with them. Measured on a DisplayLink dock with the lid
-    ///     closed: the machine exposes a transport node for its own HDMI port only, so
-    ///     capping that display read 0 with the screen lit.
+    ///   - offPort: active displays that no port carries: the built-in panel, and an
+    ///     external that still carries its product name while no port carries it (a
+    ///     DisplayLink dock's USB framebuffer). Never capped: what the ports say has
+    ///     nothing to do with them. Measured on a DisplayLink dock with the lid closed:
+    ///     the machine exposes a transport node for its own HDMI port only, so capping
+    ///     that display read 0 with the screen lit.
     ///   - onPort: active displays that arrived through a port.
     ///   - portCap: ports with a DisplayPort or Thunderbolt transport node and hot-plug
     ///     detect asserted, or nil when the machine exposes no transport nodes at all.

--- a/Crisp/Services/DisplayLuminanceService.swift
+++ b/Crisp/Services/DisplayLuminanceService.swift
@@ -3,7 +3,9 @@ import CoreGraphics
 import IOKit
 import os
 
-private let _CoreDisplayCreateInfoDictionary: (@convention(c) (CGDirectDisplayID) -> Unmanaged<CFDictionary>?)? = {
+/// CoreDisplay's per-display info dictionary. Shared with PhysicalDisplayToggleService,
+/// which reads kCGDisplayIsVirtualDevice from it.
+let _CoreDisplayCreateInfoDictionary: (@convention(c) (CGDirectDisplayID) -> Unmanaged<CFDictionary>?)? = {
     guard let handle = dlopen("/System/Library/Frameworks/CoreDisplay.framework/CoreDisplay", RTLD_LAZY),
           let symbol = dlsym(handle, "CoreDisplay_DisplayCreateInfoDictionary") else { return nil }
     return unsafeBitCast(

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -168,7 +168,7 @@ final class PhysicalDisplayToggleService: ObservableObject {
         var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
         guard CGGetActiveDisplayList(count, &ids, &count) == .success else { return 0 }
         let virtual = VirtualDisplayService.shared
-        return ids.prefix(Int(count)).filter { id in
+        let viewable = ids.prefix(Int(count)).filter { id in
             guard !virtual.isVirtualDisplay(id) else { return false }
             // Real panels carry 16-bit EDID vendor and product codes. Two kinds of
             // entry enumerate as active without a screen behind them, and both fail
@@ -184,7 +184,47 @@ final class PhysicalDisplayToggleService: ObservableObject {
             let vendor = CGDisplayVendorNumber(id), model = CGDisplayModelNumber(id)
             let hasNoPanel = vendor == 0 || model == 0 || vendor > 0xFFFF || model > 0xFFFF
             return !hasNoPanel
-        }.count
+        }
+        // The shape filter above catches an entry with nothing behind it. It cannot catch
+        // the third kind, from #112: after an undock while asleep, WindowServer
+        // re-enumerates the absent externals at the full wake with their EDID identities
+        // intact, so they are active, 16-bit and completely real-looking, and they stay
+        // that way until the dock goes back in -- measured at 104 s with the desk dark the
+        // whole time and the rescue standing down on a count of 2.
+        //
+        // What actually left with the cable is the port's transport node, so ask the ports
+        // instead and cap the external count at what they can be carrying. Presence alone
+        // is not enough: an empty HDMI port keeps its node, reading hpd Unknown and sink 0
+        // in every sample of a whole run, and a phantom could hide behind it. Hot-plug
+        // detect is the part that tracks the cable.
+        let externals = viewable.filter { CGDisplayIsBuiltin($0) != 1 }.count
+        let builtin = viewable.count - externals
+        return PhantomPortCap.activeCount(builtin: builtin, external: externals, portCap: liveDisplayPortCount())
+    }
+
+    /// The number of ports that can have a display behind them right now: a DisplayPort or
+    /// Thunderbolt transport node with hot-plug detect asserted.
+    ///
+    /// nil rather than 0 when the machine exposes no transport nodes of either class at
+    /// all, which means the signal is not available here rather than that nothing is
+    /// plugged in -- capping on that would black out a desk this rule has never seen.
+    /// A Mac that does expose them and reports none asserted is the #112 state, and 0 is
+    /// the right answer there.
+    private func liveDisplayPortCount() -> Int? {
+        var nodes = 0, asserted = 0
+        for cls in ["IOPortTransportStateDisplayPort", "IOPortTransportStateCIO"] {
+            var it: io_iterator_t = 0
+            guard IOServiceGetMatchingServices(kIOMainPortDefault, IOServiceMatching(cls), &it) == KERN_SUCCESS else { continue }
+            defer { IOObjectRelease(it) }
+            while case let node = IOIteratorNext(it), node != 0 {
+                defer { IOObjectRelease(node) }
+                nodes += 1
+                let hpd = IORegistryEntryCreateCFProperty(node, "HPD_StateDescription" as CFString, kCFAllocatorDefault, 0)?
+                    .takeRetainedValue() as? String
+                if hpd == "High" { asserted += 1 }
+            }
+        }
+        return nodes == 0 ? nil : asserted
     }
 
     private func uuid(for displayID: CGDirectDisplayID) -> String {

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -203,7 +203,15 @@ final class PhysicalDisplayToggleService: ObservableObject {
     }
 
     /// The number of ports that can have a display behind them right now: a DisplayPort or
-    /// Thunderbolt transport node with hot-plug detect asserted.
+    /// Thunderbolt transport node with hot-plug detect asserted, or a sink counted on it.
+    ///
+    /// Either signal is enough, because each one drops out on its own for a few hundred
+    /// milliseconds around a transition while the other holds. Measured on one desk: a live
+    /// display's port read `hpd=Low sink=1` right after an enable, and `hpd=High sink=0`
+    /// during a wake. Requiring hpd alone capped a real display away in both. Neither
+    /// signal is present on a port with nothing behind it -- an empty built-in HDMI port
+    /// reads `hpd=Unknown sink=0`, an emptied dock port `hpd=Low sink=0` -- and in the
+    /// phantom state the whole node is gone, so the pair still reads zero there.
     ///
     /// nil rather than 0 when the machine exposes no transport nodes of either class at
     /// all, which means the signal is not available here rather than that nothing is
@@ -221,7 +229,9 @@ final class PhysicalDisplayToggleService: ObservableObject {
                 nodes += 1
                 let hpd = IORegistryEntryCreateCFProperty(node, "HPD_StateDescription" as CFString, kCFAllocatorDefault, 0)?
                     .takeRetainedValue() as? String
-                if hpd == "High" { asserted += 1 }
+                let sinks = IORegistryEntryCreateCFProperty(node, "SinkCount" as CFString, kCFAllocatorDefault, 0)?
+                    .takeRetainedValue() as? Int ?? 0
+                if hpd == "High" || sinks > 0 { asserted += 1 }
             }
         }
         return nodes == 0 ? nil : asserted

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -197,9 +197,38 @@ final class PhysicalDisplayToggleService: ObservableObject {
         // is not enough: an empty HDMI port keeps its node, reading hpd Unknown and sink 0
         // in every sample of a whole run, and a phantom could hide behind it. Hot-plug
         // detect is the part that tracks the cable.
-        let externals = viewable.filter { CGDisplayIsBuiltin($0) != 1 }.count
-        let builtin = viewable.count - externals
-        return PhantomPortCap.activeCount(builtin: builtin, external: externals, portCap: liveDisplayPortCount())
+        //
+        // Only a display that came through a port is capped. The built-in is not on one,
+        // and neither is a display WindowServer draws for a virtual device: a DisplayLink
+        // dock's USB framebuffer, which CoreDisplay marks kCGDisplayIsVirtualDevice.
+        // Measured on such a dock with the lid closed: the machine exposes a transport
+        // node for its own HDMI port only (hpd Low, sink 0), so capping that display
+        // read 0 with the screen lit, which would hide every Disconnect row with the lid
+        // open, refuse a remembered built-in disconnect at launch, and fire this rescue
+        // on every callback.
+        //
+        // The info dictionary costs 2.5 to 8 ms per display, and this count runs from a
+        // view body for every card, so it is only read once the ports say fewer than the
+        // externals lit, which is the phantom state or a virtual-device desk. An ordinary
+        // desk never pays for it.
+        let externals = viewable.filter { CGDisplayIsBuiltin($0) != 1 }
+        let portCap = liveDisplayPortCount()
+        var onPort = externals.count
+        if let portCap, portCap < externals.count {
+            onPort = externals.filter { !Self.isVirtualDevice($0) }.count
+        }
+        return PhantomPortCap.activeCount(offPort: viewable.count - onPort, onPort: onPort, portCap: portCap)
+    }
+
+    /// A display WindowServer draws for a virtual device rather than for a panel on a
+    /// port (DisplayLink and similar USB framebuffers), from CoreDisplay's info
+    /// dictionary. False when the dictionary cannot be read, which leaves the display
+    /// subject to the cap, the behaviour the rule had before this exemption.
+    private static func isVirtualDevice(_ id: CGDirectDisplayID) -> Bool {
+        guard let info = _CoreDisplayCreateInfoDictionary?(id)?.takeRetainedValue() as? [String: Any] else {
+            return false
+        }
+        return (info["kCGDisplayIsVirtualDevice"] as? NSNumber)?.boolValue ?? false
     }
 
     /// The number of ports that can have a display behind them right now: a DisplayPort or
@@ -914,6 +943,14 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// Re-enable a still-attached disconnected display (built-in first) so the machine always
     /// has a live screen. The settle delay rides out transient empty display lists during
     /// wake/replug storms, so a monitor that comes right back keeps the disconnect intact.
+    ///
+    /// The contract, written down after the rescue had grown a layer per desk shape (#91,
+    /// #99, #106, #117, #112): it exists to bring back a screen that Crisp itself turned
+    /// off when nothing viewable is left. It reads CoreGraphics and, for the undock case,
+    /// the port transport nodes. A display that is not on a port, the built-in or a
+    /// virtual device, is never doubted. It accepts about three seconds of dark. This is
+    /// the last layer: a desk shape it does not cover waits for a report from a release
+    /// build, not for a new predicate.
     func restoreIfNoActiveDisplay() {
         guard isSupported, !disconnected.isEmpty else { return }
         // With records to act on, every stand-down is worth a line: a capture of a dark

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -161,14 +161,20 @@ final class PhysicalDisplayToggleService: ObservableObject {
 
     /// Count of active displays that are real physical screens, excluding virtual
     /// displays managed by VirtualDisplayService (a virtual display is active in
-    /// CGGetActiveDisplayList but is not a viewable screen).
+    /// CGGetActiveDisplayList but is not a viewable screen). This is what the Disconnect
+    /// row and the launch re-apply read; the blackout rescue reads
+    /// phantomAwareActiveDisplayCount instead.
     private func physicalActiveDisplayCount() -> Int {
+        viewableActiveDisplays().count
+    }
+
+    private func viewableActiveDisplays() -> [CGDirectDisplayID] {
         var count: UInt32 = 0
-        guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return 0 }
+        guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return [] }
         var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
-        guard CGGetActiveDisplayList(count, &ids, &count) == .success else { return 0 }
+        guard CGGetActiveDisplayList(count, &ids, &count) == .success else { return [] }
         let virtual = VirtualDisplayService.shared
-        let viewable = ids.prefix(Int(count)).filter { id in
+        return ids.prefix(Int(count)).filter { id in
             guard !virtual.isVirtualDisplay(id) else { return false }
             // Real panels carry 16-bit EDID vendor and product codes. Two kinds of
             // entry enumerate as active without a screen behind them, and both fail
@@ -185,50 +191,75 @@ final class PhysicalDisplayToggleService: ObservableObject {
             let hasNoPanel = vendor == 0 || model == 0 || vendor > 0xFFFF || model > 0xFFFF
             return !hasNoPanel
         }
-        // The shape filter above catches an entry with nothing behind it. It cannot catch
-        // the third kind, from #112: after an undock while asleep, WindowServer
-        // re-enumerates the absent externals at the full wake with their EDID identities
-        // intact, so they are active, 16-bit and completely real-looking, and they stay
-        // that way until the dock goes back in -- measured at 104 s with the desk dark the
-        // whole time and the rescue standing down on a count of 2.
-        //
-        // What actually left with the cable is the port's transport node, so ask the ports
-        // instead and cap the external count at what they can be carrying. Presence alone
-        // is not enough: an empty HDMI port keeps its node, reading hpd Unknown and sink 0
-        // in every sample of a whole run, and a phantom could hide behind it. Hot-plug
-        // detect is the part that tracks the cable.
-        //
-        // Only a display that came through a port is capped. The built-in is not on one,
-        // and neither is a display WindowServer draws for a virtual device: a DisplayLink
-        // dock's USB framebuffer, which CoreDisplay marks kCGDisplayIsVirtualDevice.
-        // Measured on such a dock with the lid closed: the machine exposes a transport
-        // node for its own HDMI port only (hpd Low, sink 0), so capping that display
-        // read 0 with the screen lit, which would hide every Disconnect row with the lid
-        // open, refuse a remembered built-in disconnect at launch, and fire this rescue
-        // on every callback.
-        //
-        // The info dictionary costs 2.5 to 8 ms per display, and this count runs from a
-        // view body for every card, so it is only read once the ports say fewer than the
-        // externals lit, which is the phantom state or a virtual-device desk. An ordinary
-        // desk never pays for it.
+    }
+
+    /// The count the blackout rescue reads: physicalActiveDisplayCount with the #112
+    /// phantoms taken out. Read by restoreIfNoActiveDisplay and nowhere else, on
+    /// purpose: the Disconnect row and the launch re-apply keep the plain count, so a
+    /// wrong answer from the ports on a desk shape this has never seen can only make
+    /// the rescue fire, which re-enables a display Crisp itself turned off, and can
+    /// never hide a row or refuse a remembered disconnect.
+    ///
+    /// The shape filter in viewableActiveDisplays catches an entry with nothing behind
+    /// it. It cannot catch the third kind, from #112: after an undock while asleep,
+    /// WindowServer re-enumerates the absent externals at the full wake with their EDID
+    /// identities intact, so they are active, 16-bit and completely real-looking, and
+    /// they stay that way until the dock goes back in -- measured at 104 s with the desk
+    /// dark the whole time and the rescue standing down on a count of 2.
+    ///
+    /// What actually left with the cable is the port's transport node, so ask the ports
+    /// instead and cap the external count at what they can be carrying. Presence alone
+    /// is not enough: an empty HDMI port keeps its node, reading hpd Unknown and sink 0
+    /// in every sample of a whole run, and a phantom could hide behind it. Hot-plug
+    /// detect is the part that tracks the cable.
+    ///
+    /// Only a display that came through a port is capped. The built-in is not on one,
+    /// and neither is an external that still carries its product name while no port
+    /// carries it: a DisplayLink dock's USB framebuffer, measured here with the lid
+    /// closed (the machine exposes a transport node for its own HDMI port only, hpd Low,
+    /// sink 0, so the plain cap read 0 with the screen lit). It is the name and not
+    /// kCGDisplayIsVirtualDevice because the flag reads 1 on the phantoms too, and on
+    /// any real monitor while WindowServer re-enumerates it: through a display sleep
+    /// @ncchen99 measured virtual 0 to 1, transport 1 to 0 and the product name to
+    /// empty, all back at wake. The flag means "CoreDisplay knows nothing about this
+    /// entry yet", and a phantom is that state made permanent. The lit DisplayLink
+    /// display reads the same two flags and a full product name, which is where they
+    /// part.
+    ///
+    /// Two residuals, stated rather than patched. A phantom that turns out to carry a
+    /// name is counted and the rescue stands down, which is what it does without this
+    /// rule. And a DisplayLink-only desk in display sleep reads 0 for the length of the
+    /// sleep, since the name empties and no port carries it, so with a record on the
+    /// books the rescue would fire there and bring a screen back that the user turned
+    /// off. Reports from a release build decide whether either needs more.
+    ///
+    /// The info dictionary costs 2.5 to 8 ms per display, so it is read only once the
+    /// ports say fewer than the externals lit, which is the phantom state or a
+    /// DisplayLink desk. An ordinary desk never pays for it.
+    private func phantomAwareActiveDisplayCount() -> Int {
+        let viewable = viewableActiveDisplays()
         let externals = viewable.filter { CGDisplayIsBuiltin($0) != 1 }
         let portCap = liveDisplayPortCount()
         var onPort = externals.count
         if let portCap, portCap < externals.count {
-            onPort = externals.filter { !Self.isVirtualDevice($0) }.count
+            onPort = externals.filter { !Self.hasProductName($0) }.count
         }
         return PhantomPortCap.activeCount(offPort: viewable.count - onPort, onPort: onPort, portCap: portCap)
     }
 
-    /// A display WindowServer draws for a virtual device rather than for a panel on a
-    /// port (DisplayLink and similar USB framebuffers), from CoreDisplay's info
-    /// dictionary. False when the dictionary cannot be read, which leaves the display
+    /// Whether CoreDisplay still knows the display by name. Populated for a lit panel
+    /// whether or not a port carries it; empty for an entry WindowServer is
+    /// re-enumerating, or has re-enumerated with no hardware behind it (the #112
+    /// phantom). False when the dictionary cannot be read, which leaves the display
     /// subject to the cap, the behaviour the rule had before this exemption.
-    private static func isVirtualDevice(_ id: CGDirectDisplayID) -> Bool {
+    private static func hasProductName(_ id: CGDirectDisplayID) -> Bool {
         guard let info = _CoreDisplayCreateInfoDictionary?(id)?.takeRetainedValue() as? [String: Any] else {
             return false
         }
-        return (info["kCGDisplayIsVirtualDevice"] as? NSNumber)?.boolValue ?? false
+        if let names = info["DisplayProductName"] as? [String: Any] {
+            return names.values.contains { ($0 as? String)?.isEmpty == false }
+        }
+        return (info["DisplayProductName"] as? String)?.isEmpty == false
     }
 
     /// The number of ports that can have a display behind them right now: a DisplayPort or
@@ -947,17 +978,18 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// The contract, written down after the rescue had grown a layer per desk shape (#91,
     /// #99, #106, #117, #112): it exists to bring back a screen that Crisp itself turned
     /// off when nothing viewable is left. It reads CoreGraphics and, for the undock case,
-    /// the port transport nodes. A display that is not on a port, the built-in or a
-    /// virtual device, is never doubted. It accepts about three seconds of dark. This is
-    /// the last layer: a desk shape it does not cover waits for a report from a release
-    /// build, not for a new predicate.
+    /// the port transport nodes; nothing else in Crisp reads the ports. A display that is
+    /// not on a port is never doubted: the built-in, and an external that keeps its
+    /// product name with no port carrying it (a DisplayLink display). It accepts about
+    /// three seconds of dark. This is the last layer: a desk shape it does not cover
+    /// waits for a report from a release build, not for a new predicate.
     func restoreIfNoActiveDisplay() {
         guard isSupported, !disconnected.isEmpty else { return }
         // With records to act on, every stand-down is worth a line: a capture of a dark
         // desk otherwise cannot tell "never asked" from "asked and refused", and which guard
         // refused (issue #92: a dock pulled during sleep can keep its displays in the online
         // list until the link times out, and those count as active).
-        let active = physicalActiveDisplayCount()
+        let active = phantomAwareActiveDisplayCount()
         guard !restoreInFlight, active == 0 else {
             Self.log.notice("restore asked with \(self.disconnected.count, privacy: .public) record(s): \(active, privacy: .public) active display(s), in flight \(self.restoreInFlight, privacy: .public), standing down")
             return
@@ -986,12 +1018,12 @@ final class PhysicalDisplayToggleService: ObservableObject {
             // a zero-count desk that is only asleep. What keeps this guard clear of that
             // state is that it runs from reconfiguration callbacks, and none arrive while
             // the displays are down.
-            var settled = self.physicalActiveDisplayCount()
+            var settled = self.phantomAwareActiveDisplayCount()
             var repolls = 0
             while settled == 0, repolls < Self.settleRepolls {
                 try? await Task.sleep(nanoseconds: Self.settleRepollInterval)
                 guard !Task.isCancelled else { return }
-                settled = self.physicalActiveDisplayCount()
+                settled = self.phantomAwareActiveDisplayCount()
                 repolls += 1
             }
             guard settled == 0 else {
@@ -1016,14 +1048,14 @@ final class PhysicalDisplayToggleService: ObservableObject {
             for (record, _) in candidates {
                 // macOS re-probes displays by itself in this state and often wins the race;
                 // stop as soon as anything viewable is back, whoever brought it back.
-                guard self.physicalActiveDisplayCount() == 0 else { return }
+                guard self.phantomAwareActiveDisplayCount() == 0 else { return }
                 guard case .success = await self.reconnect(uuid: record.uuid) else { continue }
                 // A successful transaction is NOT proof of recovery (see verifyBackOnline):
                 // around sleep transitions it reports success while the display stays
                 // disabled, and that lie used to end the restore with every screen still
                 // black. Only enumeration ends it; otherwise move on to the next record.
                 for _ in 0..<20 {
-                    if self.physicalActiveDisplayCount() > 0 { return }
+                    if self.phantomAwareActiveDisplayCount() > 0 { return }
                     try? await Task.sleep(nanoseconds: 100_000_000)
                 }
             }

--- a/CrispTests/PhantomPortCapTests.swift
+++ b/CrispTests/PhantomPortCapTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+/// The capping rule from #112: an external display can only be behind a port that is
+/// carrying something, so the count of externals is capped at the number of transport
+/// nodes with hot-plug detect asserted.
+final class PhantomPortCapTests: XCTestCase {
+    private func cap(builtin: Int, external: Int, portCap: Int?) -> Int {
+        PhantomPortCap.activeCount(builtin: builtin, external: external, portCap: portCap)
+    }
+
+    /// The state the rule exists for. After an undock while asleep CG reports the two
+    /// absent externals as active with real 16-bit EDID, and no port carries them.
+    func testPhantomsBehindDeadPortsAreNotCounted() {
+        XCTAssertEqual(cap(builtin: 0, external: 2, portCap: 0), 0)
+    }
+
+    /// The same desk with the built-in still on is not a blackout, and the built-in is
+    /// not on a port, so it survives the cap.
+    func testBuiltinIsNeverCapped() {
+        XCTAssertEqual(cap(builtin: 1, external: 2, portCap: 0), 1)
+    }
+
+    /// An ordinary docked desk: the cap changes nothing.
+    func testLiveDisplaysAreLeftAlone() {
+        XCTAssertEqual(cap(builtin: 0, external: 2, portCap: 2), 2)
+        XCTAssertEqual(cap(builtin: 1, external: 1, portCap: 2), 2)
+    }
+
+    /// The cap is an upper bound, never a floor: more live ports than displays is the
+    /// normal state of a dock with a spare socket, and must not invent a display.
+    func testMorePortsThanDisplaysDoesNotAdd() {
+        XCTAssertEqual(cap(builtin: 0, external: 1, portCap: 3), 1)
+        XCTAssertEqual(cap(builtin: 0, external: 0, portCap: 3), 0)
+    }
+
+    /// One of two cables gone: the remaining display still counts, so the desk is not
+    /// treated as dark.
+    func testPartialCapKeepsTheSurvivor() {
+        XCTAssertEqual(cap(builtin: 0, external: 2, portCap: 1), 1)
+    }
+
+    /// nil means the machine exposes no transport nodes at all, i.e. the signal is not
+    /// available rather than zero. Capping on that would black out a desk the rule has
+    /// never seen, so it must pass everything through untouched.
+    func testUnavailableSignalDoesNotCap() {
+        XCTAssertEqual(cap(builtin: 0, external: 2, portCap: nil), 2)
+        XCTAssertEqual(cap(builtin: 1, external: 2, portCap: nil), 3)
+        XCTAssertEqual(cap(builtin: 0, external: 0, portCap: nil), 0)
+    }
+}

--- a/CrispTests/PhantomPortCapTests.swift
+++ b/CrispTests/PhantomPortCapTests.swift
@@ -20,11 +20,11 @@ final class PhantomPortCapTests: XCTestCase {
         XCTAssertEqual(cap(builtin: 1, external: 2, portCap: 0), 1)
     }
 
-    /// A DisplayLink desk: the dock's display is a virtual device that no port carries,
-    /// and the only transport node the machine exposes is its own empty HDMI port. Lid
-    /// closed it is the only screen, lid open it sits beside the built-in; neither may
-    /// read as dark. (offPort carries it, like the built-in.)
-    func testVirtualDeviceDisplayIsNeverCapped() {
+    /// A DisplayLink desk: the dock's display keeps its product name while no port
+    /// carries it, and the only transport node the machine exposes is its own empty HDMI
+    /// port. Lid closed it is the only screen, lid open it sits beside the built-in;
+    /// neither may read as dark. (offPort carries it, like the built-in.)
+    func testNamedDisplayOffPortIsNeverCapped() {
         XCTAssertEqual(PhantomPortCap.activeCount(offPort: 1, onPort: 0, portCap: 0), 1)
         XCTAssertEqual(PhantomPortCap.activeCount(offPort: 2, onPort: 0, portCap: 0), 2)
         XCTAssertEqual(PhantomPortCap.activeCount(offPort: 1, onPort: 1, portCap: 0), 1)

--- a/CrispTests/PhantomPortCapTests.swift
+++ b/CrispTests/PhantomPortCapTests.swift
@@ -5,7 +5,7 @@ import XCTest
 /// nodes with hot-plug detect asserted.
 final class PhantomPortCapTests: XCTestCase {
     private func cap(builtin: Int, external: Int, portCap: Int?) -> Int {
-        PhantomPortCap.activeCount(builtin: builtin, external: external, portCap: portCap)
+        PhantomPortCap.activeCount(offPort: builtin, onPort: external, portCap: portCap)
     }
 
     /// The state the rule exists for. After an undock while asleep CG reports the two
@@ -18,6 +18,16 @@ final class PhantomPortCapTests: XCTestCase {
     /// not on a port, so it survives the cap.
     func testBuiltinIsNeverCapped() {
         XCTAssertEqual(cap(builtin: 1, external: 2, portCap: 0), 1)
+    }
+
+    /// A DisplayLink desk: the dock's display is a virtual device that no port carries,
+    /// and the only transport node the machine exposes is its own empty HDMI port. Lid
+    /// closed it is the only screen, lid open it sits beside the built-in; neither may
+    /// read as dark. (offPort carries it, like the built-in.)
+    func testVirtualDeviceDisplayIsNeverCapped() {
+        XCTAssertEqual(PhantomPortCap.activeCount(offPort: 1, onPort: 0, portCap: 0), 1)
+        XCTAssertEqual(PhantomPortCap.activeCount(offPort: 2, onPort: 0, portCap: 0), 2)
+        XCTAssertEqual(PhantomPortCap.activeCount(offPort: 1, onPort: 1, portCap: 0), 1)
     }
 
     /// An ordinary docked desk: the cap changes nothing.

--- a/project.yml
+++ b/project.yml
@@ -77,6 +77,7 @@ targets:
       - path: Crisp/Models/DisplayPreset.swift
       - path: Crisp/Models/CrispControlModel.swift
       - path: Crisp/Models/BrightnessKeySteps.swift
+      - path: Crisp/Models/PhantomPortCap.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.crisp.tests


### PR DESCRIPTION
Closes #112. Stacks with #132; they touch the same guard from opposite sides — that one
makes the count read more than once, this one makes it read the right thing.

Count the DisplayPort and Thunderbolt transport nodes with hot-plug detect asserted, and
cap the external display count at that.

## Why hpd and not node presence

From the #112 capture: this desk's empty `HDMI3` port keeps its node in **every sample of
every run**, reading `hpd=Unknown sink=0`, so a phantom could hide behind an empty socket.
The two USB-C nodes read `hpd=High sink=1` while their displays were up and were gone
6.6 s before the phantoms appeared. Hot-plug detect is the half that tracks the cable.

## The precondition you asked for

> that hpd stays High on your dock's ports through display sleep, since if it drops there
> the rule would call a sleeping display a phantom and the rescue would fire on a desk
> about to come back

It holds. 1893 samples across two runs — one with Crisp not running at all, both externals
active, a single 3-minute display sleep; one on clean main with the reported arrangement
and four 32 s sleeps. `predicate-probe.swift` computed this rule on every 200 ms sample and
flagged `effective < actual` and `effective == 0 while actual > 0`. **Neither ever
occurred.** The port carrying an active display never left `hpd=High sink=1`, through the
display sleeps and through every wake blackout window. Full numbers on #112.

One caveat, in the code comment too: hpd does go `Low sink=0` for 400-600 ms on a port
whose display *Crisp has just switched off* — two of those blips landed 20 ms and 151 ms
after a `Display 3 setEnabled:0` in WindowServer. A live display's port never did it, and
the cap is an upper bound so a low read on a switched-off display's port cannot remove an
active one. Worth knowing before anyone samples this inside their own toggle.

## nil, not 0

`liveDisplayPortCount()` returns nil when the machine exposes no transport nodes of either
class. That is "the signal is not available here", not "nothing is plugged in", and capping
on it would black out a desk this rule has never seen — I have no way to check every Mac
that is not this one. A machine that *does* expose the nodes and reports none asserted is
exactly the #112 state, and 0 is the right answer there.

## Tests

The rule is a plain function in `Crisp/Models/PhantomPortCap.swift`, added to the test
target the way the other model types are, with six cases: the phantom state, the built-in
never being capped, an ordinary docked desk, more ports than displays, one of two cables
gone, and the unavailable-signal passthrough.

`make check` green.

## Not driven

The phantom state itself. Reproducing it needs a dock pulled during sleep, and I did not
want to hand you a fix validated only against the arithmetic — but the capture on #112 is
from exactly that sequence on this hardware, and the rule is read off it. I can run the
undock-while-asleep sequence against this branch and post the probe output if you would
rather have that before merging; say the word and it is one evening.
