### PR TITLE
Follow the dock: auto-disconnect the built-in panel, and rescue an all-dark Mac

### DIFF
--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -139,6 +139,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // it only starts the first time the menu panel is opened (its only other ref).
         _ = AutoBrightnessService.shared
 
+        // Auto dock switching, and the blackout rescue behind it. The rescue arms whether or not
+        // the rule is switched on: a display the window server has off with every screen dark is
+        // never a state to leave the Mac in, and a wake from a long standby can produce it.
+        AutoDisplaySwitchService.shared.start()
+
         // Re-establish Extra Brightness (EDR upscaling) for displays whose
         // toggle is persisted on. Deferred a beat so DisplayManager's initial
         // display list is populated.
@@ -158,8 +163,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 // Delivered on `queue: .main`, so the main actor is current.
                 MainActor.assumeIsolated {
                     if name == NSWorkspace.didWakeNotification { self?.fullWakePending = true }
+                    AutoDisplaySwitchService.shared.displaysDidWake()
                     self?.onWake?()
                 }
+            })
+        }
+
+        // The matching half: while asleep every display is out of the active list, which reads
+        // exactly like every screen having gone dark. Auto dock switching has to know the
+        // difference, or its rescue switches displays back on mid-sleep.
+        for name in [NSWorkspace.willSleepNotification, NSWorkspace.screensDidSleepNotification] {
+            wakeObservers.append(NSWorkspace.shared.notificationCenter.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { _ in
+                MainActor.assumeIsolated { AutoDisplaySwitchService.shared.displaysWillSleep() }
             })
         }
 
@@ -328,6 +347,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 // Re-establish EDR boost overlays (Metal drawables and HDR
                 // mode may not survive sleep).
                 BrightnessBoostService.shared.reapplyAll()
+                // Last: settle the built-in against what is actually attached now. Waking
+                // undocked must bring the panel back, waking docked must keep it away, and a
+                // wake that came up with nothing viewable at all must be rescued.
+                await AutoDisplaySwitchService.shared.evaluate()
             }
         }
     }

--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -120,21 +120,21 @@
     "%lld%%" : {
       "shouldTranslate" : false
     },
-    "Stays disconnected until you reconnect it here." : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "将保持断开，直到你在这里重新连接。"
-          }
-        }
-      }
-    },
     "×" : {
       "shouldTranslate" : false
     },
     "∞" : {
       "shouldTranslate" : false
+    },
+    "Absolute brightness ratio" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "绝对亮度比率"
+          }
+        }
+      }
     },
     "Activate" : {
       "localizations" : {
@@ -363,16 +363,6 @@
         }
       }
     },
-    "Absolute brightness ratio" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "绝对亮度比率"
-          }
-        }
-      }
-    },
     "Cancel" : {
       "localizations" : {
         "zh-Hans" : {
@@ -511,6 +501,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "合并亮度"
+          }
+        }
+      }
+    },
+    "Command Line Tool" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "命令行工具"
           }
         }
       }
@@ -692,6 +692,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "删除"
+          }
+        }
+      }
+    },
+    "Disconnect Built-in While Docked" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接上外接显示器时关闭内建屏幕"
           }
         }
       }
@@ -927,6 +937,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "为不报告音量支持的显示器强制启用音量控制。Crisp 可以设置音量，但无法读取当前音量。"
+          }
+        }
+      }
+    },
+    "From each panel's rated nits. HDR monitors report their HDR peak, so lower this if the built-in runs too bright" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "根据各屏幕的标称 nit 值计算。HDR 显示器报告的是其 HDR 峰值，若内建屏幕过亮请调低此值"
           }
         }
       }
@@ -1190,16 +1211,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登录时启动"
-          }
-        }
-      }
-    },
-    "Command Line Tool" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "命令行工具"
           }
         }
       }
@@ -1862,6 +1873,16 @@
         }
       }
     },
+    "Stays disconnected until you reconnect it here." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将保持断开，直到你在这里重新连接。"
+          }
+        }
+      }
+    },
     "Support Crisp" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -1930,6 +1951,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "蓝绿色"
+          }
+        }
+      }
+    },
+    "The built-in display switches off while an external is connected, and back on when the last is unplugged." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接外接显示器时自动关闭内建屏幕，拔除最后一台外接显示器后自动恢复。"
           }
         }
       }
@@ -2033,16 +2064,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新为当前值"
-          }
-        }
-      }
-    },
-    "From each panel's rated nits. HDR monitors report their HDR peak, so lower this if the built-in runs too bright" : {
-      "localizations" : {
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "根据各屏幕的标称 nit 值计算。HDR 显示器报告的是其 HDR 峰值，若内建屏幕过亮请调低此值"
           }
         }
       }

