### PR TITLE
Show the volume sliders row as soon as Volume Control is switched on

### DIFF
--- a/Crisp/Services/VolumeService.swift
+++ b/Crisp/Services/VolumeService.swift
@@ -39,8 +39,12 @@ final class VolumeService: ObservableObject {
     /// writes, so the probe can never prove support. Forced displays run
     /// write-only with the assumed max of 100 (the pump's default).
     private let forcedKey = "crisp.volumeForcedDisplays"
-    private lazy var forcedCapable: Set<String> =
-        Set(UserDefaults.standard.stringArray(forKey: forcedKey) ?? [])
+    /// Published so the Settings block re-checks whether any display reports
+    /// volume when the toggle flips: DisplayInfo.volumeSupported alone only
+    /// re-renders the display's own card, and the Show Volume Sliders row
+    /// stayed hidden until the display list next changed.
+    @Published private var forcedCapable: Set<String> =
+        Set(UserDefaults.standard.stringArray(forKey: "crisp.volumeForcedDisplays") ?? [])
 
     func isForced(_ display: DisplayInfo) -> Bool {
         forcedCapable.contains(display.displayUUID)

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -460,6 +460,7 @@ private struct SupportLinkRow: View {
 
 struct SettingsView: View {
     @ObservedObject private var settings = SettingsService.shared
+    @ObservedObject private var volumeService = VolumeService.shared
     // SettingsView stays mounted (only height-clipped) across panel opens, so the
     // support submenu's expansion must be reset explicitly on close like every
     // other section, or it reopens still expanded.
@@ -636,7 +637,7 @@ struct SettingsView: View {
             // Show volume sliders (issue #23). Hidden while no connected monitor
             // exposes DDC volume: the toggle would control nothing. Hiding the
             // sliders does not disable the volume keys.
-            if displayManager.displays.contains(where: { $0.volumeSupported }) {
+            if displayManager.displays.contains(where: { $0.volumeSupported || volumeService.isForced($0) }) {
                 Toggle(isOn: Binding(
                     get: { settings.showVolumeSliders },
                     set: { newValue in withAnimation(.panelResize) { settings.showVolumeSliders = newValue } }


### PR DESCRIPTION
Found on the 1.6.0 candidate: switch Volume Control on for a display and the Settings block still has no Show Volume Sliders row, because that row appears only when some display reports volume and the block re-checked it only when the display list changed. With the sliders setting off (as it was on this Mac from earlier testing) that left a display forced on with no slider and no row to turn sliders back on. VolumeService now publishes the forced set and the Settings block observes it. Driven on a scratch build through the accessibility tree: off removes the row at once, on brings it back. make check green.
