### PR TITLE
Run the release dry run beside the checks, and only where it matters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ permissions:
   contents: read
 
 jobs:
+  # Everything a pull request is held to. The job name is the status check
+  # main's branch rule requires, so it stays "build".
   build:
     # macOS 26 SDK required: the panel backdrop uses NSGlassEffectView (macOS 26),
     # which must exist at compile time even though it's #available-gated at runtime.
@@ -44,6 +46,12 @@ jobs:
       # survived to a release.
       - name: Test
         run: make test
+      # The release binary is universal. Code that only compiles on arm64 (an
+      # `#if arch(arm64)` block a caller outside it depends on, how #110 first
+      # failed) breaks the x86_64 slice, and typechecking that slice takes
+      # seconds where the universal build in the job below takes minutes.
+      - name: Typecheck the x86_64 slice
+        run: make typecheck-x86
       # Every localization key the code uses must exist in the String Catalog.
       # SwiftUI coalesces interpolated text into "%@"-style lookup keys, and a
       # key missing from the catalog silently falls back to English at runtime
@@ -70,8 +78,33 @@ jobs:
           else
             python3 scripts/check-translations.py Crisp/Resources/Localizable.xcstrings || true
           fi
-      # Reuses the release script's dry run: compiles the universal binary,
-      # builds the icon, compiles the String Catalog, and packages the DMG,
-      # so a green check means the real release path builds. Publishes nothing.
+
+  # Reuses the release script's dry run: compiles the universal binary,
+  # builds the icon, compiles the String Catalog, and packages the DMG,
+  # so a green run means the real release path builds. Publishes nothing.
+  #
+  # Four minutes of the six a run used to take, so it runs beside the job
+  # above rather than after it, and a pull request only pays for it when it
+  # touches the release path itself (the script, the project, the Makefile,
+  # this workflow). Every push to main still runs it in full.
+  release-build:
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Decide whether the release path is affected
+        id: affected
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "${{ github.event.pull_request.base.sha }}" HEAD \
+               | grep -qE '^(project\.yml|Makefile|scripts/|\.github/workflows/)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Release path untouched; skipping the dry run."
+          fi
       - name: Build (release dry run)
+        if: steps.affected.outputs.run == 'true'
         run: ./scripts/release.sh v0.0.0-ci

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #   make dev        compile, swap the binary into /Applications/Crisp.app, relaunch
 #   make compile    compile the binary only (./Crisp-bin), no swap — quick build check
 #   make test       generate the Xcode project and run unit tests
-#   make check      lint + tests + localization keys, everything CI enforces: run before pushing
+#   make check      lint + tests + x86_64 typecheck + localization keys, everything CI enforces: run before pushing
 #                   (auto-run on every push after: git config core.hooksPath .githooks)
 #
 # Distributable DMG:
@@ -38,7 +38,7 @@ SWIFTC_FLAGS := -O -swift-version 5 -strict-concurrency=minimal -parse-as-librar
                 -Xlinker -undefined -Xlinker dynamic_lookup
 
 .DEFAULT_GOAL := help
-.PHONY: help dev compile test lint loc-check check build dmg release clean vendor
+.PHONY: help dev compile test lint loc-check typecheck-x86 check build dmg release clean vendor
 
 # Sparkle framework, pinned + cached in vendor/ (needed to compile and to
 # generate the Xcode project's framework reference).
@@ -50,7 +50,7 @@ help:
 	@echo "  make dev        compile + swap into /Applications/Crisp.app + relaunch (dev.sh)"
 	@echo "  make compile    compile ./Crisp-bin only, no swap (quick build check)"
 	@echo "  make test       generate the Xcode project and run unit tests"
-	@echo "  make check      lint + tests + localization keys, everything CI enforces"
+	@echo "  make check      lint + tests + x86_64 typecheck + localization keys, everything CI enforces"
 	@echo "  make build      signed universal DMG, no Xcode (scripts/release.sh v$(VERSION))"
 	@echo "  make dmg        DMG via Xcode (scripts/build-dmg.sh)"
 	@echo "  make release ARGS=\"vX.Y.Z notes.md --publish\"   full release (scripts/release.sh)"
@@ -88,9 +88,18 @@ loc-check: vendor
 	python3 scripts/check-localization-keys.py build/loc/en.xcloc \
 		Crisp/Resources/Localizable.xcstrings scripts/i18n-missing-allowlist.txt
 
-# Everything CI enforces (lint + build + tests + localization keys), locally.
-check: lint test loc-check
-	@echo "check passed: lint clean, tests green, localization keys complete"
+# The release binary is universal, and code that only compiles on arm64 (an
+# `#if arch(arm64)` block that a caller outside it depends on, which is how #110
+# first failed the hook) breaks the x86_64 slice. Typechecking that slice takes
+# seconds where the universal build takes minutes, so it runs on every check.
+typecheck-x86: vendor
+	swiftc -typecheck -target x86_64-apple-macos14.0 -swift-version 5 -strict-concurrency=minimal \
+		-parse-as-library -import-objc-header Crisp/Crisp-Bridging-Header.h \
+		-F vendor/Sparkle $(SWIFT_SOURCES)
+
+# Everything CI enforces (lint + build + tests + x86_64 slice + localization keys), locally.
+check: lint test typecheck-x86 loc-check
+	@echo "check passed: lint clean, tests green, x86_64 slice typechecks, localization keys complete"
 
 build:
 	./scripts/release.sh v$(VERSION)


### PR DESCRIPTION
CI ran six and a half minutes on every pull request, and four of those were the release dry run: a universal Release build, the icon and a DMG, to prove the release script still builds. That is worth proving on main and on the few PRs that touch the release path, and it is wasted on a PR that changes a view.

Two changes. The dry run is its own job now, running beside lint, tests and the localization checks instead of after them, and it only builds when the push is to main or the PR touches project.yml, the Makefile, scripts/ or the workflow; otherwise it prints one line and finishes in seconds. And the one thing the dry run caught that nothing else did, the x86_64 slice of the universal binary (how #110 first failed the hook), is covered on every PR by a ten-second `swiftc -typecheck` of that slice, as `make typecheck-x86`, which `make check` runs too.

The job the branch rule requires keeps its name, so nothing changes in the repo settings. Expected: a PR that leaves the release path alone lands around two and a half minutes; main and release-path PRs around four and a half, since the two jobs overlap. This PR touches the workflow, so both jobs run in full here.
