### PR TITLE
crispctl display power off

### DIFF
--- a/Crisp/Models/CrispControlModel.swift
+++ b/Crisp/Models/CrispControlModel.swift
@@ -75,6 +75,7 @@ struct CrispControlRequest: Codable, Equatable {
         case connectDisplay
         case disconnectDisplay
         case toggleDisplay
+        case powerOffDisplay
     }
 
     let command: Command
@@ -165,25 +166,34 @@ struct CrispControlConnectionChange: Equatable {
     let uuid: String
     let connect: Bool
 }
+/// A resolved `display power off`: one DDC/CI write of VCP D6 asking the monitor to
+/// switch itself off. One-way by the MCCS definition of that value (the power button
+/// brings it back), so there is no direction field.
+struct CrispControlPowerChange: Equatable {
+    let displayID: UInt32
+}
 struct CrispControlResult {
     let response: CrispControlResponse
     let brightnessChange: CrispControlBrightnessChange?
     let brightnessBoostChange: CrispControlBrightnessBoostChange?
     let hdrChange: CrispControlHDRChange?
     let connectionChange: CrispControlConnectionChange?
+    let powerChange: CrispControlPowerChange?
 
     init(
         _ response: CrispControlResponse,
         _ brightnessChange: CrispControlBrightnessChange?,
         _ brightnessBoostChange: CrispControlBrightnessBoostChange?,
         _ hdrChange: CrispControlHDRChange?,
-        _ connectionChange: CrispControlConnectionChange? = nil
+        _ connectionChange: CrispControlConnectionChange? = nil,
+        powerChange: CrispControlPowerChange? = nil
     ) {
         self.response = response
         self.brightnessChange = brightnessChange
         self.brightnessBoostChange = brightnessBoostChange
         self.hdrChange = hdrChange
         self.connectionChange = connectionChange
+        self.powerChange = powerChange
     }
 }
 enum CrispControlModel {
@@ -280,7 +290,29 @@ enum CrispControlModel {
             )
         case .connectDisplay, .disconnectDisplay, .toggleDisplay:
             return handleConnection(request, displays: displays)
+        case .powerOffDisplay:
+            return handlePowerOff(request, displays: displays)
         }
+    }
+
+    /// The built-in has no DDC/CI, and a display Crisp is holding disconnected has no
+    /// channel to write to; everything else is the monitor's call.
+    private static func handlePowerOff(
+        _ request: CrispControlRequest, displays: [CrispControlDisplay]
+    ) -> CrispControlResult {
+        guard hasDisplaySelector(request) else {
+            return .init(.failure("display is required"), nil, nil, nil)
+        }
+        guard let display = target(of: request, in: displays) else {
+            return .init(.failure("display not found"), nil, nil, nil)
+        }
+        guard !display.isBuiltin else {
+            return .init(.failure("the built-in display has no DDC/CI; use display sleep"), nil, nil, nil)
+        }
+        guard display.connected ?? true else {
+            return .init(.failure("display is disconnected, so there is no DDC channel to write to"), nil, nil, nil)
+        }
+        return .init(.success(), nil, nil, nil, powerChange: .init(displayID: display.id))
     }
 
     /// Resolves a connection request against the online list plus the displays Crisp
@@ -429,6 +461,10 @@ enum CrispControlCLIModel {
                                                  Disconnect Display does; refused if it would leave
                                                  no active display. Apple Silicon only
           display toggle <display>               Disconnect if connected, connect if not
+          display power <display> off            Tell the monitor to switch itself off over DDC/CI
+                                                 (VCP D6). One-way: its DDC/CI goes with it and the
+                                                 power button brings it back. Firmware decides
+                                                 whether it is honoured; ok means the write was taken
 
           brightness get <display>               Read logical brightness and its live maximum
           brightness set <display> <percent>     Set 0-100, or up to maxBrightness while Extra
@@ -464,6 +500,8 @@ enum CrispControlCLIModel {
         // The window server answers inside the app's 10 s wrapper, but the DDC hold
         // ahead of the transaction can wait 15 s and the mode restore after it 3 s.
         case .connectDisplay, .disconnectDisplay, .toggleDisplay: return 30
+        // Three write attempts, each able to sit on a wedged channel for the 6 s I2C timeout.
+        case .powerOffDisplay: return 20
         default: return 2
         }
     }
@@ -502,6 +540,10 @@ enum CrispControlCLIModel {
             case "off": return .request(.init(command: .setHDR, selector: arguments[2], enabled: false))
             default: break
             }
+        }
+        if arguments.count == 4, arguments[0...1] == ["display", "power"], !arguments[2].isEmpty,
+           arguments[3] == "off" {
+            return .request(.init(command: .powerOffDisplay, selector: arguments[2]))
         }
         return connectionRequest(arguments) ?? .failure
     }