--- a/Crisp/Services/AutoDisplaySwitchService.swift
+++ b/Crisp/Services/AutoDisplaySwitchService.swift
@@ -89,8 +89,10 @@ final class AutoDisplaySwitchService: ObservableObject {
     /// ended in a rescue. Cleared when the externals change, which is the only evidence that the
     /// situation is different.
     private var blockedExternalsSignature: String?
-    /// The displays that were on the desk the last time it was demonstrably lit. What makes a
-    /// display believable afterwards: see `hasTrustedDisplay`.
+    /// The displays that were on the desk the last time it was demonstrably lit. Not what
+    /// makes a display believable any more — the ports decide that, see `hasTrustedDisplay` —
+    /// but still what tells an external that turned up during a blackout from one that was
+    /// already there, which the port count cannot, since it is a count and names no display.
     private var lastHealthyDisplayIDs: Set<CGDirectDisplayID> = []
     /// Displays that turned up while the desk was dark and were never part of a lit desk. macOS
     /// re-probes when the last display leaves and can bring a long-detached monitor back by
@@ -428,16 +430,21 @@ final class AutoDisplaySwitchService: ObservableObject {
 
     // MARK: - Topology helpers
 
-    /// Whether anything on the desk can be believed to be showing a picture: the built-in panel,
-    /// which is certainly attached, or a display that was already there when things last worked.
-    /// A display that appears mid-blackout and matches neither is not evidence of recovery — it
-    /// is the shape a resurrected detached monitor takes (see `suspectDisplayIDs`). With no
-    /// history yet (a fresh launch), any usable display has to be taken at face value.
+    /// Whether anything on the desk can be believed to be showing a picture: the built-in
+    /// panel, which is certainly attached, or an external while a port is carrying something.
+    /// That is exactly the count the blackout rescue reads (#112, #133), so the two agree by
+    /// construction rather than by two rules that have to be kept in step.
+    ///
+    /// It used to key on the display IDs seen on the last demonstrably lit desk, and that was
+    /// wrong twice over. macOS re-issues the ID at display sleep (2 -> 31, 34, 36, 38 on four
+    /// consecutive sleeps here), so the one monitor on a single-display desk stopped being
+    /// recognised the moment it slept: an ordinary display sleep read as a blackout and cost a
+    /// doomed enable that failed at 10 s. Keying on the UUID instead is not the fix either —
+    /// the phantom an undock leaves behind carries the same UUID as the real monitor, measured
+    /// with the dock out of the machine, so the watch trusted the phantom and never armed.
+    /// Identity cannot separate the two states; the ports can.
     private func hasTrustedDisplay() -> Bool {
-        let usable = toggle.viewableActiveDisplays()
-        guard !usable.isEmpty else { return false }
-        guard !lastHealthyDisplayIDs.isEmpty else { return true }
-        return usable.contains { CGDisplayIsBuiltin($0) != 0 || lastHealthyDisplayIDs.contains($0) }
+        toggle.phantomAwareActiveDisplayCount() > 0
     }
 
     /// Online, real external displays: what "docked" means here.

--- a/Crisp/Services/AutoDisplaySwitchService.swift
+++ b/Crisp/Services/AutoDisplaySwitchService.swift
@@ -1,0 +1,541 @@
+import Foundation
+import CoreGraphics
+import AppKit
+import os
+
+/// Auto dock switching: keeps the built-in panel's connected state a function of whether an
+/// external display is attached, and rescues the machine when every screen ends up dark.
+///
+/// Two independent parts, on purpose:
+///
+/// 1. **The rule** (opt-in, `SettingsService.autoBuiltinFollowsExternal`): an external is
+///    online -> disconnect the built-in, so a docked laptop drives the monitor alone; the last
+///    external goes away -> reconnect the built-in. Doing it by hand through the menu is the
+///    same two calls, so this only removes the two clicks per dock/undock. Reconnecting the
+///    panel by hand hands it back to the user until the next dock (see `userOwnsBuiltin`):
+///    the rule automates the dock, it does not police the panel.
+///
+/// 2. **The rescue** (always on): re-enables window-server-disabled displays when nothing
+///    viewable is left. `PhysicalDisplayToggleService.restoreIfNoActiveDisplay` already does
+///    this, but only for displays still in the `disconnected` record set, which a multi-day
+///    standby can outlive. This one works from remembered display IDs instead.
+///
+///    It is armed by an evaluation, never by a standing timer: the only thing it polls is a
+///    desk that is already dark, where no further reconfiguration callback need arrive to say
+///    whether it got better, and that watch is bounded at both ends. Sleep is excluded outright
+///    — a sleeping Mac has no active displays by definition, and rescuing into that state
+///    switched the built-in back on mid-sleep, so it was already lit at the next wake with
+///    nothing left for the rule to disconnect (observed live).
+///
+/// Everything here is a no-op on Intel, where the underlying disconnect API does not perform a
+/// true disconnect (see PhysicalDisplayToggleService.isSupported).
+@MainActor
+final class AutoDisplaySwitchService: ObservableObject {
+    static let shared = AutoDisplaySwitchService()
+    // Deliberately touches nothing: SettingsService's own loadAll() reaches this singleton
+    // through its didSet, so an init that read SettingsService.shared back would deadlock on
+    // its half-built instance. The setting is read inside evaluate(), which always runs later.
+    private init() {}
+
+    /// Every state change this service makes is logged: dock switching and the rescue act on
+    /// their own, usually while nobody is watching, so the unified log is the only way to see
+    /// afterwards what happened and why (the capture the project asks for in bug reports).
+    private static let log = Logger(subsystem: "com.crisp.app", category: "autoswitch")
+
+    private var toggle: PhysicalDisplayToggleService { .shared }
+
+    // MARK: - Tuning
+
+    /// Debounce after a display change. A dock plug produces a burst of reconfigurations and
+    /// the arrangement keeps moving for a second or two; acting on the first event disconnects
+    /// the built-in while the external is still training its link.
+    private static let settleDelay: TimeInterval = 2.5
+    /// How long the desk must stay dark, awake, before a rescue. Displays leave the active list
+    /// during ordinary transitions (a mode switch, a dock renegotiating, a softReconnect blink),
+    /// so a moment of "nothing viewable" is not yet a blackout.
+    private static let blackoutConfirm: TimeInterval = 4
+    /// Cadence and lifetime of the blackout watch. It only ever runs while the desk is dark, and
+    /// gives up on its own: nothing here is a standing timer.
+    private static let blackoutPoll: TimeInterval = 1
+    private static let blackoutWatchLimit: TimeInterval = 30
+    /// Displays come back over several seconds after a wake, in whatever order the hardware
+    /// manages. Nothing is judged inside this window.
+    private static let wakeGrace: TimeInterval = 6
+    /// After a rescue the rule stands down this long, then re-evaluates by itself.
+    private static let rescueCooloff: TimeInterval = 30
+    /// A rescue this soon after the rule's own disconnect means the disconnect is what darkened
+    /// the desk: the external enumerates but shows no picture (a half-dead dock link), which is
+    /// indistinguishable from a working one on this side. A clock is the wrong guard for that,
+    /// since it comes back to the same conclusion; the rule waits for the displays to change.
+    private static let ruleCausedWindow: TimeInterval = 90
+
+    // MARK: - State
+
+    private var pending: Task<Void, Never>?
+    private var blackoutWatch: Task<Void, Never>?
+    /// Tells one watch from the next, so a watch that ends while a later one is already running
+    /// clears only its own handle.
+    private var blackoutWatchGeneration = 0
+    private var running = false
+    private var suppressRuleUntil: Date = .distantPast
+    /// Set between a sleep notification and the next wake. Rescuing in this window is what put
+    /// the built-in back on mid-sleep; see the type doc.
+    private var displaysAsleep = false
+    private var wakeGraceUntil: Date = .distantPast
+    /// When the rule last took the built-in out of the layout, to tell a blackout it caused from
+    /// one it merely walked into.
+    private var lastRuleDisconnect: Date = .distantPast
+    /// External topology the rule stands down for because disconnecting the built-in against it
+    /// ended in a rescue. Cleared when the externals change, which is the only evidence that the
+    /// situation is different.
+    private var blockedExternalsSignature: String?
+    /// The displays that were on the desk the last time it was demonstrably lit. What makes a
+    /// display believable afterwards: see `hasTrustedDisplay`.
+    private var lastHealthyDisplayIDs: Set<CGDirectDisplayID> = []
+    /// Displays that turned up while the desk was dark and were never part of a lit desk. macOS
+    /// re-probes when the last display leaves and can bring a long-detached monitor back by
+    /// itself (observed live), and such a display is indistinguishable from a real one through
+    /// CoreGraphics: EDID, a full mode list, an NSScreen with a name. The rule must not treat
+    /// one as the external it is docking to, or it disconnects the built-in against a screen
+    /// that does not exist. Dropped as soon as the display leaves the online list.
+    private var suspectDisplayIDs: Set<CGDirectDisplayID> = []
+    /// Set when the user reconnects the built-in panel themselves while docked: from then on
+    /// their choice owns the panel and the rule stands down, so a deliberate "no, I want both
+    /// screens" is not undone two seconds later. Cleared by an actual dock event — the externals
+    /// going away and coming back — or by the user disconnecting the panel again.
+    ///
+    /// Deliberately not keyed on which externals are attached, which is what it used to be:
+    /// plugging a second monitor into a desk you are already docked to is not a new decision to
+    /// make, but keying on the set made it one, and connecting that monitor took away a panel
+    /// the user had just asked for.
+    private var userOwnsBuiltin = false
+    /// Whether the last evaluation found an external attached. The override above is dropped on
+    /// the transition out of that state, not while it holds: an undock is an event, and
+    /// re-deciding the panel every time the display list is re-read is how a standing choice
+    /// gets undone by something that never happened.
+    private var wasDocked = false
+    /// Set when the user disconnects an external through Crisp's own menu, and consumed by the
+    /// next evaluation. That empties the external set exactly as unplugging the dock does, and
+    /// the rule cannot tell the two apart from the display list alone — but Crisp was told, so
+    /// it does not have to guess.
+    private var userRemovedExternal = false
+
+    /// Last-known IDs of real displays, and whether each was the built-in. The rescue's only
+    /// usable input in a full blackout: verified live on macOS 26.6 that once the last real
+    /// display leaves, SLSGetDisplayList shrinks to the placeholder alone, so at the exact
+    /// moment the rescue is needed the window server can no longer name the display to switch
+    /// back on. A stale ID still works (SLSConfigureDisplayEnabled honours it for attached
+    /// hardware; detached hardware just fails the transaction and the loop moves on), so
+    /// remember them while the lists are still honest. Persisted, so a relaunch into the dark
+    /// has them too.
+    private var knownDisplays: [CGDirectDisplayID: Bool] = [:]
+    private static let knownDisplaysKey = "crisp.autoswitch.knownDisplays"
+
+    var isRuleEnabled: Bool { toggle.isSupported && SettingsService.shared.autoBuiltinFollowsExternal }
+
+    /// Whether to offer the rule at all: Apple Silicon, and a Mac with a built-in panel to
+    /// switch. Read from the full display list, so a built-in that is currently switched off
+    /// still counts (that is the state the setting is most likely to be changed from).
+    var isAvailable: Bool {
+        toggle.isSupported
+            && toggle.allDisplaysIncludingDisabled().contains { CGDisplayIsBuiltin($0) != 0 }
+    }
+
+    /// True when the rule, not a stored record, decides whether the built-in is connected.
+    /// `PhysicalDisplayToggleService.reconcile` checks this so it never re-applies a stale
+    /// built-in disconnect to a Mac that woke up undocked.
+    var ownsBuiltinState: Bool { isRuleEnabled }
+
+    // MARK: - Entry points
+
+    /// First evaluation of the session. Called once at launch.
+    func start() {
+        evaluateSoon()
+    }
+
+    /// Coalesces the reconfiguration burst a plug, unplug, wake or lid change produces into one
+    /// evaluation, `settleDelay` after the last of them.
+    func evaluateSoon() {
+        // Live displays while we still believe the machine is asleep means a wake notification
+        // never reached us; treat it as the wake rather than staying stood down on a stale flag.
+        // Safe because system sleep empties the active list outright on this path (that is the
+        // very state the sleep flag exists for), so this cannot fire mid-sleep.
+        if displaysAsleep, !toggle.viewableActiveDisplays().isEmpty {
+            displaysDidWake()
+            return
+        }
+        scheduleEvaluate(after: Self.settleDelay)
+    }
+
+    /// One pending evaluation at a time, always the latest. Also how the rule comes back on its
+    /// own after a stand-down: nothing else would necessarily wake it, since the display state
+    /// it is waiting on is not changing.
+    private func scheduleEvaluate(after delay: TimeInterval) {
+        guard toggle.isSupported else { return }
+        pending?.cancel()
+        pending = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(max(delay, 0.1) * 1_000_000_000))
+            guard !Task.isCancelled, let self else { return }
+            await self.evaluate()
+        }
+    }
+
+    /// The machine or its screens are going to sleep: every display leaves the active list, and
+    /// by enumeration alone that is indistinguishable from every screen having gone dark. Stop
+    /// judging until they are back.
+    func displaysWillSleep() {
+        displaysAsleep = true
+        pending?.cancel(); pending = nil
+        blackoutWatch?.cancel(); blackoutWatch = nil
+    }
+
+    /// Woken: give the displays their grace window to arrive, then evaluate once.
+    func displaysDidWake() {
+        displaysAsleep = false
+        wakeGraceUntil = Date().addingTimeInterval(Self.wakeGrace)
+        scheduleEvaluate(after: Self.wakeGrace + Self.settleDelay)
+    }
+
+    /// The setting changed: apply it now rather than at the next display event, so switching it
+    /// on while already docked disconnects the built-in there and then.
+    func settingDidChange() {
+        userOwnsBuiltin = false
+        evaluateSoon()
+    }
+
+    /// The user reconnected a display from the menu. If that's the built-in, it is a deliberate
+    /// override of the rule; respect it until the next dock event.
+    func userDidReconnect(uuid: String) {
+        guard isRuleEnabled, isBuiltin(uuid: uuid) else { return }
+        userOwnsBuiltin = true
+    }
+
+    /// The user disconnected a display from the menu. The built-in: they have handed the panel
+    /// back, so the rule takes it over from here. An external: this is not an undock, however
+    /// much it looks like one from the display list, and the rule must not treat the display
+    /// coming back as a fresh dock.
+    func userDidDisconnect(uuid: String) {
+        guard isBuiltin(uuid: uuid) else {
+            userRemovedExternal = true
+            return
+        }
+        userOwnsBuiltin = false
+    }
+
+    // MARK: - The rule
+
+    func evaluate() async {
+        guard toggle.isSupported, !running, !toggle.isBlinking, !displaysAsleep else { return }
+        // Displays are still arriving after a wake; come back once they have settled.
+        guard Date() >= wakeGraceUntil else {
+            scheduleEvaluate(after: wakeGraceUntil.timeIntervalSinceNow + Self.settleDelay)
+            return
+        }
+        running = true
+        defer { running = false }
+
+        rememberDisplays()
+
+        // Nothing believable on the desk. Not acted on here: a display leaving is ordinary
+        // mid-transition, and a blackout is only a blackout once it holds. The watch confirms it,
+        // whatever the setting says, because no screen is never a state to leave a Mac in.
+        if !hasTrustedDisplay() {
+            startBlackoutWatch()
+            return
+        }
+        blackoutWatch?.cancel()
+        blackoutWatch = nil
+        let usable = toggle.viewableActiveDisplays()
+        lastHealthyDisplayIDs = Set(usable)
+        suspectDisplayIDs.formIntersection(toggle.onlineDisplayIDs())
+
+        guard isRuleEnabled else { return }
+        guard Date() >= suppressRuleUntil else {
+            // Standing down on a clock: come back when it runs out, since the display state the
+            // rule is waiting on will not change by itself and nothing else would wake it.
+            scheduleEvaluate(after: suppressRuleUntil.timeIntervalSinceNow + 0.5)
+            return
+        }
+
+        let externals = currentExternals()
+        let docked = !externals.isEmpty
+        let undocked = wasDocked && !docked
+        let byHand = userRemovedExternal
+        userRemovedExternal = false
+        wasDocked = docked
+        if !docked {
+            // Undocked. The panel must come back, whether it was this rule that took it away,
+            // a manual disconnect, or a window-server state that outlived the last session.
+            // The desk the user made their choice on is gone, so the rule takes the panel back
+            // over at the next dock — but only for an undock that actually happened. Switching
+            // the external off from Crisp's own menu empties this list identically, and taking
+            // that as an undock is how connecting that display again took away a panel the user
+            // had just asked for.
+            if undocked, !byHand {
+                userOwnsBuiltin = false
+            }
+            blockedExternalsSignature = nil
+            if let builtin = disabledBuiltinID() {
+                Self.log.notice("Undocked: bringing the built-in panel back")
+                await bringBack(builtin)
+            }
+        } else {
+            guard !userOwnsBuiltin else { return }
+            guard blockedExternalsSignature != signature(of: externals) else { return }
+            // Docked. Take the panel out of the layout, but never as the last screen standing.
+            guard let builtin = onlineBuiltinID(),
+                  !toggle.wouldLeaveNoActiveDisplay(builtin) else { return }
+            let info = DisplayManagerAccessor.shared.displays.first { $0.displayID == builtin }
+                ?? DisplayInfo(displayID: builtin)
+            Self.log.notice("Docked (\(externals.count, privacy: .public) external(s)): disconnecting the built-in panel")
+            lastRuleDisconnect = Date()
+            let result = await toggle.disconnect(info)
+            if case .failure(let error) = result {
+                Self.log.error("Built-in disconnect failed: \(error.description, privacy: .public)")
+            }
+        }
+    }
+
+    // MARK: - Blackout watch
+
+    /// Armed by an evaluation that found nothing viewable, and by nothing else. In the dark a
+    /// further reconfiguration callback is exactly what cannot be relied on, so this is the one
+    /// state worth polling for — and it is bounded at both ends: it stops the moment a screen is
+    /// back, when the machine sleeps, once it has rescued, or after `blackoutWatchLimit`. The
+    /// app holds no timer at any other time.
+    private func startBlackoutWatch() {
+        // Nothing to switch back on means nothing to watch for: a Mac genuinely running headless
+        // (a virtual display only) must not be polled into a rescue loop.
+        guard blackoutWatch == nil, !rescueCandidates().isEmpty else { return }
+        blackoutWatchGeneration += 1
+        let generation = blackoutWatchGeneration
+        blackoutWatch = Task { [weak self] in
+            var darkFor: TimeInterval = 0
+            var elapsed: TimeInterval = 0
+            while !Task.isCancelled, elapsed < Self.blackoutWatchLimit {
+                try? await Task.sleep(nanoseconds: UInt64(Self.blackoutPoll * 1_000_000_000))
+                guard !Task.isCancelled, let self else { return }
+                elapsed += Self.blackoutPoll
+                // Asleep, or still inside the post-wake window: the display list means nothing
+                // yet, so the confirmation starts over rather than counting this second.
+                guard !self.displaysAsleep, Date() >= self.wakeGraceUntil else {
+                    darkFor = 0
+                    continue
+                }
+                guard !self.hasTrustedDisplay() else { break }
+                darkFor += Self.blackoutPoll
+                guard darkFor >= Self.blackoutConfirm, !self.running, !self.toggle.isBlinking
+                else { continue }
+                self.running = true
+                await self.rescue()
+                self.running = false
+                break
+            }
+            if let self, self.blackoutWatchGeneration == generation { self.blackoutWatch = nil }
+        }
+    }
+
+    /// Brings a screen back when nothing viewable is left: the built-in first, since it is the
+    /// one display that is certainly attached, then every other switched-off display. Re-enabling
+    /// fires a CG reconfiguration, so DisplayManager refreshes itself and
+    /// `PhysicalDisplayToggleService.reconcile` drops the records that came back.
+    private func rescue() async {
+        let ruleCaused = Date().timeIntervalSince(lastRuleDisconnect) < Self.ruleCausedWindow
+        Self.log.error("""
+            Every screen dark for \(Self.blackoutConfirm, privacy: .public)s with \
+            \(self.toggle.disabledDisplayIDs().count, privacy: .public) display(s) switched off \
+            at the window server: re-enabling
+            """)
+
+        // On a Mac with a built-in panel, that panel is the whole rescue: it is the one display
+        // certainly still attached, while re-enabling a remembered external can produce a screen
+        // that is not physically there and hides the blackout behind it. Desktops have no such
+        // anchor, so there the remembered IDs are all there is to try.
+        let candidates = rescueCandidates()
+        let builtins = candidates.filter { isKnownBuiltin($0) }
+        let targets = builtins.isEmpty ? candidates : builtins
+
+        for attempt in 0..<3 {
+            for id in targets {
+                await toggle.forceEnable(displayID: id)
+                // Enumeration lags the transaction; a short wait here is what lets the loop
+                // stop at the first display that actually comes back instead of switching
+                // every remembered one on.
+                for _ in 0..<10 where !hasTrustedDisplay() {
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                }
+                if hasTrustedDisplay() { break }
+            }
+            if hasTrustedDisplay() { break }
+            if attempt < 2 { try? await Task.sleep(nanoseconds: 1_000_000_000) }
+        }
+
+        // Whatever else is online now that was never part of a lit desk turned up during the
+        // blackout on its own. Mark it, so the rule does not dock the built-in away against it.
+        // The mark lasts until that display goes offline: a monitor genuinely plugged in during
+        // a blackout gets caught by this too, and a replug is what clears it.
+        suspectDisplayIDs.formUnion(toggle.viewableActiveDisplays().filter {
+            CGDisplayIsBuiltin($0) == 0 && !lastHealthyDisplayIDs.contains($0) && !targets.contains($0)
+        })
+
+        toggle.reconcile()
+        if hasTrustedDisplay() {
+            Self.log.notice("""
+                Rescue done: \(self.toggle.viewableActiveDisplays().count, privacy: .public) \
+                display(s) online, \(self.suspectDisplayIDs.count, privacy: .public) of them unverifiable
+                """)
+        } else {
+            Self.log.fault("Rescue could not bring a display the user can be shown back")
+        }
+
+        if ruleCaused {
+            // The rule's own disconnect preceded this: whatever it left running shows no
+            // picture. Waiting out a clock would only reach the same conclusion, so stand down
+            // until the external displays themselves change.
+            blockedExternalsSignature = signature(of: currentExternals())
+            Self.log.notice("Blackout followed the rule's own disconnect: standing down until the displays change")
+        } else {
+            suppressRuleUntil = Date().addingTimeInterval(Self.rescueCooloff)
+            scheduleEvaluate(after: Self.rescueCooloff + Self.settleDelay)
+        }
+
+        await restoreRememberedModes()
+    }
+
+    /// Reconnects the built-in through the normal path (so its record is dropped), falling back
+    /// to a direct enable for a window-server state with no record behind it.
+    private func bringBack(_ builtinID: CGDirectDisplayID) async {
+        let builtinUUID = toggle.displayUUID(for: builtinID)
+        if toggle.isDisconnected(uuid: builtinUUID) {
+            _ = await toggle.reconnect(uuid: builtinUUID)
+        } else {
+            await toggle.forceEnable(displayID: builtinID)
+        }
+        _ = await toggle.verifyBackOnline(uuid: builtinUUID, timeout: 3.0)
+        await restoreRememberedModes()
+    }
+
+    /// A display that has just been switched back on re-enumerates its modes and can land on the
+    /// window server's default rather than the resolution the user chose (the HiDPI scaled mode
+    /// they set up Crisp for in the first place). The saved-mode restore is the same one the
+    /// wake path runs, and a no-op when the display is already where it belongs.
+    private func restoreRememberedModes() async {
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+        for id in toggle.viewableActiveDisplays() {
+            ResolutionService.shared.reapplySavedModeIfNeeded(for: id)
+        }
+    }
+
+    // MARK: - Topology helpers
+
+    /// Whether anything on the desk can be believed to be showing a picture: the built-in panel,
+    /// which is certainly attached, or a display that was already there when things last worked.
+    /// A display that appears mid-blackout and matches neither is not evidence of recovery — it
+    /// is the shape a resurrected detached monitor takes (see `suspectDisplayIDs`). With no
+    /// history yet (a fresh launch), any usable display has to be taken at face value.
+    private func hasTrustedDisplay() -> Bool {
+        let usable = toggle.viewableActiveDisplays()
+        guard !usable.isEmpty else { return false }
+        guard !lastHealthyDisplayIDs.isEmpty else { return true }
+        return usable.contains { CGDisplayIsBuiltin($0) != 0 || lastHealthyDisplayIDs.contains($0) }
+    }
+
+    /// Online, real external displays: what "docked" means here.
+    private func currentExternals() -> [CGDirectDisplayID] {
+        toggle.viewableActiveDisplays().filter {
+            CGDisplayIsBuiltin($0) == 0 && !suspectDisplayIDs.contains($0)
+        }
+    }
+
+    /// Order-independent identity for a set of externals, so a stand-down survives an ID
+    /// reshuffle but not an actual change of desk.
+    private func signature(of ids: [CGDirectDisplayID]) -> String {
+        ids.map { toggle.displayUUID(for: $0) }.sorted().joined(separator: "|")
+    }
+
+    private func onlineBuiltinID() -> CGDirectDisplayID? {
+        toggle.viewableActiveDisplays().first { CGDisplayIsBuiltin($0) != 0 }
+    }
+
+    /// The built-in panel while the window server has it switched off. Read from the full
+    /// (including disabled) list rather than from the `disconnected` records: after a long
+    /// standby, or a session that ended uncleanly, the window-server state can outlive them.
+    private func disabledBuiltinID() -> CGDirectDisplayID? {
+        toggle.disabledDisplayIDs().first { CGDisplayIsBuiltin($0) != 0 }
+    }
+
+    /// Whether an ID is the built-in panel, trusting the remembered flag when CoreGraphics can
+    /// no longer say (it answers with garbage for an ID the window server has forgotten, which
+    /// is the state a blackout leaves every real display in).
+    private func isKnownBuiltin(_ id: CGDirectDisplayID) -> Bool {
+        if knownDisplays.isEmpty { knownDisplays = loadKnownDisplays() }
+        return CGDisplayIsBuiltin(id) != 0 || knownDisplays[id] == true
+    }
+
+    /// Records every real display the window server can currently name, so the rescue has
+    /// something to aim at once it can no longer name any (see knownDisplays).
+    private func rememberDisplays() {
+        var known = knownDisplays.isEmpty ? loadKnownDisplays() : knownDisplays
+        var changed = false
+        for id in toggle.allDisplaysIncludingDisabled() {
+            // Skip the placeholder and any virtual display: re-enabling those rescues nothing.
+            guard CGDisplayVendorNumber(id) <= 0xFFFF, CGDisplayModelNumber(id) <= 0xFFFF,
+                  !VirtualDisplayService.shared.isVirtualDisplay(id) else { continue }
+            let builtin = CGDisplayIsBuiltin(id) != 0
+            if known[id] != builtin { known[id] = builtin; changed = true }
+        }
+        knownDisplays = known
+        if changed {
+            UserDefaults.standard.set(
+                Dictionary(uniqueKeysWithValues: known.map { (String($0.key), $0.value) }),
+                forKey: Self.knownDisplaysKey)
+        }
+    }
+
+    private func loadKnownDisplays() -> [CGDirectDisplayID: Bool] {
+        let stored = UserDefaults.standard.dictionary(forKey: Self.knownDisplaysKey) as? [String: Bool] ?? [:]
+        return Dictionary(uniqueKeysWithValues: stored.compactMap { key, value in
+            CGDirectDisplayID(key).map { ($0, value) }
+        })
+    }
+
+    /// Displays worth switching back on, built-in first (it is the one display certainly still
+    /// attached). Three sources, because in a blackout the first two can both come up empty:
+    /// what the window server reports as off, the IDs stored in the disconnect records, and the
+    /// remembered real displays. Anything already online is dropped; a stale ID for hardware
+    /// that is genuinely gone simply fails its transaction.
+    private func rescueCandidates() -> [CGDirectDisplayID] {
+        if knownDisplays.isEmpty { knownDisplays = loadKnownDisplays() }
+        let online = toggle.onlineDisplayIDs()
+        var builtin: [CGDirectDisplayID] = []
+        var rest: [CGDirectDisplayID] = []
+        var seen: Set<CGDirectDisplayID> = []
+        func add(_ id: CGDirectDisplayID, isBuiltin: Bool) {
+            guard !online.contains(id), seen.insert(id).inserted else { return }
+            if isBuiltin { builtin.append(id) } else { rest.append(id) }
+        }
+        for id in toggle.disabledDisplayIDs() {
+            add(id, isBuiltin: CGDisplayIsBuiltin(id) != 0 || knownDisplays[id] == true)
+        }
+        for record in toggle.disconnected {
+            // CGDisplayIsBuiltin answers with garbage for an ID the window server has forgotten,
+            // so the remembered flag is what decides the order here.
+            add(record.displayID, isBuiltin: knownDisplays[record.displayID] == true)
+        }
+        for (id, isBuiltin) in knownDisplays {
+            add(id, isBuiltin: isBuiltin)
+        }
+        return builtin + rest
+    }
+
+    /// Whether a UUID names the built-in panel, resolved against the full display list so the
+    /// answer does not depend on the display being online at this instant: a just-reconnected
+    /// display takes a moment to appear in the online list, and the manual override has to be
+    /// recorded before the next evaluation, not after.
+    private func isBuiltin(uuid: String) -> Bool {
+        guard let id = toggle.allDisplaysIncludingDisabled().first(where: {
+            toggle.displayUUID(for: $0) == uuid
+        }) else { return false }
+        return CGDisplayIsBuiltin(id) != 0
+    }
+}

