### PR TITLE
Seven small fixes from the 1.5.0 to 1.6.0 review

### DIFF
--- a/Crisp/Models/CrispControlModel.swift
+++ b/Crisp/Models/CrispControlModel.swift
@@ -424,18 +424,21 @@ enum CrispControlCLIModel {
           display list                           Displays as JSON: id, uuid, name, resolution,
                                                  brightness, maxBrightness, brightnessBackend,
                                                  connected (false while Crisp holds it off)
-          brightness get <display>               Read logical brightness and its live maximum
-          brightness set <display> <pct>         Set 0-100, or up to maxBrightness while Extra
-                                                 Brightness is enabled and eligible; clears preset
-          brightness boost get <display>         Read Extra Brightness eligibility and state
-          brightness boost set <display> on|off  Enable or disable Extra Brightness
-          hdr get <display>                      Read live HDR state for an eligible external display
-          hdr set <display> on|off               Set HDR on an eligible external and verify live state
+          display connect <display>              Put a disconnected display back
           display disconnect <display>           Take the display out of the layout, as the menu's
                                                  Disconnect Display does; refused if it would leave
                                                  no active display. Apple Silicon only
-          display connect <display>              Put a disconnected display back
           display toggle <display>               Disconnect if connected, connect if not
+
+          brightness get <display>               Read logical brightness and its live maximum
+          brightness set <display> <percent>     Set 0-100, or up to maxBrightness while Extra
+                                                 Brightness is enabled and eligible; clears preset
+          brightness boost get <display>         Read Extra Brightness eligibility and state
+          brightness boost set <display> on|off  Enable or disable Extra Brightness
+
+          hdr get <display>                      Read live HDR state for an eligible external display
+          hdr set <display> on|off               Set HDR on an eligible external and verify live state
+
           help                                   Show this help (also -h, --help)
 
         <display> is a runtime id or a uuid from 'display list'. Ids can change after

--- a/Crisp/Services/BrightnessService.swift
+++ b/Crisp/Services/BrightnessService.swift
@@ -539,10 +539,16 @@ final class BrightnessService: @unchecked Sendable {
             to: target,
             steps: max(8, Int(duration / 0.016)),
             duration: duration
-        ) { [weak display] value, _ in
-            guard let display, set(displayID, Float(value)) == 0, let get = _DSGetBrightness else { return }
-            var user: Float = 0
-            if get(displayID, &user) == 0 { display.brightness = Double(user) * 100.0 }
+        ) { [weak self, weak display] value, _ in
+            // The private DisplayServices calls are IPC: keep them off the main
+            // thread like the single-shot path above, publish the read-back on main.
+            self?.queue.async {
+                guard set(displayID, Float(value)) == 0, let get = _DSGetBrightness else { return }
+                var user: Float = 0
+                guard get(displayID, &user) == 0 else { return }
+                let brightness = Double(user) * 100.0
+                DispatchQueue.main.async { display?.brightness = brightness }
+            }
         }
     }
 