--- a/Crisp/Services/CrispControlServer.swift
+++ b/Crisp/Services/CrispControlServer.swift
@@ -205,6 +205,21 @@ final class CrispControlServer {
         if let change = result.connectionChange, let error = await apply(change, among: managedDisplays) {
             return CrispControlModel.encode(.failure(error))
         }
+        if let change = result.powerChange {
+            guard let display = managedDisplays.first(where: { $0.displayID == change.displayID }) else {
+                return CrispControlModel.encode(.failure("display not found"))
+            }
+            let taken = await withCheckedContinuation { continuation in
+                DDCService.shared.writeAsync(
+                    displayID: display.displayID,
+                    command: DDCService.powerModeVCP,
+                    value: DDCService.powerModeOff
+                ) { continuation.resume(returning: $0) }
+            }
+            return CrispControlModel.encode(
+                taken ? .success() : .failure("the monitor did not take the DDC power write")
+            )
+        }
         return CrispControlModel.encode(result.response)
     }
 

--- a/Crisp/Services/DDCService.swift
+++ b/Crisp/Services/DDCService.swift
@@ -35,6 +35,10 @@ final class DDCService: ObservableObject, @unchecked Sendable {
     static let brightnessVCP: UInt8 = 0x10
     static let contrastVCP: UInt8   = 0x12
     static let volumeVCP: UInt8     = 0x62
+    /// MCCS power mode. 0x05 is the write-only "switch off" value: the monitor cuts its
+    /// own controller, DDC/CI included, and the power button brings it back.
+    static let powerModeVCP: UInt8  = 0xD6
+    static let powerModeOff: UInt16 = 0x05
 
     /// Diagnostics for support threads. Transitions and failures go out at
     /// notice/error (persisted; reporters run `log show --predicate

--- a/CrispTests/CrispControlModelTests.swift
+++ b/CrispTests/CrispControlModelTests.swift
@@ -73,7 +73,12 @@ final class CrispControlModelTests: XCTestCase {
                 ["display", "disconnect", "DECC7CEF-5E36-4E9B-8F18-CE11AE5902AD"],
                 .init(command: .disconnectDisplay, selector: "DECC7CEF-5E36-4E9B-8F18-CE11AE5902AD")
             ),
-            (["display", "toggle", "42"], .init(command: .toggleDisplay, selector: "42"))
+            (["display", "toggle", "42"], .init(command: .toggleDisplay, selector: "42")),
+            (["display", "power", "42", "off"], .init(command: .powerOffDisplay, selector: "42")),
+            (
+                ["display", "power", "decc7cef-5e36-4e9b-8f18-ce11ae5902ad", "off"],
+                .init(command: .powerOffDisplay, selector: "decc7cef-5e36-4e9b-8f18-ce11ae5902ad")
+            )
         ]
         for (arguments, request) in cases {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .request(request))
@@ -114,7 +119,10 @@ final class CrispControlModelTests: XCTestCase {
             ["hdr", "set", "42", "true"], ["hdr", "set", "42", "ON"],
             ["hdr", "set", "42", "on", "extra"],
             ["display", "toggle"], ["display", "toggle", ""], ["display", "reboot", "42"],
-            ["display", "toggle", "42", "now"]
+            ["display", "toggle", "42", "now"],
+            // Power is one-way by design: there is no on, standby or bare form.
+            ["display", "power", "42"], ["display", "power", "42", "on"], ["display", "power", "", "off"],
+            ["display", "power", "42", "off", "now"]
         ]
         for arguments in cases {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .failure)
