### PR TITLE
crispctl help as group and command pages

### DIFF
--- a/Crisp/Models/CrispControlModel.swift
+++ b/Crisp/Models/CrispControlModel.swift
@@ -451,18 +451,34 @@ enum CrispControlCLIModel {
             case .hdr: return "HDR commands"
             }
         }
+        var description: String {
+            switch self {
+            case .display: return "List, connect, disconnect and power off the displays Crisp controls."
+            case .brightness: return "Read and set brightness and Extra Brightness."
+            case .hdr: return "Read and switch HDR on external displays."
+            }
+        }
+        var examples: [String] {
+            switch self {
+            case .display: return ["crispctl display list", "crispctl display disconnect 3", "crispctl display connect <uuid>"]
+            case .brightness: return ["crispctl brightness set 3 40", "crispctl brightness boost set 3 on"]
+            case .hdr: return ["crispctl hdr get 3", "crispctl hdr set 3 on"]
+            }
+        }
     }
 
-    /// One documented command: the usage as typed, a one-line summary for the
-    /// top-level table, and the detail the group's help prints under it. Kept in the
-    /// shared model so the app and the CLI cannot drift.
-    struct Entry {
+    /// One documented command: the usage as typed, a one-line summary for the tables,
+    /// and the detail its own help page prints. Kept in the shared model so the app
+    /// and the CLI cannot drift.
+    struct Entry: Equatable {
         let group: Group
         let usage: String
         let summary: String
         let detail: String
+        /// The usage without the group: "power <display> off" on the group's page.
+        var subcommand: String { String(usage.drop { $0 != " " }.dropFirst()) }
         /// The literal words before the first placeholder ("display power" for
-        /// "display power <display> off"): what a wrong invocation is matched on.
+        /// "display power <display> off"): what an invocation is matched on.
         var words: [String] {
             Array(usage.split(separator: " ").map(String.init).prefix { !$0.hasPrefix("<") })
         }
@@ -470,29 +486,35 @@ enum CrispControlCLIModel {
 
     static let entries: [Entry] = [
         Entry(group: .display, usage: "display list", summary: "List displays as JSON", detail: """
-            Each display: id, uuid, name, resolution, brightness, maxBrightness,
-            brightnessBackend and connected (false while Crisp holds it off).
+            Each display carries id, uuid, name, resolution, brightness, maxBrightness,
+            brightnessBackend and connected, which is false while Crisp holds it off.
             """),
-        Entry(group: .display, usage: "display connect <display>", summary: "Put a disconnected display back", detail: ""),
+        Entry(group: .display, usage: "display connect <display>", summary: "Put a disconnected display back", detail: """
+            Asking for the state a display is already in succeeds and changes nothing.
+            The reply comes after the window server has answered.
+            """),
         Entry(group: .display, usage: "display disconnect <display>", summary: "Take a display out of the layout", detail: """
-            As the menu's Disconnect Display does; refused if it would leave no active
-            display. Apple Silicon only.
+            The same as Disconnect Display in the menu; refused if it would leave no
+            active display. Apple Silicon only. Asking for the state a display is
+            already in succeeds and changes nothing. The reply comes after the window
+            server has answered.
             """),
-        Entry(group: .display, usage: "display toggle <display>", summary: "Disconnect if connected, connect if not", detail: ""),
+        Entry(group: .display, usage: "display toggle <display>", summary: "Disconnect if connected, connect if not", detail: """
+            The reply comes after the window server has answered. If it is lost, run
+            'display list' before retrying: the display may already have changed state.
+            """),
         Entry(group: .display, usage: "display power <display> off", summary: "Ask the monitor to switch itself off", detail: """
             One DDC/CI write (VCP D6). One-way: the monitor's DDC/CI goes with it and its
             power button brings it back. Firmware decides whether it is honoured; ok means
-            the write was taken.
+            the write was taken. The built-in display has no DDC/CI and is refused.
             """),
         Entry(group: .brightness, usage: "brightness get <display>", summary: "Read brightness and its live maximum", detail: ""),
         Entry(group: .brightness, usage: "brightness set <display> <percent>", summary: "Set brightness", detail: """
-            0-100, or up to maxBrightness while Extra Brightness is enabled and eligible;
-            boosted values past the live maximum are refused, not clamped. A set is a
-            manual change like the slider and clears the active preset. The reply means
-            Crisp accepted the request, not that the panel was read back.
+            A set is a manual change like the slider and clears the active preset. The
+            reply means Crisp accepted the request, not that the panel was read back.
             """),
         Entry(group: .brightness, usage: "brightness boost get <display>", summary: "Read Extra Brightness state",
-              detail: "Whether the display is eligible and whether it is on."),
+              detail: "Whether the display is eligible for Extra Brightness and whether it is on."),
         Entry(group: .brightness, usage: "brightness boost set <display> on|off", summary: "Switch Extra Brightness", detail: ""),
         Entry(group: .hdr, usage: "hdr get <display>", summary: "Read HDR state",
               detail: "The live state of an eligible external display."),
@@ -510,14 +532,15 @@ enum CrispControlCLIModel {
         Control a running Crisp from the command line. Crisp must be running for the
         same user; crispctl talks to it over a local socket and never launches it.
         """
-    static let displayNote = """
-        <display> is a runtime id or a uuid from 'display list'. Ids can change after
-        an unplug or a wake; uuids do not. A disconnected display is gone from every
-        macOS display list, so its id is only a last-known value: use the uuid for it.
+    static let displayArgument = """
+          <display>   A runtime id or a uuid from 'display list'. Ids can change after
+                      an unplug or a wake; uuids do not. A disconnected display is gone
+                      from every macOS display list, so use its uuid.
         """
-    static let connectionNote = """
-        Asking for the connection state a display is already in succeeds and changes
-        nothing. A connection reply comes after the window server has answered.
+    static let percentArgument = """
+          <percent>   0-100, or up to maxBrightness while Extra Brightness is enabled
+                      and eligible; boosted values past the live maximum are refused,
+                      not clamped.
         """
     static let contract = """
         Output is one JSON object per call: {"ok":true,...} or {"ok":false,"error":"..."}.
@@ -525,43 +548,57 @@ enum CrispControlCLIModel {
         """
 
     /// The top-level reference: one line per command, the way docker and gh lay
-    /// theirs out. The detail lives in each group's own help.
+    /// theirs out. The detail lives on the group and command pages.
     static let help: String = {
         var lines = [intro, "", "Usage:  crispctl <command> <subcommand> [<args>]", ""]
+        let column = 2 + (entries.map(\.usage.count) + otherRows.map(\.usage.count)).max()!
         for group in Group.allCases {
             lines.append(group.title + ":")
-            for entry in entries where entry.group == group { lines.append(row(entry.usage, entry.summary)) }
+            for entry in entries where entry.group == group { lines.append(row(entry.usage, entry.summary, column)) }
             lines.append("")
         }
         lines.append("Other commands:")
-        for other in otherRows { lines.append(row(other.usage, other.summary)) }
-        lines += ["", displayNote, contract, "",
-                  "Run 'crispctl <command>' for the details of a command group, e.g. 'crispctl display'."]
+        for other in otherRows { lines.append(row(other.usage, other.summary, column)) }
+        lines += ["", "Arguments:", displayArgument, "", contract, "",
+                  "Run 'crispctl <command>' for a group's commands, 'crispctl <command> <subcommand> --help' for one command."]
         return lines.joined(separator: "\n")
     }()
 
-    /// One group's reference, printed for `crispctl display`, `crispctl display help`
-    /// and any invocation in the group that ends in --help or -h.
+    /// One group's page, printed for `crispctl display`, `crispctl display help`
+    /// and `crispctl display --help`.
     static func help(for group: Group) -> String {
-        var lines = ["Usage:  crispctl \(group.rawValue) <subcommand> [<args>]", "", group.title + ":"]
-        for entry in entries where entry.group == group {
-            lines.append(row(entry.usage, entry.summary))
-            for line in entry.detail.split(separator: "\n") { lines.append("      " + line) }
-        }
-        lines += ["", displayNote]
-        if group == .display { lines.append(connectionNote) }
-        lines.append(contract)
+        let inGroup = entries.filter { $0.group == group }
+        let column = 2 + inGroup.map(\.subcommand.count).max()!
+        var lines = [group.description, "", "Usage:  crispctl \(group.rawValue) <subcommand> [<args>]", "", "Commands:"]
+        lines += inGroup.map { row($0.subcommand, $0.summary, column) }
+        lines += ["", "Arguments:", displayArgument]
+        if group == .brightness { lines.append(percentArgument) }
+        lines += ["", "Examples:"] + group.examples.map { "  $ " + $0 }
+        lines += ["", "Run 'crispctl \(group.rawValue) <subcommand> --help' for the details of one command."]
         return lines.joined(separator: "\n")
     }
 
-    private static let column = 2 + (entries.map(\.usage.count) + otherRows.map(\.usage.count)).max()!
-    private static func row(_ usage: String, _ summary: String) -> String {
+    /// One command's page, printed for any invocation of it that ends in --help or -h.
+    static func help(for entry: Entry) -> String {
+        var lines = ["Usage:  crispctl \(entry.usage)", "", entry.summary + "."]
+        if !entry.detail.isEmpty { lines += ["", entry.detail] }
+        lines += ["", "Arguments:", displayArgument]
+        if entry.usage.contains("<percent>") { lines.append(percentArgument) }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func row(_ usage: String, _ summary: String, _ column: Int) -> String {
         "  " + usage.padding(toLength: column, withPad: " ", startingAt: 0) + summary
     }
 
+    enum HelpTopic: Equatable {
+        case all
+        case group(Group)
+        case command(Entry)
+    }
     enum ParseResult: Equatable {
         case request(CrispControlRequest)
-        case help(Group?)
+        case help(HelpTopic)
         case version
         case failure(String)
     }
@@ -585,13 +622,15 @@ enum CrispControlCLIModel {
     }
     private static func helpRequest(_ arguments: [String]) -> ParseResult? {
         let helpWords: Set<String> = ["help", "--help", "-h"]
-        if arguments.isEmpty || (arguments.count == 1 && helpWords.contains(arguments[0])) { return .help(nil) }
+        if arguments.isEmpty || (arguments.count == 1 && helpWords.contains(arguments[0])) { return .help(.all) }
         if arguments == ["version"] || arguments == ["--version"] { return .version }
         guard let group = Group(rawValue: arguments[0]) else { return nil }
-        if arguments.count == 1 || helpWords.contains(arguments[1]) || arguments.last == "--help" || arguments.last == "-h" {
-            return .help(group)
-        }
-        return nil
+        if arguments.count == 1 || (arguments.count == 2 && helpWords.contains(arguments[1])) { return .help(.group(group)) }
+        guard let last = arguments.last, last == "--help" || last == "-h" else { return nil }
+        // The longest command whose literal words open the invocation gets its own page.
+        let opened = entries.filter { $0.group == group && arguments.starts(with: $0.words) }
+            .max { $0.words.count < $1.words.count }
+        return .help(opened.map(HelpTopic.command) ?? .group(group))
     }
     /// What a wrong invocation gets: the usage of the command it was closest to, or,
     /// for a word that is no command at all, where the commands are listed.

--- a/CrispTests/CrispControlModelTests.swift
+++ b/CrispTests/CrispControlModelTests.swift
@@ -87,34 +87,40 @@ final class CrispControlModelTests: XCTestCase {
 
     func testParserReturnsHelpForNoArgumentsAndHelpFlags() {
         for arguments in [[], ["help"], ["--help"], ["-h"]] {
-            XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .help(nil), "\(arguments)")
+            XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .help(.all), "\(arguments)")
         }
-        // A bare group, or anything in it that asks, prints that group's reference.
-        for arguments in [["display"], ["display", "help"], ["display", "--help"], ["display", "-h"],
-                          ["display", "power", "--help"]] {
-            XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .help(.display), "\(arguments)")
+        // A bare group, or the group asked, prints the group's page; an invocation of a
+        // command that ends in --help or -h prints that command's page.
+        for arguments in [["display"], ["display", "help"], ["display", "--help"], ["display", "-h"]] {
+            XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .help(.group(.display)), "\(arguments)")
         }
-        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["brightness", "set", "-h"]), .help(.brightness))
-        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["hdr"]), .help(.hdr))
+        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["hdr"]), .help(.group(.hdr)))
+        let power = CrispControlCLIModel.entries.first { $0.usage == "display power <display> off" }!
+        let boostSet = CrispControlCLIModel.entries.first { $0.usage == "brightness boost set <display> on|off" }!
+        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["display", "power", "--help"]), .help(.command(power)))
+        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["display", "power", "3", "-h"]), .help(.command(power)))
+        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["brightness", "boost", "set", "--help"]), .help(.command(boostSet)))
+        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["brightness", "nope", "--help"]), .help(.group(.brightness)))
         for arguments in [["version"], ["--version"]] {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .version, "\(arguments)")
         }
-        // The top-level reference names every command, and each group's reference names
-        // its own, so a wrong invocation still leads to the full text.
+        // The top-level reference names every command, each group's page names its own
+        // subcommands without the group, and each command's page opens with its usage.
         let commands = [
             "display list", "brightness get <display>", "brightness set <display>",
             "brightness boost get <display>", "brightness boost set <display>",
             "hdr get <display>", "hdr set <display>", "display power <display> off",
             "display connect <display>", "display disconnect <display>", "display toggle <display>"
         ]
-        for command in commands + ["help", "version", "crispctl display"] {
+        for command in commands + ["help", "version", "crispctl <command>"] {
             XCTAssertTrue(CrispControlCLIModel.help.contains(command), command)
         }
-        for group in CrispControlCLIModel.Group.allCases {
-            let text = CrispControlCLIModel.help(for: group)
-            for command in commands where command.hasPrefix(group.rawValue + " ") {
-                XCTAssertTrue(text.contains(command), "\(group): \(command)")
-            }
+        XCTAssertEqual(CrispControlCLIModel.entries.count, commands.count)
+        for entry in CrispControlCLIModel.entries {
+            let page = CrispControlCLIModel.help(for: entry.group)
+            XCTAssertTrue(page.contains("  " + entry.subcommand + " "), entry.usage)
+            XCTAssertFalse(page.contains("  " + entry.usage), entry.usage)
+            XCTAssertTrue(CrispControlCLIModel.help(for: entry).hasPrefix("Usage:  crispctl " + entry.usage + "\n"), entry.usage)
         }
     }
 

--- a/Sources/crispctl/main.swift
+++ b/Sources/crispctl/main.swift
@@ -107,8 +107,12 @@ private func bundledVersion() -> String {
 let request: CrispControlRequest
 switch CrispControlCLIModel.parse(arguments: Array(CommandLine.arguments.dropFirst())) {
 case let .request(value): request = value
-case let .help(group):
-    print(group.map(CrispControlCLIModel.help(for:)) ?? CrispControlCLIModel.help)
+case let .help(topic):
+    switch topic {
+    case .all: print(CrispControlCLIModel.help)
+    case let .group(group): print(CrispControlCLIModel.help(for: group))
+    case let .command(entry): print(CrispControlCLIModel.help(for: entry))
+    }
     Darwin.exit(EXIT_SUCCESS)
 case .version:
     print("crispctl \(bundledVersion())")


### PR DESCRIPTION
The group page from #139 read wrong: a table with paragraphs under some rows and not others, the group's own name in front of every row, and three notes run together at the bottom. Docker and gh both shape a group page the same way, so this follows them.

`crispctl display` now prints one line of description, the usage, the subcommands without the group in front (`list`, `connect <display>`, `power <display> off`), an Arguments block for `<display>` (and `<percent>` on the brightness page), two or three examples, and a pointer one level down. The paragraphs moved to a page per command: `crispctl display power --help` (or `-h`, on any invocation of that command) prints the usage, the one-line summary, the detail and the arguments. The connection notes went onto connect, disconnect and toggle, the boosted-values rule onto `<percent>`, the read-back note onto hdr set. The top-level page keeps the full command list, gains the Arguments block, and its footer points at both levels.

Tests: every command's page opens with its usage, every group page names its subcommands without the group and never with it, the help forms at all three levels, and the wrong-invocation messages from #139 unchanged. make check green.