--- a/Crisp/Services/DisplayManager.swift
+++ b/Crisp/Services/DisplayManager.swift
@@ -292,6 +292,9 @@ class DisplayManager: ObservableObject {
         // A physical unplug bypasses disconnect()'s last-screen guard: internal disabled via
         // Crisp + external cable pulled = zero active displays, all black. Bring one back.
         PhysicalDisplayToggleService.shared.restoreIfNoActiveDisplay()
+        // Dock plugged / pulled, lid opened, display woken: let the auto-switch rule settle the
+        // built-in panel's state once the reconfiguration burst has died down.
+        AutoDisplaySwitchService.shared.evaluateSoon()
 
         // Keep the built-in brightness observer pointed at the current built-in so the
         // slider tracks system brightness changes (keys, auto-brightness) live.

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -197,11 +197,13 @@ final class PhysicalDisplayToggleService: ObservableObject {
     }
 
     /// The count the blackout rescue reads: physicalActiveDisplayCount with the #112
-    /// phantoms taken out. Read by restoreIfNoActiveDisplay and nowhere else, on
-    /// purpose: the Disconnect row and the launch re-apply keep the plain count, so a
-    /// wrong answer from the ports on a desk shape this has never seen can only make
-    /// the rescue fire, which re-enables a display Crisp itself turned off, and can
-    /// never hide a row or refuse a remembered disconnect.
+    /// phantoms taken out. Read by the rescue paths only, on purpose: by
+    /// restoreIfNoActiveDisplay, and by the dock rule's blackout watch, which is the
+    /// same kind of reader and is held to the same bargain. The Disconnect row and the
+    /// launch re-apply keep the plain count, so a wrong answer from the ports on a desk
+    /// shape this has never seen can only make a rescue fire, which re-enables a display
+    /// Crisp itself turned off, and can never hide a row or refuse a remembered
+    /// disconnect.
     ///
     /// The shape filter in viewableActiveDisplays catches an entry with nothing behind
     /// it. It cannot catch the third kind, from #112: after an undock while asleep,
@@ -239,7 +241,7 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// The info dictionary costs 2.5 to 8 ms per display, so it is read only once the
     /// ports say fewer than the externals lit, which is the phantom state or a
     /// DisplayLink desk. An ordinary desk never pays for it.
-    private func phantomAwareActiveDisplayCount() -> Int {
+    func phantomAwareActiveDisplayCount() -> Int {
         let viewable = viewableActiveDisplays()
         let externals = viewable.filter { CGDisplayIsBuiltin($0) != 1 }
         let portCap = liveDisplayPortCount()

--- a/Crisp/Services/PhysicalDisplayToggleService.swift
+++ b/Crisp/Services/PhysicalDisplayToggleService.swift
@@ -151,7 +151,7 @@ final class PhysicalDisplayToggleService: ObservableObject {
 
     /// All display IDs known to the window server, INCLUDING ones disabled via
     /// `SLSConfigureDisplayEnabled` (which `CGGetOnlineDisplayList` omits).
-    private func allDisplaysIncludingDisabled() -> [CGDirectDisplayID] {
+    func allDisplaysIncludingDisabled() -> [CGDirectDisplayID] {
         var count: UInt32 = 0
         guard SLSGetDisplayList(0, nil, &count) == .success, count > 0 else { return [] }
         var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
@@ -168,7 +168,10 @@ final class PhysicalDisplayToggleService: ObservableObject {
         viewableActiveDisplays().count
     }
 
-    private func viewableActiveDisplays() -> [CGDirectDisplayID] {
+    /// Online, real, viewable physical displays: what the user can actually see. Also
+    /// what the dock rule reads, and it must stay the same test as the count's: a display
+    /// that does not count as a screen here cannot count as an external there.
+    func viewableActiveDisplays() -> [CGDirectDisplayID] {
         var count: UInt32 = 0
         guard CGGetActiveDisplayList(0, nil, &count) == .success, count > 0 else { return [] }
         var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
@@ -295,6 +298,29 @@ final class PhysicalDisplayToggleService: ObservableObject {
             }
         }
         return nodes == 0 ? nil : asserted
+    }
+
+    /// Displays the window server knows but has switched off (ours or another app's).
+    func disabledDisplayIDs() -> [CGDirectDisplayID] {
+        let online = onlineDisplayIDs()
+        return allDisplaysIncludingDisabled().filter { !online.contains($0) }
+    }
+
+    /// True while a softReconnect blink is toggling a framebuffer. The display list is
+    /// legitimately short (sometimes empty) for ~1s; nothing else may act on it meanwhile.
+    var isBlinking: Bool { !softReconnectInFlight.isEmpty }
+
+    /// Stable identity for a display ID, exposed for the auto-switch rule.
+    func displayUUID(for displayID: CGDirectDisplayID) -> String { uuid(for: displayID) }
+
+    /// Re-enables one display directly, bypassing the `disconnected` bookkeeping. The rescue
+    /// path uses it for displays the window server has off with no matching record (a state a
+    /// crash, a relaunch, or a wake from a multi-day standby can leave behind).
+    @discardableResult
+    func forceEnable(displayID: CGDirectDisplayID) async -> Bool {
+        guard isSupported else { return false }
+        guard case .success = await setEnabled(true, displayID: displayID) else { return false }
+        return true
     }
 
     private func uuid(for displayID: CGDirectDisplayID) -> String {
@@ -641,7 +667,7 @@ final class PhysicalDisplayToggleService: ObservableObject {
 
     /// Display IDs currently online. SLS-disabled displays are omitted here (see
     /// allDisplaysIncludingDisabled), so "online" doubles as the enabled check.
-    private func onlineDisplayIDs() -> Set<CGDirectDisplayID> {
+    func onlineDisplayIDs() -> Set<CGDirectDisplayID> {
         var count: UInt32 = 0
         CGGetOnlineDisplayList(0, nil, &count)
         var ids = [CGDirectDisplayID](repeating: 0, count: Int(count))
@@ -653,7 +679,7 @@ final class PhysicalDisplayToggleService: ObservableObject {
     /// `timeout` seconds. A successful SLSConfigureDisplayEnabled transaction is NOT proof
     /// of recovery: around sleep transitions it reports success while the display stays
     /// disabled (verified live in clamshell). Only enumeration counts.
-    private func verifyBackOnline(uuid displayUUID: String, timeout: TimeInterval = 1.0) async -> Bool {
+    func verifyBackOnline(uuid displayUUID: String, timeout: TimeInterval = 1.0) async -> Bool {
         for _ in 0..<max(Int(timeout * 10), 1) {
             if let id = allDisplaysIncludingDisabled().first(where: { uuid(for: $0) == displayUUID }),
                onlineDisplayIDs().contains(id) { return true }
@@ -765,10 +791,22 @@ final class PhysicalDisplayToggleService: ObservableObject {
         }
         // A blink (softReconnect) puts its own display back online on purpose, and a
         // reconnect in flight is the user (or the restore path) asking for exactly that.
+        // Waking undocked (the dock pulled while asleep) must bring the built-in back, and
+        // re-applying a stale disconnect here is how both screens end up dark. The
+        // last-screen guard inside the re-apply is not enough by itself: a transient second
+        // display during the wake satisfies it. So while auto dock switching owns the
+        // built-in, leave its record alone unless a real external is actually up; if one
+        // arrives later, the rule re-disconnects then.
+        let holdBuiltin = AutoDisplaySwitchService.shared.ownsBuiltinState
+            && !viewableActiveDisplays().contains { CGDisplayIsBuiltin($0) == 0 }
+        let builtinUUIDs = holdBuiltin
+            ? Set(onlineIDs.filter { CGDisplayIsBuiltin($0) != 0 }.map { uuid(for: $0) })
+            : []
         let pending = resurfaced.filter {
             !reapplyInFlight.contains($0.uuid)
                 && !softReconnectInFlight.contains($0.uuid)
                 && !reconnectInFlight.contains($0.uuid)
+                && !builtinUUIDs.contains($0.uuid)
         }
         guard !pending.isEmpty else { return }
         let leaving = Set(onlineIDs.filter { id in

--- a/Crisp/Services/SettingsService.swift
+++ b/Crisp/Services/SettingsService.swift
@@ -63,6 +63,7 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
         static let brightnessKeyTarget    = "crisp.brightnessKeyTarget"
         static let brightnessKeySelected  = "crisp.brightnessKeySelectedDisplays"
         static let hidpiShortcut          = "crisp.hidpiShortcut"
+        static let autoBuiltinFollowsExternal = "crisp.autoBuiltinFollowsExternal"
         // Per-display keys use prefix + displayID
         static let brightnessPrefix       = "crisp.brightness_"
         static let contrastPrefix         = "crisp.contrast_"
@@ -134,6 +135,16 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
             } else {
                 defaults.removeObject(forKey: Keys.hidpiShortcut)
             }
+        }
+    }
+
+    /// Auto dock switching: while an external display is connected, disconnect the built-in
+    /// panel; when the last external goes away, bring it back. Off by default, since it takes
+    /// a screen away on its own. See AutoDisplaySwitchService for the rule and its safety nets.
+    @Published var autoBuiltinFollowsExternal: Bool = false {
+        didSet {
+            defaults.set(autoBuiltinFollowsExternal, forKey: Keys.autoBuiltinFollowsExternal)
+            AutoDisplaySwitchService.shared.settingDidChange()
         }
     }
 
@@ -216,5 +227,6 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
         brightnessKeySelectedDisplayUUIDs = Set(defaults.stringArray(forKey: Keys.brightnessKeySelected) ?? [])
         hidpiShortcut = defaults.data(forKey: Keys.hidpiShortcut)
             .flatMap { try? JSONDecoder().decode(KeyboardShortcut.self, from: $0) }
+        autoBuiltinFollowsExternal = defaults.bool(forKey: Keys.autoBuiltinFollowsExternal)
     }
 }

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -655,6 +655,43 @@ struct SettingsView: View {
                 .padding(.vertical, 3)
             }
 
+            // Auto dock switching (Apple Silicon laptops only): the built-in panel follows
+            // whether an external is attached, so docking and undocking stop being two menu
+            // trips. Off by default, since switching it on takes a screen away by itself.
+            if AutoDisplaySwitchService.shared.isAvailable {
+                VStack(alignment: .leading, spacing: 0) {
+                    Toggle(isOn: Binding(
+                        get: { settings.autoBuiltinFollowsExternal },
+                        set: { newValue in
+                            withAnimation(.panelResize) { settings.autoBuiltinFollowsExternal = newValue }
+                        }
+                    )) {
+                        HStack(spacing: 8) {
+                            MenuItemIcon(systemName: "laptopcomputer.and.arrow.down",
+                                         color: .orange,
+                                         active: settings.autoBuiltinFollowsExternal)
+                                .accessibilityHidden(true)
+                            Text("Disconnect Built-in While Docked")
+                                .font(.body)
+                            Spacer()
+                        }
+                    }
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 3)
+
+                    if settings.autoBuiltinFollowsExternal {
+                        Text("The built-in display switches off while an external is connected, and back on when the last is unplugged.")
+                            .font(.caption)
+                            .foregroundColor(.secondaryReadable)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(.horizontal, 12)
+                            .padding(.bottom, 4)
+                    }
+                }
+            }
+
             // Which displays the hardware brightness keys adjust. Once Accessibility is granted,
             // an expandable row + checkmark list (the Resolution / Color Profile idiom). Before
             // that there is no row or target subtitle at all, only the opt-in toggle, so enabling

--- a/Crisp/Views/PhysicalDisplayToggleView.swift
+++ b/Crisp/Views/PhysicalDisplayToggleView.swift
@@ -36,7 +36,11 @@ struct DisconnectDisplayRow: View {
                     busy = true
                     errorMessage = nil
                     Task { @MainActor in
+                        let uuid = display.displayUUID
                         let result = await service.disconnect(display)
+                        // Doing it by hand clears any standing "keep the built-in" override,
+                        // so auto dock switching takes the panel back over from here.
+                        AutoDisplaySwitchService.shared.userDidDisconnect(uuid: uuid)
                         displayManager.refreshDisplays()
                         if case .failure(let err) = result {
                             errorMessage = err.description
@@ -106,6 +110,9 @@ struct ReconnectDisplaysSection: View {
         busyUUIDs.insert(record.uuid)
         Task { @MainActor in
             _ = await service.reconnect(uuid: record.uuid)
+            // Bringing the built-in back by hand while still docked overrides auto dock
+            // switching until the external set changes, instead of being undone seconds later.
+            AutoDisplaySwitchService.shared.userDidReconnect(uuid: record.uuid)
             displayManager.refreshDisplays()
             busyUUIDs.remove(record.uuid)
         }


### PR DESCRIPTION
# Follow the dock: auto-disconnect the built-in panel, and rescue an all-dark Mac

Closes #92. Opt-in, off by default, and the row is hidden on a Mac with no built-in panel
(`isAvailable` also requires `toggle.isSupported`, so the whole thing is a no-op on Intel) —
the terms you set in the thread.

## What it does

**The rule** (`SettingsService.autoBuiltinFollowsExternal`, menu row "Disconnect Built-in
While Docked"): an external is online, so the built-in comes out of the layout; the last
external goes away, so it comes back. Doing it by hand is the same two calls, so this only
removes the two clicks per dock and undock. Reconnecting the panel by hand hands it back to
the user until the next real undock — the rule automates the dock, it does not police the
panel.

**The rescue**: re-enables window-server-disabled displays when nothing viewable is left.
This is deliberately narrower than it was when the issue was opened, because you fixed the
thing underneath it in the meantime. `restoreIfNoActiveDisplay` works from the `disconnected`
records, and with #132 and #133 in it now does that job well. What it still cannot cover is a
display the window server has switched off with **no record behind it** — a crash, a
relaunch, or a wake from a multi-day standby leaves exactly that — so this half works from
remembered display IDs instead and calls `forceEnable`, which bypasses the record
bookkeeping.

It is armed by an evaluation, never by a standing timer. The only thing it polls is a desk
that is already dark, where no further reconfiguration callback need arrive to say whether it
got better, and that watch is bounded at both ends: it stops when a screen is back, when the
machine sleeps, once it has rescued, or after 30 s. Sleep is excluded outright — rescuing
into a sleeping Mac switched the built-in back on mid-sleep, so it was already lit at the
next wake with nothing left for the rule to disconnect.

## Your design note, and where I did not take it

You suggested firing on the **edge** — once when the external count goes zero to non-zero —
rather than continuously on the condition, which would make a manual reconnect survive for
free and delete the stand-down state.

I took it for the undock (`undocked = wasDocked && !docked`) and not for the dock, and I want
to be straight that this is the one place I went the other way, because two cases fall
through a pure edge:

- **The setting being switched on while already docked.** No transition happens, so an edge
  rule does nothing at the exact moment the user asked for it.
- **A disconnect that is refused or fails.** `wouldLeaveNoActiveDisplay` refuses to take the
  last screen, and a refusal spends the edge; the condition simply tries again at the next
  evaluation once a real external is up.

So the dock side stays a condition, and `userOwnsBuiltin` is the stand-down you predicted I
would need. It is cleared only by an undock that actually happened. That distinction cost me
a bug worth reporting: switching the external off from Crisp's own menu empties the external
list identically, and reading that as an undock is how connecting that display again took
away a panel the user had just asked for. Fixed, and it is why `userRemovedExternal` exists.

If you would still rather have the edge and lose those two cases, it is a small change and I
will make it.

**The `softReconnect` guard you asked for is in**, in both places it matters:
`evaluate()` returns early while `toggle.isBlinking`, and the blackout watch refuses to act
while it is set, so the one-second dip a blink produces cannot read as an undock or a
blackout.

## The part that took the longest: what a display can be trusted on

The blackout watch has to decide whether anything on the desk is actually showing a picture.
That decision was wrong twice before it was right, and both attempts are measured, so here
they are rather than just the answer.

**Keying on `CGDirectDisplayID` (what I first shipped on the branch) is wrong**, because
macOS re-issues the ID at display sleep — 2 to 31, 34, 36, 38 on four consecutive sleeps
here. On a single-external desk the one monitor therefore stopped being recognised the moment
it slept: an ordinary display sleep read as a blackout, and every one cost an `enable` that
failed at 10 000 ms.

**Keying on the UUID instead is also wrong, and this one looked right for a while.** The UUID
*is* stable across the display-sleep re-enumeration, `make check` passed, and three display
sleeps came through clean. Then the dock pull: the phantom an undock leaves behind carries
**the same UUID as the real monitor** (`id=44`, `uuid=97AD1CC3-…F817F8`, dock out of the
machine). The watch trusted the phantom, never armed, and the desk stayed dark until the dock
went back in — worse than the bug it replaced. Reverted, and noted on #112 so nobody spends
an evening on it twice.

Identity cannot separate a sleeping display from an absent one. **#133's predicate can**, so
the watch reads it: `hasTrustedDisplay()` is now `phantomAwareActiveDisplayCount() > 0`. A
sleeping display keeps a port carrying it and stays trusted; a phantom has no port and does
not.

`lastHealthyDisplayIDs` stays, with a narrower job — it is what still separates an external
that turned up during a blackout from one that was already there, which a count cannot do,
naming no display. That is also why `suspectDisplayIDs` survives review here.

## One change to your code, and the promise attached to it

`phantomAwareActiveDisplayCount` is now internal instead of private, and its doc comment is
updated. You wrote there that it is read "by `restoreIfNoActiveDisplay` and nowhere else, on
purpose". This adds a second reader, so the comment now names it and says why it is the same
kind of reader: both are rescues, and the bargain you wrote still holds — a wrong answer from
the ports can only make a rescue fire, which re-enables a display Crisp itself turned off,
and can never hide a row or refuse a remembered disconnect. The Disconnect row and the launch
re-apply still read the plain count.

## Measured

Rebuilt on `29a0223` rather than replayed: the branch predates #101 and #133, and its history
adds a `reapplyOnWake` that `reconcile` has since replaced. The wake guard that keeps a stale
built-in disconnect from being re-applied while nothing external is up now filters
`reconcile`'s pending list, and `usablePhysicalDisplayIDs` is gone — it was the same test as
your `viewableActiveDisplays`, written before that existed, and the two must stay one test.

Desk: MacBook Pro Mac17,2 (M5), macOS 26.6.1, j5create JCD552 dock, BenQ GW2780 on its
DisplayPort as the only lit screen, built-in and an Acer E241Y G0 both held disconnected.

**Three display sleeps, under `caffeinate -s`** so the Mac could not idle-sleep inside the
wait and turn it into a system-sleep test (my first attempt did exactly that and is
discarded). The ID was reissued on all three — 2 to 66, 68, 70 — the port held
`hpd=High sink=1` throughout, and nothing armed. No `Every screen dark`, no `enable`. Cycle
one needed one re-poll, so #132 is visibly earning its keep.

**One dock pull**, the run the UUID attempt died on:

```
20:08:55      display off, id 2 -> 72, DisplayProductName goes empty
20:09:00      Sleep
20:09:30      DarkWake  USB-C_plug                     <- dock out
20:09:29.037  cap=0 effective=0, CG still lists 72[9d1/78e6]
20:09:51      Wake  RTP.keyboard
20:09:56.985  no active display, restoring from 2 record(s)
20:09:57.057  enable 1: reported success after 71 ms
20:11:47.678  Docked (1 external(s)): disconnecting the built-in panel
```

Six seconds from the wake, against 104 s and a replug on the run that opened #112. Both
records survived and the desk ended where it started. The redock line at the end is the rule
doing its job on a built-in that had **no record** at that moment — `reconnect` had dropped
it during the rescue — which is the case this feature exists for and the one #101 alone
cannot cover.

`make check` green.

## What I did not measure

The blackout watch's own arming path. In the pull above `restoreIfNoActiveDisplay` reached
the dark desk first, so the watch was never put in the position of having to arm. It reads
the same count that had just read 0 on the phantom, which was the point of the rewrite, but
staging the arming case means a built-in the window server has off with no record behind it,
and I have not found a way to produce that on demand.

Also untested here: Thunderbolt (`IOPortTransportStateCIO`), which has never appeared on this
desk, and DisplayLink-class docks, which I have no hardware for.

## Why this is late

I said on #92 that I would open this once #101 landed. #101 landed on 6 September and this
did not follow, because the display-sleep bug above turned up first and then took two wrong
fixes and #133 to settle. I would rather have sent it late than sent you the UUID version.

## On timing

I saw your note on #133 that this waits until 1.6.0 has been out for a couple of weeks, and
that it is not a judgement on the idea. That is the right order and I am not asking you to
change it — I am opening now only so it is sitting here rather than in my worktree when you
do have the time, and so the measurements are attached while they are fresh. No rush from my
side at all.

Thank you for the time you have put into reviewing all of this. The edge suggestion, the
`softReconnect` guard, the question about whether `restoreIfNoActiveDisplay` was firing at
all, and the contract you wrote on #133 each changed what this ended up being, mostly by
making it smaller. I would not have found the UUID dead end without being pushed to measure
rather than reason.
