### PR TITLE
Re-assert True Tone after a full wake once an external is back

### DIFF
--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -23,6 +23,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// Coalesces the wake chain: a full system wake posts didWake and
     /// screensDidWake both, and one pass covers both.
     private var wakeTask: Task<Void, Never>?
+    /// Set by didWake only, never by screensDidWake: the True Tone re-assert below is
+    /// for a full system wake, where the external is still training its link when
+    /// macOS computes True Tone (issue #131); a display sleep never has that.
+    private var fullWakePending = false
     private var screenObserver: NSObjectProtocol?
     /// Debounces panel re-anchoring across the storm of screen-param changes a
     /// display connect/disconnect fires (see screenObserver).
@@ -152,7 +156,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 queue: .main
             ) { [weak self] _ in
                 // Delivered on `queue: .main`, so the main actor is current.
-                MainActor.assumeIsolated { self?.onWake?() }
+                MainActor.assumeIsolated {
+                    if name == NSWorkspace.didWakeNotification { self?.fullWakePending = true }
+                    self?.onWake?()
+                }
             })
         }
 
@@ -281,7 +288,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             guard let self, self.wakeTask == nil else { return }
             let dm = self.displayManager
             self.wakeTask = Task { @MainActor [weak self] in
-                defer { self?.wakeTask = nil }
+                defer {
+                    self?.wakeTask = nil
+                    self?.fullWakePending = false
+                }
                 // Give WindowServer 2 seconds to stabilize after wake before
                 // touching display state.
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
@@ -303,6 +313,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                         GammaService.shared.reapplyIfNeeded(for: display)
                         // Re-apply any custom resolution that macOS may have reset on wake
                         ResolutionService.shared.reapplySavedModeIfNeeded(for: display.displayID)
+                    }
+                    // Once an external is back after a full wake, toggle True Tone so macOS
+                    // recomputes it with that display present (issue #131). Once per wake,
+                    // at the first pass that lists an external; a desk with no external
+                    // never gets the tint blink.
+                    if self?.fullWakePending == true, dm.displays.contains(where: { !$0.isBuiltin }) {
+                        self?.fullWakePending = false
+                        if CoreBrightnessService.shared.reassertTrueTone() {
+                            Self.log.notice("True Tone re-asserted after wake with an external display back (issue #131)")
+                        }
                     }
                 }
                 // Re-establish EDR boost overlays (Metal drawables and HDR

--- a/Crisp/Services/CoreBrightnessService.swift
+++ b/Crisp/Services/CoreBrightnessService.swift
@@ -169,6 +169,24 @@ final class CoreBrightnessService: ObservableObject {
         trueToneEnabled = on
     }
 
+    /// After a full wake macOS computes True Tone against the built-in panel while an
+    /// external is still training its link, and the external keeps that tint until
+    /// True Tone is toggled (issue #131). This is that toggle, off and back on with a
+    /// beat between so CoreBrightness does not fold the two into nothing. The state
+    /// is read live, never from the published value, so a stale read cannot switch
+    /// True Tone on for someone who has it off. Returns whether it ran.
+    @discardableResult
+    func reassertTrueTone() -> Bool {
+        guard let c = trueToneClient, Self.boolCall(c, "supported"), Self.boolCall(c, "available"),
+              Self.boolCall(c, "enabled") else { return false }
+        Self.setBoolCall(c, "setEnabled:", false)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            Self.setBoolCall(c, "setEnabled:", true)
+            self.trueToneEnabled = true
+        }
+        return true
+    }
+
     // MARK: - ObjC runtime call helpers
 
     private nonisolated static func boolCall(_ obj: NSObject, _ name: String) -> Bool {


### PR DESCRIPTION
Fixes #131. After a full system sleep macOS brings True Tone up while the external is still training its link, so the tint is computed against the built-in panel alone and the external keeps it until True Tone is toggled by hand. per-hap-s confirmed the plan and that a display sleep never shows it.

The wake chain now does that toggle. `fullWakePending` is set by didWake only, never by screensDidWake. At the first of the chain's three passes that lists an external display, `CoreBrightnessService.reassertTrueTone()` reads supported, available and enabled live from CBTrueToneClient (never the published value, so it cannot switch True Tone on for someone who has it off), sets it off, and sets it back on 0.3 s later so CoreBrightness does not fold the two writes into nothing. Once per wake, one log line in the app category, and a desk with no external never gets the tint blink.

Not driven: a full wake with an external and True Tone on needs the lid open and a real sleep, which this session cannot do without sleeping the desk. Compiles, lints and tests green; the gate itself (didWake only, external present, True Tone on) is three guards read in the diff.