@@ -751,10 +757,14 @@ final class BrightnessService: @unchecked Sendable {
             return
         }
         queue.async {
-            self.ddcPumpLock.withLock {
-                guard self.ddcOperationGeneration.isLatestRequest(
-                    target.token, for: displayID
-                ), self.pendingDDCTarget[displayID] == nil else { return }
+            // Decide under the lock, write outside it: setSoftwareBrightness is a
+            // WindowServer gamma IPC plus a defaults write, and the refresh path
+            // takes this lock on the main actor to adopt a read.
+            let settle: Bool = self.ddcPumpLock.withLock {
+                self.ddcOperationGeneration.isLatestRequest(target.token, for: displayID)
+                    && self.pendingDDCTarget[displayID] == nil
+            }
+            if settle {
                 let softwarePercent = target.percent < self.gammaBlendThreshold
                     ? target.percent / self.gammaBlendThreshold * 100.0
                     : 100.0
@@ -792,12 +802,11 @@ final class BrightnessService: @unchecked Sendable {
             Self.log.notice("display \(displayID, privacy: .public): 3 consecutive DDC brightness writes failed, brightness now software gamma until reconnect")
         }
         queue.async {
-            self.ddcPumpLock.withLock {
-                guard self.ddcOperationGeneration.isLatestRequest(
-                    fallback.token, for: displayID
-                ) else { return }
-                self.setSoftwareBrightness(fallback.percent, for: displayID)
+            let isLatest = self.ddcPumpLock.withLock {
+                self.ddcOperationGeneration.isLatestRequest(fallback.token, for: displayID)
             }
+            guard isLatest else { return }
+            self.setSoftwareBrightness(fallback.percent, for: displayID)
         }
     }
 

--- a/Crisp/Services/CrispControlServer.swift
+++ b/Crisp/Services/CrispControlServer.swift
@@ -1,9 +1,16 @@
 import Darwin
 import Foundation
+import os
 
 @MainActor
 final class CrispControlServer {
     private nonisolated static let requestLimit = 8 * 1_024
+    /// Same-user clients only, so these bound a runaway script rather than an
+    /// attacker: a connection holds a cooperative-pool thread until it is answered,
+    /// and the per-recv timeout alone lets a client trickle bytes for ever.
+    private nonisolated static let readDeadline: DispatchTimeInterval = .seconds(5)
+    private nonisolated static let connectionLimit = 16
+    private nonisolated static let openConnections = OSAllocatedUnfairLock(initialState: 0)
     private let displayManager: DisplayManager
     private let acceptQueue = DispatchQueue(label: "com.crisp.app.control", qos: .utility)
     private var listenerFD: Int32 = -1
@@ -58,12 +65,15 @@ final class CrispControlServer {
                 if errno == EINTR { continue }
                 return
             }
-            guard Self.configure(client), Self.isCurrentUser(client) else {
+            guard Self.configure(client), Self.isCurrentUser(client), Self.admit() else {
                 Darwin.close(client)
                 continue
             }
             Task.detached { [weak self] in
-                defer { Darwin.close(client) }
+                defer {
+                    Darwin.close(client)
+                    Self.openConnections.withLock { $0 -= 1 }
+                }
                 await self?.serve(client)
             }
         }
@@ -273,15 +283,25 @@ final class CrispControlServer {
         return display
     }
 
+    private nonisolated static func admit() -> Bool {
+        openConnections.withLock { open in
+            guard open < connectionLimit else { return false }
+            open += 1
+            return true
+        }
+    }
+
     private nonisolated static func read(_ client: Int32) -> CrispControlFrame.Result {
         var data = Data()
         var buffer = [UInt8](repeating: 0, count: 1_024)
+        let deadline = DispatchTime.now() + readDeadline
         while true {
             let count = Darwin.recv(client, &buffer, buffer.count, 0)
             if count > 0 { data.append(contentsOf: buffer.prefix(Int(count))) }
             let result = CrispControlFrame.parse(data, maximumBytes: requestLimit, endOfStream: count == 0)
             if result != .incomplete { return result }
             if count < 0, errno != EINTR { return .failure("request read failed") }
+            if DispatchTime.now() >= deadline { return .failure("request read timed out") }
         }
     }
 

--- a/Crisp/Services/DisplayLuminanceService.swift
+++ b/Crisp/Services/DisplayLuminanceService.swift
@@ -17,6 +17,8 @@ private let _CoreDisplayCreateInfoDictionary: (@convention(c) (CGDirectDisplayID
 /// external monitor publishes CTA/EDID max luminance in IORegistry as 16.16.
 enum DisplayLuminanceService {
     private static let log = Logger(subsystem: "com.crisp.app", category: "brightness")
+    /// Below 40 nits nothing is a display panel; above 10 000 nothing is a nominal peak.
+    private static let plausibleNits: ClosedRange<Double> = 40...10_000
 
     static func maximumSDRNits(displayID: CGDirectDisplayID, isBuiltin: Bool) -> Double? {
         let nits = isBuiltin ? builtinMaximumSDRNits(displayID: displayID) : externalMaximumNits(displayID: displayID)
@@ -30,7 +32,7 @@ enum DisplayLuminanceService {
         // Non-reference is the normal Apple XDR preset; the reference peak
         // is the fallback for fixed-luminance reference presets.
         for key in ["NonReferencePeakSDRLuminance", "ReferencePeakSDRLuminance"] {
-            if let value = number(dictionary[key]), value > 0 { return value }
+            if let value = number(dictionary[key]), plausibleNits.contains(value) { return value }
         }
         return nil
     }
@@ -104,7 +106,7 @@ enum DisplayLuminanceService {
     private static func maximumNits(in luminance: [String: Any]?) -> Double? {
         guard let raw = number(luminance?["Max"]), raw > 0 else { return nil }
         let nits = raw > 10_000 ? raw / 65_536.0 : raw
-        return (40...10_000).contains(nits) ? nits : nil
+        return plausibleNits.contains(nits) ? nits : nil
     }
 
     private static func number(_ value: Any?) -> Double? {

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -282,6 +282,12 @@ final class PhysicalDisplayToggleService: ObservableObject {
         defer { reconnectInFlight.remove(uuid) }
         let result = await setEnabled(true, displayID: targetID)
         if case .success = result {
+            // A reported success is not proof (see verifyBackOnline). The record is
+            // dropped either way: keeping it would have reconcile take the display
+            // away again the moment it does appear. The log says which case it was.
+            if !(await verifyBackOnline(uuid: uuid, timeout: 2.0)) {
+                Self.log.notice("reconnect of \(uuid, privacy: .public) reported success but the display is not back online after 2 s, record dropped")
+            }
             disconnected.removeAll { $0.uuid == uuid }
             saveDesired()
         }

--- a/README.md
+++ b/README.md
@@ -100,15 +100,18 @@ It supports ten control commands:
 
 ```sh
 crispctl display list
+crispctl display connect <display>
+crispctl display disconnect <display>
+crispctl display toggle <display>
+
 crispctl brightness get <display>
 crispctl brightness set <display> <percent>
 crispctl brightness boost get <display>
 crispctl brightness boost set <display> on|off
+
 crispctl hdr get <display>
 crispctl hdr set <display> on|off
-crispctl display disconnect <display>
-crispctl display connect <display>
-crispctl display toggle <display>
+
 crispctl help
 ```
 

--- a/Sources/crispctl/main.swift
+++ b/Sources/crispctl/main.swift
@@ -111,10 +111,15 @@ do {
     do {
         response = try receive(from: client)
     } catch {
-        guard request.command != .setHDR else {
+        switch request.command {
+        case .setHDR:
             fail("HDR response timed out or was lost; \(CrispControlModel.hdrUncertainRecovery)", code: 1)
+        case .toggleDisplay:
+            fail("toggle response timed out or was lost; the display may already have changed state, "
+                 + "run 'display list' before retrying", code: 1)
+        default:
+            throw error
         }
-        throw error
     }
     switch CrispControlCLIModel.classify(response, for: request.command) {
     case .success:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,7 +13,7 @@ never break, they just see no update).
 
 ## crispctl
 
-`release.sh` compiles `crispctl` universal from the same source list as the `crispctl` target in `project.yml` and puts it at `Crisp.app/Contents/MacOS/crispctl`, signed inside-out before the app like Sparkle's nested code. Settings links it into `/usr/local/bin`; the cask needs the same link once, so the first release that ships it also sends homebrew/cask a PR adding `binary "#{appdir}/Crisp.app/Contents/MacOS/crispctl"` under the `app` stanza. Autobump only moves the version, so that line has to be added by hand.
+`release.sh` compiles `crispctl` universal from the same source list as the `crispctl` target in `project.yml` and puts it at `Crisp.app/Contents/MacOS/crispctl`, signed inside-out before the app like Sparkle's nested code. Settings links it into `/usr/local/bin`; the cask needs the same link once. Right after the first release that ships it, send homebrew/cask one PR by hand with the version bump, the new sha256 and `binary "#{appdir}/Crisp.app/Contents/MacOS/crispctl"` under the `app` stanza (`brew bump-cask-pr crisp --version X.Y.Z` builds the bump; add the line to the same commit). Do not wait for autobump: it only moves the version, and a `binary` line against a release whose bundle has no crispctl breaks `brew install`.
 
 ## Signing and notarization
 

--- a/docs/ddc-notes.md
+++ b/docs/ddc-notes.md
@@ -96,6 +96,18 @@ write restarts the fade. Seen on other Dells too; accepted as a quirk.
    controller stays powered). This is the only cure for a fully deaf
    controller, and per ddcutil's tracker even it is not guaranteed.
 
+## The hold around enable and disable
+
+WindowServer's display enable waits behind an in-flight I2C transaction on
+the DCP, and the whole Mac freezes with it (2.8 to 3.0 s measured on a
+wedged channel, #110). So every SkyLight enable and disable is wrapped in
+`DDCService.hold()`: it drains the DDC queues, parks them until the
+transaction has landed, and logs `waited N ms for DDC to go idle` past
+500 ms. The 15 s safety timeout bounds only the parked phase. The drain
+itself waits for whatever read or write is in flight with no Crisp-side
+bound, on purpose: a read that takes 6 s to give up costs 6 s of waiting,
+where issuing the transaction under it costs 6 s of a frozen Mac.
+
 ## Rules of engagement
 
 - Never trust an acked write as proof DDC works; only a checksum-valid

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -203,7 +203,7 @@ echo "    version $(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString
 echo "    crispctl archs $(lipo -archs "$APP/Contents/MacOS/crispctl")"
 
 if [ "$PUBLISH" != true ]; then
-  echo "==> Dry run. Pass --publish to create the release and bump the tap."
+  echo "==> Dry run. Pass --publish to create the release and regenerate the appcast."
   exit 0
 fi
 


### PR DESCRIPTION
The small things from my read of everything between 1.5.0 and main, in one PR so the tag has nothing loose under it.

- The built-in smooth glide ran its private DisplayServices set and get on the main thread at every step of the 200 ms animation. They run on the brightness queue now, like the single-shot path next to it, and the read-back is published on main.
- Both DDC write outcomes called `setSoftwareBrightness` while holding `ddcPumpLock`. That is a WindowServer gamma IPC plus a defaults write, and the refresh path takes the same lock on the main actor to adopt a read, so a slow gamma write could stall the main thread. The decision is now made under the lock and the write happens outside it; latest-wins is carried by the tokens as before.
- The control server had a 2 s timeout per recv call and nothing else, so a same-user client could trickle a byte at a time for ever, and every connection holds a cooperative-pool thread until it is answered. A request now has 5 s to arrive in full, and at most 16 connections are open at once, extras closed at accept.
- crispctl printed its do-not-retry hint only for `hdr set`. `display toggle` is not idempotent either, so it gets the same treatment, pointing at `display list`.
- The built-in nits reader accepted anything above zero where the external reader wants 40 to 10 000. One range for both.
- `reconnect` dropped its record on a reported success without looking. It still drops it, since keeping it would have the remembered-disconnect reconcile take the display away again the moment it appears, but it now waits up to 2 s for the display to be back online and logs when it is not.
- The release script's dry-run line promised a tap bump that nothing does, RELEASING.md now gives the cask sequence for the release that ships crispctl, and ddc-notes.md records the hold around enable and disable and why its drain has no Crisp-side bound.
- The crispctl help and the README list are grouped by command family (display, brightness, hdr) and both say `<percent>`.

Driven on this Mac with the branch installed: twenty idle sockets opened 20 ms apart, the four over the cap closed at accept, the sixteen inside it answered "request read failed" and closed once the receive timeout ran out; a real client refused while sixteen idle ones were held and served 2.5 s later; a client sending one byte every 0.9 s cut at about 5 s; the grouped help printed from the branch build; make check green. The glide, pump lock and reconnect changes are verified by reading and by the build, since the glide needs the lid open and the other two are structural. Seen on the way and left alone: the listen backlog of 8 refuses one connect out of a burst of twenty fired with no gap, which a client retries.
