### PR TITLE
crispctl help tables in three columns, poweroff as one word

### DIFF
--- a/Crisp/Models/CrispControlModel.swift
+++ b/Crisp/Models/CrispControlModel.swift
@@ -468,10 +468,16 @@ enum CrispControlCLIModel {
         let usage: String
         let summary: String
         let detail: String
-        /// The usage without the group: "power <display> off" on the group's page.
+        /// The usage without the group: "poweroff <display>" on the group's page.
         var subcommand: String { String(usage.drop { $0 != " " }.dropFirst()) }
-        /// The literal words before the first placeholder ("display power" for
-        /// "display power <display> off"): what an invocation is matched on.
+        /// The usage split at the first placeholder: ("display poweroff", "<display>").
+        var columns: (command: String, arguments: String) {
+            let parts = usage.split(separator: " ").map(String.init)
+            let command = parts.prefix { !$0.hasPrefix("<") }
+            return (command.joined(separator: " "), parts.dropFirst(command.count).joined(separator: " "))
+        }
+        /// The literal words before the first placeholder ("display poweroff" for
+        /// "display poweroff <display>"): what an invocation is matched on.
         var words: [String] {
             Array(usage.split(separator: " ").map(String.init).prefix { !$0.hasPrefix("<") })
         }
@@ -496,7 +502,7 @@ enum CrispControlCLIModel {
             The reply comes after the window server has answered. If it is lost, run
             'display list' before retrying: the display may already have changed state.
             """),
-        Entry(group: .display, usage: "display power <display> off", summary: "Ask the monitor to switch itself off", detail: """
+        Entry(group: .display, usage: "display poweroff <display>", summary: "Ask the monitor to switch itself off", detail: """
             One DDC/CI write (VCP D6). One-way: the monitor's DDC/CI goes with it and its
             power button brings it back. Firmware decides whether it is honoured; ok means
             the write was taken. The built-in display has no DDC/CI and is refused.
@@ -541,14 +547,14 @@ enum CrispControlCLIModel {
     /// theirs out. The detail lives on the group and command pages.
     static let help: String = {
         var lines = [intro, "", "Usage:  crispctl <command> <subcommand> [<args>]", ""]
-        let column = 2 + (entries.map(\.usage.count) + otherRows.map(\.usage.count)).max()!
+        let widths = columnWidths(entries.map(\.columns) + otherRows.map { ($0.usage, "") })
         for group in Group.allCases {
             lines.append(group.title + ":")
-            for entry in entries where entry.group == group { lines.append(row(entry.usage, entry.summary, column)) }
+            for entry in entries where entry.group == group { lines.append(row(entry.columns, entry.summary, widths)) }
             lines.append("")
         }
         lines.append("Other commands:")
-        for other in otherRows { lines.append(row(other.usage, other.summary, column)) }
+        for other in otherRows { lines.append(row((other.usage, ""), other.summary, widths)) }
         lines += ["", displayNote, "", contract, "", "Run 'crispctl <command> --help' for more information on a command."]
         return lines.joined(separator: "\n")
     }()
@@ -557,9 +563,13 @@ enum CrispControlCLIModel {
     /// and `crispctl display --help`: what `docker container --help` prints.
     static func help(for group: Group) -> String {
         let inGroup = entries.filter { $0.group == group }
-        let column = 2 + inGroup.map(\.subcommand.count).max()!
+        let rows = inGroup.map { entry -> (command: String, arguments: String) in
+            let columns = entry.columns
+            return (String(columns.command.dropFirst(group.rawValue.count + 1)), columns.arguments)
+        }
+        let widths = columnWidths(rows)
         var lines = [group.description, "", "Usage:  crispctl \(group.rawValue) <subcommand> [<args>]", "", "Commands:"]
-        lines += inGroup.map { row($0.subcommand, $0.summary, column) }
+        lines += zip(rows, inGroup).map { row($0, $1.summary, widths) }
         lines += ["", "Run 'crispctl \(group.rawValue) <subcommand> --help' for more information on a command."]
         return lines.joined(separator: "\n")
     }
@@ -571,8 +581,15 @@ enum CrispControlCLIModel {
         return lines.joined(separator: "\n")
     }
 
-    private static func row(_ usage: String, _ summary: String, _ column: Int) -> String {
-        "  " + usage.padding(toLength: column, withPad: " ", startingAt: 0) + summary
+    /// Three aligned columns: command, its arguments, what it does. An empty
+    /// argument column collapses so a table without arguments has no gap.
+    private static func columnWidths(_ rows: [(command: String, arguments: String)]) -> (Int, Int) {
+        let arguments = rows.map(\.arguments.count).max()!
+        return (1 + rows.map(\.command.count).max()!, arguments == 0 ? 0 : 2 + arguments)
+    }
+    private static func row(_ columns: (command: String, arguments: String), _ summary: String, _ widths: (Int, Int)) -> String {
+        "  " + columns.command.padding(toLength: widths.0, withPad: " ", startingAt: 0)
+            + columns.arguments.padding(toLength: widths.1, withPad: " ", startingAt: 0) + summary
     }
 
     enum HelpTopic: Equatable {
@@ -667,10 +684,6 @@ enum CrispControlCLIModel {
             default: break
             }
         }
-        if arguments.count == 4, arguments[0...1] == ["display", "power"], !arguments[2].isEmpty,
-           arguments[3] == "off" {
-            return .init(command: .powerOffDisplay, selector: arguments[2])
-        }
         return connectionRequest(arguments)
     }
     private static func connectionRequest(_ arguments: [String]) -> CrispControlRequest? {
@@ -679,6 +692,7 @@ enum CrispControlCLIModel {
         case "connect": return .init(command: .connectDisplay, selector: arguments[2])
         case "disconnect": return .init(command: .disconnectDisplay, selector: arguments[2])
         case "toggle": return .init(command: .toggleDisplay, selector: arguments[2])
+        case "poweroff": return .init(command: .powerOffDisplay, selector: arguments[2])
         default: return nil
         }
     }

--- a/CrispTests/CrispControlModelTests.swift
+++ b/CrispTests/CrispControlModelTests.swift
@@ -74,9 +74,9 @@ final class CrispControlModelTests: XCTestCase {
                 .init(command: .disconnectDisplay, selector: "DECC7CEF-5E36-4E9B-8F18-CE11AE5902AD")
             ),
             (["display", "toggle", "42"], .init(command: .toggleDisplay, selector: "42")),
-            (["display", "power", "42", "off"], .init(command: .powerOffDisplay, selector: "42")),
+            (["display", "poweroff", "42"], .init(command: .powerOffDisplay, selector: "42")),
             (
-                ["display", "power", "decc7cef-5e36-4e9b-8f18-ce11ae5902ad", "off"],
+                ["display", "poweroff", "decc7cef-5e36-4e9b-8f18-ce11ae5902ad"],
                 .init(command: .powerOffDisplay, selector: "decc7cef-5e36-4e9b-8f18-ce11ae5902ad")
             )
         ]
@@ -95,10 +95,10 @@ final class CrispControlModelTests: XCTestCase {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .help(.group(.display)), "\(arguments)")
         }
         XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["hdr"]), .help(.group(.hdr)))
-        let power = CrispControlCLIModel.entries.first { $0.usage == "display power <display> off" }!
+        let power = CrispControlCLIModel.entries.first { $0.usage == "display poweroff <display>" }!
         let boostSet = CrispControlCLIModel.entries.first { $0.usage == "brightness boost set <display> on|off" }!
-        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["display", "power", "--help"]), .help(.command(power)))
-        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["display", "power", "3", "-h"]), .help(.command(power)))
+        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["display", "poweroff", "--help"]), .help(.command(power)))
+        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["display", "poweroff", "3", "-h"]), .help(.command(power)))
         XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["brightness", "boost", "set", "--help"]), .help(.command(boostSet)))
         XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["brightness", "nope", "--help"]), .help(.group(.brightness)))
         for arguments in [["version"], ["--version"]] {
@@ -106,20 +106,19 @@ final class CrispControlModelTests: XCTestCase {
         }
         // The top-level reference names every command, each group's page names its own
         // subcommands without the group, and each command's page opens with its usage.
-        let commands = [
-            "display list", "brightness get <display>", "brightness set <display>",
-            "brightness boost get <display>", "brightness boost set <display>",
-            "hdr get <display>", "hdr set <display>", "display power <display> off",
-            "display connect <display>", "display disconnect <display>", "display toggle <display>"
-        ]
-        for command in commands + ["help", "version", "crispctl <command>"] {
-            XCTAssertTrue(CrispControlCLIModel.help.contains(command), command)
+        // The tables are three columns, so a command and its arguments are padded apart.
+        for word in ["help", "version", "crispctl <command>"] {
+            XCTAssertTrue(CrispControlCLIModel.help.contains(word), word)
         }
-        XCTAssertEqual(CrispControlCLIModel.entries.count, commands.count)
+        XCTAssertEqual(CrispControlCLIModel.entries.count, 11)
         for entry in CrispControlCLIModel.entries {
+            let columns = entry.columns
+            XCTAssertTrue(CrispControlCLIModel.help.contains("  " + columns.command + " "), entry.usage)
+            XCTAssertTrue(columns.arguments.isEmpty || CrispControlCLIModel.help.contains(columns.arguments), entry.usage)
             let page = CrispControlCLIModel.help(for: entry.group)
-            XCTAssertTrue(page.contains("  " + entry.subcommand + " "), entry.usage)
-            XCTAssertFalse(page.contains("  " + entry.usage), entry.usage)
+            let name = String(columns.command.dropFirst(entry.group.rawValue.count + 1))
+            XCTAssertTrue(page.contains("  " + name + " "), entry.usage)
+            XCTAssertFalse(page.contains("  " + entry.group.rawValue + " "), entry.usage)
             XCTAssertTrue(CrispControlCLIModel.help(for: entry).hasPrefix("Usage:  crispctl " + entry.usage + "\n"), entry.usage)
         }
     }
@@ -136,7 +135,8 @@ final class CrispControlModelTests: XCTestCase {
             (["brightness", "boost", "set", "42"], "usage: crispctl brightness boost set <display> on|off"),
             (["brightness", "boost"],
              "usage: crispctl brightness boost get <display> or crispctl brightness boost set <display> on|off"),
-            (["display", "power", "42", "on"], "usage: crispctl display power <display> off")
+            (["display", "poweroff", "42", "now"], "usage: crispctl display poweroff <display>"),
+            (["display", "power", "42", "off"], "unknown command 'display power'; run 'crispctl display' for the display commands")
         ]
         for (arguments, message) in cases {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .failure(message), "\(arguments)")
@@ -161,9 +161,9 @@ final class CrispControlModelTests: XCTestCase {
             ["hdr", "set", "42", "on", "extra"],
             ["display", "toggle"], ["display", "toggle", ""], ["display", "reboot", "42"],
             ["display", "toggle", "42", "now"],
-            // Power is one-way by design: there is no on, standby or bare form.
-            ["display", "power", "42"], ["display", "power", "42", "on"], ["display", "power", "", "off"],
-            ["display", "power", "42", "off", "now"]
+            // Power is one-way by design: there is no on, standby or two-word form.
+            ["display", "poweroff"], ["display", "poweroff", ""], ["display", "poweroff", "42", "off"],
+            ["display", "power", "42", "off"]
         ]
         for arguments in cases {
             guard case .failure = CrispControlCLIModel.parse(arguments: arguments) else {

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ crispctl display list
 crispctl display connect <display>
 crispctl display disconnect <display>
 crispctl display toggle <display>
-crispctl display power <display> off
+crispctl display poweroff <display>
 
 crispctl brightness get <display>
 crispctl brightness set <display> <percent>
@@ -127,7 +127,7 @@ For example, `brightness boost get` returns `{"ok":true,"brightnessBoost":{"disp
 
 `display disconnect`, `connect` and `toggle` are the menu's Disconnect Display and Reconnect from a script, for a KVM desk or a button: Apple Silicon only, and a disconnect is refused when it would leave no active display. A display Crisp is holding disconnected is absent from every macOS display list, so `display list` still shows it with `connected:false` and its last-known id; use the uuid for it. Asking for the state a display is already in succeeds and changes nothing, and the reply comes after the window server has answered, which can take a few seconds.
 
-`display power <display> off` tells the monitor to switch itself off over DDC/CI (the MCCS power-mode control, VCP D6). It is one-way: a monitor that has switched itself off has no DDC/CI left to hear an on, so its power button brings it back, and whether a monitor honours the value is up to its firmware. The reply means the monitor took the write, nothing more. The built-in display is refused, since it has no DDC/CI; display sleep is the tool for that one.
+`display poweroff <display>` tells the monitor to switch itself off over DDC/CI (the MCCS power-mode control, VCP D6). It is one-way: a monitor that has switched itself off has no DDC/CI left to hear an on, so its power button brings it back, and whether a monitor honours the value is up to its firmware. The reply means the monitor took the write, nothing more. The built-in display is refused, since it has no DDC/CI; display sleep is the tool for that one.
 
 `hdr get` and `hdr set` work on the external displays Crisp shows its HDR toggle for; the built-in panel and externals without HDR modes are refused. `get` reads the live state. `set` writes once through the same path as the toggle and reports success only when the read-back agrees; when it cannot tell (a timeout, or the display going away mid-way) it says so and does not retry, so run `hdr get` before retrying. Exit codes are unchanged.
 


### PR DESCRIPTION
Every help table is now three aligned columns: command, arguments, description, so it is visible at a glance which commands take a display and what else they take. And the power command is one word, `display poweroff <display>`: there is no `on` and there cannot be one (a monitor that has switched itself off has no DDC/CI left to hear it), so `power <display> off` was two words saying one thing. Parser, tests and README follow. make check green.
