### PR TITLE
Ship crispctl inside the app bundle

### DIFF
--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -1194,6 +1194,66 @@
         }
       }
     },
+    "crispctl Command Line Tool" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "crispctl 命令行工具"
+          }
+        }
+      }
+    },
+    "Install" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "安装"
+          }
+        }
+      }
+    },
+    "Installed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已安装"
+          }
+        }
+      }
+    },
+    "crispctl command line tool, installed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "crispctl 命令行工具，已安装"
+          }
+        }
+      }
+    },
+    "crispctl command line tool, not installed" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "crispctl 命令行工具，未安装"
+          }
+        }
+      }
+    },
+    "Click to link crispctl into /usr/local/bin" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点击将 crispctl 链接到 /usr/local/bin"
+          }
+        }
+      }
+    },
     "Loading profiles…" : {
       "localizations" : {
         "zh-Hans" : {

--- a/Crisp/Services/CrispctlInstaller.swift
+++ b/Crisp/Services/CrispctlInstaller.swift
@@ -1,0 +1,43 @@
+import Foundation
+import os
+
+/// Puts the bundled crispctl on the PATH. Release builds carry it at
+/// Contents/MacOS/crispctl; installing is one symlink into /usr/local/bin, behind
+/// the same admin prompt the HiDPI override uses, because that directory is
+/// root-owned on a stock Mac. The Homebrew cask makes the same link on install.
+@MainActor
+enum CrispctlInstaller {
+    private static let log = Logger(subsystem: "com.crisp.app", category: "app")
+    static let linkPath = "/usr/local/bin/crispctl"
+    static let bundledPath = Bundle.main.bundleURL.appendingPathComponent("Contents/MacOS/crispctl").path
+
+    /// False on a dev build (dev.sh swaps the app binary only) and while the app
+    /// runs translocated from a DMG or Downloads, where the bundle path is a
+    /// temporary mount and a link to it would dangle on the next launch.
+    static var isAvailable: Bool {
+        FileManager.default.isExecutableFile(atPath: bundledPath)
+            && !bundledPath.contains("/AppTranslocation/")
+    }
+
+    /// The link must point at this bundle: a moved app offers the install again.
+    static var isInstalled: Bool {
+        (try? FileManager.default.destinationOfSymbolicLink(atPath: linkPath)) == bundledPath
+    }
+
+    static func install() {
+        // Where /usr/local/bin belongs to the user (Intel Macs with Homebrew) the
+        // link needs no prompt, so try that first, the way VS Code's shell
+        // command install does; a stale link of ours is replaced on the way.
+        let fm = FileManager.default
+        if (try? fm.destinationOfSymbolicLink(atPath: linkPath)) != nil { try? fm.removeItem(atPath: linkPath) }
+        if (try? fm.createSymbolicLink(atPath: linkPath, withDestinationPath: bundledPath)) != nil { return }
+        // Single-quoted for the shell, then escaped for the AppleScript literal.
+        let shellPath = bundledPath.replacingOccurrences(of: "'", with: "'\\''")
+        let command = "mkdir -p /usr/local/bin && ln -sfn '\(shellPath)' \(linkPath)"
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        if let error = HiDPIService.shared.executePrivilegedCommand(command) {
+            log.error("crispctl install failed: \(error, privacy: .public)")
+        }
+    }
+}

--- a/Crisp/Services/HiDPIService.swift
+++ b/Crisp/Services/HiDPIService.swift
@@ -161,7 +161,7 @@ final class HiDPIService: @unchecked Sendable {
 
     /// Executes a shell command with administrator privileges via AppleScript.
     /// Returns nil on success, or an error message on failure.
-    private func executePrivilegedCommand(_ command: String) -> String? {
+    func executePrivilegedCommand(_ command: String) -> String? {
         let script = """
             do shell script "\(command)" with administrator privileges
             """

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -322,6 +322,46 @@ struct UpdateRow: View {
     }
 }
 
+// MARK: - CommandLineToolRow
+
+/// Settings row that links the bundled crispctl into /usr/local/bin. Shown only
+/// when the bundle carries the tool (release builds); reads Installed while the
+/// link points at this bundle, and offers the install again once the app moves.
+struct CommandLineToolRow: View {
+    @State private var installed = CrispctlInstaller.isInstalled
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(spacing: 8) {
+            MenuItemIcon(systemName: "terminal.fill", color: .gray, active: installed)
+                .accessibilityHidden(true)
+            Text("crispctl Command Line Tool").font(.body)
+            Spacer()
+            Text(installed ? "Installed" : "Install")
+                .font(.caption)
+                .foregroundColor(installed ? .secondary : .accentColor)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 3)
+        .menuRowHover(isHovered && !installed)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard !installed, PanelOpenGuard.allowsActivation else { return }
+            CrispctlInstaller.install()
+            installed = CrispctlInstaller.isInstalled
+        }
+        .onHover { hovering in
+            isHovered = hovering
+            guard !installed else { return }
+            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+        }
+        .onAppear { installed = CrispctlInstaller.isInstalled }
+        .accessibilityLabel(installed ? "crispctl command line tool, installed" : "crispctl command line tool, not installed")
+        .accessibilityHint("Click to link crispctl into /usr/local/bin")
+        .accessibilityAddTraits(.isButton)
+    }
+}
+
 // MARK: - SupportRow
 
 /// Optional "buy me a coffee" link at the bottom of Settings, styled as a normal
@@ -700,6 +740,10 @@ struct SettingsView: View {
             .controlSize(.small)
             .padding(.horizontal, 12)
             .padding(.vertical, 3)
+
+            if CrispctlInstaller.isAvailable {
+                CommandLineToolRow()
+            }
 
             SectionDivider()
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To keep Keep Awake off on company Macs, push a configuration profile for the `co
 
 ## Automation
 
-Source builds include a minimal `crispctl` target:
+Crisp ships with `crispctl`, a command line tool for the same controls. It lives inside the app at `Crisp.app/Contents/MacOS/crispctl`; Settings > crispctl Command Line Tool links it into `/usr/local/bin` after one admin prompt, and the Homebrew cask makes the same link on install. Source builds get it with:
 
 ```sh
 xcodegen generate && xcodebuild -scheme crispctl -configuration Release
@@ -123,8 +123,6 @@ For example, `brightness boost get` returns `{"ok":true,"brightnessBoost":{"disp
 `display disconnect`, `connect` and `toggle` are the menu's Disconnect Display and Reconnect from a script, for a KVM desk or a button: Apple Silicon only, and a disconnect is refused when it would leave no active display. A display Crisp is holding disconnected is absent from every macOS display list, so `display list` still shows it with `connected:false` and its last-known id; use the uuid for it. Asking for the state a display is already in succeeds and changes nothing, and the reply comes after the window server has answered, which can take a few seconds.
 
 `hdr get` and `hdr set` work on the external displays Crisp shows its HDR toggle for; the built-in panel and externals without HDR modes are refused. `get` reads the live state. `set` writes once through the same path as the toggle and reports success only when the read-back agrees; when it cannot tell (a timeout, or the display going away mid-way) it says so and does not retry, so run `hdr get` before retrying. Exit codes are unchanged.
-
-The current public Crisp 1.5.0 release, normal DMG, and Homebrew cask do not include `crispctl`.
 
 ## Building
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -11,6 +11,10 @@ the `project.yml` version bump. In-app updates go live only when GitHub Pages
 serves the new appcast; until then installed apps simply keep waiting (they
 never break, they just see no update).
 
+## crispctl
+
+`release.sh` compiles `crispctl` universal from the same source list as the `crispctl` target in `project.yml` and puts it at `Crisp.app/Contents/MacOS/crispctl`, signed inside-out before the app like Sparkle's nested code. Settings links it into `/usr/local/bin`; the cask needs the same link once, so the first release that ships it also sends homebrew/cask a PR adding `binary "#{appdir}/Crisp.app/Contents/MacOS/crispctl"` under the `app` stanza. Autobump only moves the version, so that line has to be added by hand.
+
 ## Signing and notarization
 
 `release.sh` signs, notarizes and staples two separate artifacts: the app,

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -50,6 +50,18 @@ for a in arm64 x86_64; do
 done
 lipo -create "$BUILD/Crisp-arm64" "$BUILD/Crisp-x86_64" -output "$APP/Contents/MacOS/Crisp"
 
+# crispctl ships inside the bundle (Contents/MacOS/crispctl); Settings links it
+# into /usr/local/bin and the Homebrew cask's binary stanza does the same. The
+# source list mirrors the crispctl target in project.yml. No -parse-as-library:
+# main.swift is top-level code.
+echo "==> Compiling crispctl (arm64 + x86_64)…"
+for a in arm64 x86_64; do
+  swiftc -O -target "$a-apple-macos14.0" \
+    Sources/crispctl/main.swift Crisp/Models/CrispControlModel.swift Crisp/Models/BrightnessKeySteps.swift \
+    -o "$BUILD/crispctl-$a"
+done
+lipo -create "$BUILD/crispctl-arm64" "$BUILD/crispctl-x86_64" -output "$APP/Contents/MacOS/crispctl"
+
 echo "==> Embedding Sparkle.framework…"
 mkdir -p "$APP/Contents/Frameworks"
 cp -R "$ROOT/vendor/Sparkle/Sparkle.framework" "$APP/Contents/Frameworks/"
@@ -123,7 +135,7 @@ PLIST
 # Sparkle's docs explicitly warn against it.
 xattr -cr "$APP"
 SPARKLE_FW="$APP/Contents/Frameworks/Sparkle.framework"
-SPARKLE_NESTED=("$SPARKLE_FW/Versions/B/Autoupdate" "$SPARKLE_FW/Versions/B/Updater.app" "$SPARKLE_FW")
+SPARKLE_NESTED=("$SPARKLE_FW/Versions/B/Autoupdate" "$SPARKLE_FW/Versions/B/Updater.app" "$SPARKLE_FW" "$APP/Contents/MacOS/crispctl")
 if [ -n "${CRISP_SIGN_ID:-}" ]; then
   echo "==> Signing (Developer ID: $CRISP_SIGN_ID, hardened runtime)…"
   for item in "${SPARKLE_NESTED[@]}"; do
@@ -188,6 +200,7 @@ fi
 SHA=$(shasum -a 256 "$DMG" | awk '{print $1}')
 echo "==> Built $DMG"
 echo "    version $(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' "$APP/Contents/Info.plist"), archs $(lipo -archs "$APP/Contents/MacOS/Crisp"), sha256 $SHA"
+echo "    crispctl archs $(lipo -archs "$APP/Contents/MacOS/crispctl")"
 
 if [ "$PUBLISH" != true ]; then
   echo "==> Dry run. Pass --publish to create the release and bump the tap."


### PR DESCRIPTION
crispctl now ships inside the app. `release.sh` compiles it universal from the same three sources as the `crispctl` target in `project.yml`, puts it at `Crisp.app/Contents/MacOS/crispctl` and signs it inside-out with the rest of the bundle, so a notarized release carries it with the hardened runtime like Sparkle's nested code.

Getting it onto the PATH needs an admin prompt on a stock Mac, since `/usr/local/bin` is root-owned, so I put a row in Settings rather than prompting at first launch: "crispctl Command Line Tool" with Install on the right, which links the bundled binary into `/usr/local/bin`. It tries a plain symlink first, which is silent where that directory belongs to the user (Intel Macs with Homebrew), and otherwise goes through the same AppleScript prompt the HiDPI override already uses, the way VS Code's "Install 'code' command in PATH" does it. The row and reads Installed while the link points at this bundle. The row stays hidden on dev builds (dev.sh swaps the app binary only, so there is nothing to link) and while the app runs translocated from a DMG or Downloads, where a link would dangle on the next launch. Homebrew users get the same link from a `binary` stanza in the cask; that is a one-line PR to homebrew/cask at release time, noted in docs/RELEASING.md because autobump only moves the version.

Verified with a local dry run: `lipo -archs` reports x86_64 and arm64 for both binaries, `codesign --verify --deep --strict` passes, the bundled crispctl lists displays against the running app, and with the release identity the tool carries the runtime flag. Installed the build here: the row is in Settings and reads not installed. The README's Automation section no longer says the tool is source builds only.