@@ -133,6 +141,7 @@ final class CrispControlModelTests: XCTestCase {
         for command in [CrispControlRequest.Command.connectDisplay, .disconnectDisplay, .toggleDisplay] {
             XCTAssertEqual(CrispControlCLIModel.receiveTimeoutSeconds(for: command), 30)
         }
+        XCTAssertEqual(CrispControlCLIModel.receiveTimeoutSeconds(for: .powerOffDisplay), 20)
         for command in [
             CrispControlRequest.Command.list, .getBrightness, .setBrightness, .getBrightnessBoost, .getHDR
         ] {
@@ -604,7 +613,7 @@ final class CrispControlModelTests: XCTestCase {
     private var commands: [CrispControlRequest.Command] {
         [
             .list, .getBrightness, .setBrightness, .getBrightnessBoost, .setBrightnessBoost, .getHDR, .setHDR,
-            .connectDisplay, .disconnectDisplay, .toggleDisplay
+            .connectDisplay, .disconnectDisplay, .toggleDisplay, .powerOffDisplay
         ]
     }
 
@@ -671,6 +680,29 @@ final class CrispControlModelTests: XCTestCase {
             let result = CrispControlModel.handle(Data(request.utf8), displays: displays)
             XCTAssertFalse(result.response.ok, request)
             XCTAssertNil(result.connectionChange, request)
+        }
+    }
+
+    func testPowerOffResolvesAnExternalAndRefusesBuiltinAndHeld() {
+        let builtin = CrispControlDisplay(id: 1, name: "Built-in", brightness: 50, isBuiltin: true, uuid: "B")
+        let displays = [display, held, builtin]
+        for selector in ["7", "37d8832a-2d66-02ca-b9f7-8f30a301b230"] {
+            let result = CrispControlModel.handle(
+                Data(#"{"command":"powerOffDisplay","selector":"\#(selector)"}"#.utf8), displays: displays
+            )
+            XCTAssertTrue(result.response.ok, selector)
+            XCTAssertEqual(result.powerChange, .init(displayID: display.id), selector)
+            XCTAssertNil(result.connectionChange, selector)
+        }
+        for request in [
+            #"{"command":"powerOffDisplay"}"#,
+            #"{"command":"powerOffDisplay","selector":"404"}"#,
+            #"{"command":"powerOffDisplay","selector":"1"}"#,
+            #"{"command":"powerOffDisplay","selector":"9"}"#
+        ] {
+            let result = CrispControlModel.handle(Data(request.utf8), displays: displays)
+            XCTAssertFalse(result.response.ok, request)
+            XCTAssertNil(result.powerChange, request)
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -96,13 +96,14 @@ Crisp ships with `crispctl`, a command line tool for the same controls. It lives
 xcodegen generate && xcodebuild -scheme crispctl -configuration Release
 ```
 
-It supports ten control commands:
+It supports eleven control commands:
 
 ```sh
 crispctl display list
 crispctl display connect <display>
 crispctl display disconnect <display>
 crispctl display toggle <display>
+crispctl display power <display> off
 
 crispctl brightness get <display>
 crispctl brightness set <display> <percent>
@@ -124,6 +125,8 @@ Crisp must already be running; crispctl never launches it. `brightness set` acce
 For example, `brightness boost get` returns `{"ok":true,"brightnessBoost":{"displayID":7,"eligible":true,"enabled":false}}`. `eligible` is the running Extra Brightness service's current eligibility result; `enabled` is its persisted per-display toggle state, so the two can differ while capability has collapsed and cleanup or auto-disable is pending. `brightness boost set` uses that existing service: `on` is refused when currently ineligible or when enabling fails, while `off` remains available for a connected display regardless of current eligibility. Enabling an external display may wait while the service settles HDR mode. Success means the service returned `true`, not that hardware, EDR headroom, or luminance was independently verified. A transport timeout does not prove the change was not applied; do not retry automatically—run `brightness boost get` first.
 
 `display disconnect`, `connect` and `toggle` are the menu's Disconnect Display and Reconnect from a script, for a KVM desk or a button: Apple Silicon only, and a disconnect is refused when it would leave no active display. A display Crisp is holding disconnected is absent from every macOS display list, so `display list` still shows it with `connected:false` and its last-known id; use the uuid for it. Asking for the state a display is already in succeeds and changes nothing, and the reply comes after the window server has answered, which can take a few seconds.
+
+`display power <display> off` tells the monitor to switch itself off over DDC/CI (the MCCS power-mode control, VCP D6). It is one-way: a monitor that has switched itself off has no DDC/CI left to hear an on, so its power button brings it back, and whether a monitor honours the value is up to its firmware. The reply means the monitor took the write, nothing more. The built-in display is refused, since it has no DDC/CI; display sleep is the tool for that one.
 
 `hdr get` and `hdr set` work on the external displays Crisp shows its HDR toggle for; the built-in panel and externals without HDR modes are refused. `get` reads the live state. `set` writes once through the same path as the toggle and reports success only when the read-back agrees; when it cannot tell (a timeout, or the display going away mid-way) it says so and does not retry, so run `hdr get` before retrying. Exit codes are unchanged.
 


### PR DESCRIPTION
From discussion #74: a headless Mac with one external display, and the wish to switch that monitor off from a key without reaching for it. macOS can put a display to sleep but cannot ask a monitor to cut its own power; DDC/CI can, through the MCCS power-mode control (VCP D6), whose value 5 the spec defines as "switch off, the power button brings it back".

That makes it a poor fit for the panel, where I only want controls Crisp can verify and undo, and a fair fit for crispctl: `crispctl display power <display> off` writes D6 = 5 once over the same DDC path as brightness and replies ok when the monitor took the write, nothing more. There is no on or standby form on purpose. A monitor that has switched itself off has no DDC/CI left to hear an on, and standby over DDC is display sleep done worse (the Mac keeps rendering into it, and some monitors wake straight back up on the live signal). Whether a monitor honours the value is its firmware, and the help and README say so. The built-in is refused (no DDC/CI; display sleep is the tool there), and so is a display Crisp is holding disconnected. Receive timeout 20 s, since three write attempts on a wedged channel can each sit on the 6 s I2C timeout.

Driven here on a DisplayLink display with no DDC channel: the write was attempted (`write 0xD6=5 display 7: failed all 3 attempts` in the ddc log) and refused with exit 3 in 0.1 s; bad forms exit 2; the help row prints; make check green with the parser, timeout and handler tests. Not driven on a monitor that honours it, since the only DDC monitor on this desk today has no channel; the asker's monitor is the one that matters. Stacked on #137, rebases to one commit once that is in. This is the last addition before 1.6.0.
