### PR TITLE
Make the crispctl row a switch

### DIFF
--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -1194,62 +1194,22 @@
         }
       }
     },
-    "crispctl Command Line Tool" : {
+    "Command Line Tool" : {
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "crispctl 命令行工具"
+            "value" : "命令行工具"
           }
         }
       }
     },
-    "Install" : {
+    "Links crispctl into /usr/local/bin" : {
       "localizations" : {
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "安装"
-          }
-        }
-      }
-    },
-    "Installed" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "已安装"
-          }
-        }
-      }
-    },
-    "crispctl command line tool, installed" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "crispctl 命令行工具，已安装"
-          }
-        }
-      }
-    },
-    "crispctl command line tool, not installed" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "crispctl 命令行工具，未安装"
-          }
-        }
-      }
-    },
-    "Click to link crispctl into /usr/local/bin" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "点击将 crispctl 链接到 /usr/local/bin"
+            "value" : "将 crispctl 链接到 /usr/local/bin"
           }
         }
       }

--- a/Crisp/Services/CrispctlInstaller.swift
+++ b/Crisp/Services/CrispctlInstaller.swift
@@ -40,4 +40,13 @@ enum CrispctlInstaller {
             log.error("crispctl install failed: \(error, privacy: .public)")
         }
     }
+
+    /// Removes the link; a regular file at that path is not ours and is left alone.
+    static func uninstall() {
+        guard (try? FileManager.default.destinationOfSymbolicLink(atPath: linkPath)) != nil else { return }
+        if (try? FileManager.default.removeItem(atPath: linkPath)) != nil { return }
+        if let error = HiDPIService.shared.executePrivilegedCommand("rm -f \(linkPath)") {
+            log.error("crispctl uninstall failed: \(error, privacy: .public)")
+        }
+    }
 }

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -324,41 +324,35 @@ struct UpdateRow: View {
 
 // MARK: - CommandLineToolRow
 
-/// Settings row that links the bundled crispctl into /usr/local/bin. Shown only
-/// when the bundle carries the tool (release builds); reads Installed while the
-/// link points at this bundle, and offers the install again once the app moves.
+/// Settings switch that links the bundled crispctl into /usr/local/bin. Shown only
+/// when the bundle carries the tool (release builds); reads on while the link
+/// points at this bundle, so a moved app reads off again until it is relinked.
 struct CommandLineToolRow: View {
     @State private var installed = CrispctlInstaller.isInstalled
-    @State private var isHovered = false
 
     var body: some View {
-        HStack(spacing: 8) {
-            MenuItemIcon(systemName: "terminal.fill", color: .gray, active: installed)
-                .accessibilityHidden(true)
-            Text("crispctl Command Line Tool").font(.body)
-            Spacer()
-            Text(installed ? "Installed" : "Install")
-                .font(.caption)
-                .foregroundColor(installed ? .secondary : .accentColor)
+        Toggle(isOn: Binding(
+            get: { installed },
+            set: { newValue in
+                guard PanelOpenGuard.allowsActivation else { return }
+                if newValue { CrispctlInstaller.install() } else { CrispctlInstaller.uninstall() }
+                installed = CrispctlInstaller.isInstalled
+            }
+        )) {
+            HStack(spacing: 8) {
+                MenuItemIcon(systemName: "terminal.fill", color: .indigo, active: installed)
+                    .accessibilityHidden(true)
+                Text("Command Line Tool")
+                    .font(.body)
+                Spacer()
+            }
         }
+        .toggleStyle(.switch)
+        .controlSize(.small)
         .padding(.horizontal, 12)
         .padding(.vertical, 3)
-        .menuRowHover(isHovered && !installed)
-        .contentShape(Rectangle())
-        .onTapGesture {
-            guard !installed, PanelOpenGuard.allowsActivation else { return }
-            CrispctlInstaller.install()
-            installed = CrispctlInstaller.isInstalled
-        }
-        .onHover { hovering in
-            isHovered = hovering
-            guard !installed else { return }
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
         .onAppear { installed = CrispctlInstaller.isInstalled }
-        .accessibilityLabel(installed ? "crispctl command line tool, installed" : "crispctl command line tool, not installed")
-        .accessibilityHint("Click to link crispctl into /usr/local/bin")
-        .accessibilityAddTraits(.isButton)
+        .accessibilityHint("Links crispctl into /usr/local/bin")
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To keep Keep Awake off on company Macs, push a configuration profile for the `co
 
 ## Automation
 
-Crisp ships with `crispctl`, a command line tool for the same controls. It lives inside the app at `Crisp.app/Contents/MacOS/crispctl`; Settings > crispctl Command Line Tool links it into `/usr/local/bin` after one admin prompt, and the Homebrew cask makes the same link on install. Source builds get it with:
+Crisp ships with `crispctl`, a command line tool for the same controls. It lives inside the app at `Crisp.app/Contents/MacOS/crispctl`; the Command Line Tool switch in Settings links it into `/usr/local/bin` after one admin prompt (off removes the link), and the Homebrew cask makes the same link on install. Source builds get it with:
 
 ```sh
 xcodegen generate && xcodebuild -scheme crispctl -configuration Release


### PR DESCRIPTION
The row from #135 was the only one of its kind in Settings: a gray outline chip that read as a disabled row and a caption-sized Install on the right that nothing else uses. Launch at Login sits next to it and is the same kind of setting, so this is a switch too. On links crispctl into /usr/local/bin behind the admin prompt, off removes the link (a plain unlink first, the prompt only when the directory is root-owned, and a regular file at that path is left alone), the chip colours while it is on, and the label is Command Line Tool. The six strings from #135 are replaced by two, and the README names the switch.

Driven on this Mac: on links, off unlinks, both through the prompt since /usr/local/bin is root-owned here, and crispctl answers from a login shell while the switch is on.