### PR TITLE
Pull crispctl display poweroff before 1.6.0

### DIFF
--- a/Crisp/Models/CrispControlModel.swift
+++ b/Crisp/Models/CrispControlModel.swift
@@ -75,7 +75,6 @@ struct CrispControlRequest: Codable, Equatable {
         case connectDisplay
         case disconnectDisplay
         case toggleDisplay
-        case powerOffDisplay
     }
 
     let command: Command
@@ -166,34 +165,25 @@ struct CrispControlConnectionChange: Equatable {
     let uuid: String
     let connect: Bool
 }
-/// A resolved `display power off`: one DDC/CI write of VCP D6 asking the monitor to
-/// switch itself off. One-way by the MCCS definition of that value (the power button
-/// brings it back), so there is no direction field.
-struct CrispControlPowerChange: Equatable {
-    let displayID: UInt32
-}
 struct CrispControlResult {
     let response: CrispControlResponse
     let brightnessChange: CrispControlBrightnessChange?
     let brightnessBoostChange: CrispControlBrightnessBoostChange?
     let hdrChange: CrispControlHDRChange?
     let connectionChange: CrispControlConnectionChange?
-    let powerChange: CrispControlPowerChange?
 
     init(
         _ response: CrispControlResponse,
         _ brightnessChange: CrispControlBrightnessChange?,
         _ brightnessBoostChange: CrispControlBrightnessBoostChange?,
         _ hdrChange: CrispControlHDRChange?,
-        _ connectionChange: CrispControlConnectionChange? = nil,
-        powerChange: CrispControlPowerChange? = nil
+        _ connectionChange: CrispControlConnectionChange? = nil
     ) {
         self.response = response
         self.brightnessChange = brightnessChange
         self.brightnessBoostChange = brightnessBoostChange
         self.hdrChange = hdrChange
         self.connectionChange = connectionChange
-        self.powerChange = powerChange
     }
 }
 enum CrispControlModel {
@@ -290,29 +280,7 @@ enum CrispControlModel {
             )
         case .connectDisplay, .disconnectDisplay, .toggleDisplay:
             return handleConnection(request, displays: displays)
-        case .powerOffDisplay:
-            return handlePowerOff(request, displays: displays)
         }
-    }
-
-    /// The built-in has no DDC/CI, and a display Crisp is holding disconnected has no
-    /// channel to write to; everything else is the monitor's call.
-    private static func handlePowerOff(
-        _ request: CrispControlRequest, displays: [CrispControlDisplay]
-    ) -> CrispControlResult {
-        guard hasDisplaySelector(request) else {
-            return .init(.failure("display is required"), nil, nil, nil)
-        }
-        guard let display = target(of: request, in: displays) else {
-            return .init(.failure("display not found"), nil, nil, nil)
-        }
-        guard !display.isBuiltin else {
-            return .init(.failure("the built-in display has no DDC/CI; use display sleep"), nil, nil, nil)
-        }
-        guard display.connected ?? true else {
-            return .init(.failure("display is disconnected, so there is no DDC channel to write to"), nil, nil, nil)
-        }
-        return .init(.success(), nil, nil, nil, powerChange: .init(displayID: display.id))
     }
 
     /// Resolves a connection request against the online list plus the displays Crisp
@@ -468,16 +436,16 @@ enum CrispControlCLIModel {
         let usage: String
         let summary: String
         let detail: String
-        /// The usage without the group: "poweroff <display>" on the group's page.
+        /// The usage without the group: "toggle <display>" on the group's page.
         var subcommand: String { String(usage.drop { $0 != " " }.dropFirst()) }
-        /// The usage split at the first placeholder: ("display poweroff", "<display>").
+        /// The usage split at the first placeholder: ("display toggle", "<display>").
         var columns: (command: String, arguments: String) {
             let parts = usage.split(separator: " ").map(String.init)
             let command = parts.prefix { !$0.hasPrefix("<") }
             return (command.joined(separator: " "), parts.dropFirst(command.count).joined(separator: " "))
         }
-        /// The literal words before the first placeholder ("display poweroff" for
-        /// "display poweroff <display>"): what an invocation is matched on.
+        /// The literal words before the first placeholder ("display toggle" for
+        /// "display toggle <display>"): what an invocation is matched on.
         var words: [String] {
             Array(usage.split(separator: " ").map(String.init).prefix { !$0.hasPrefix("<") })
         }
@@ -501,11 +469,6 @@ enum CrispControlCLIModel {
         Entry(group: .display, usage: "display toggle <display>", summary: "Disconnect if connected, connect if not", detail: """
             The reply comes after the window server has answered. If it is lost, run
             'display list' before retrying: the display may already have changed state.
-            """),
-        Entry(group: .display, usage: "display poweroff <display>", summary: "Ask the monitor to switch itself off", detail: """
-            One DDC/CI write (VCP D6). One-way: the monitor's DDC/CI goes with it and its
-            power button brings it back. Firmware decides whether it is honoured; ok means
-            the write was taken. The built-in display has no DDC/CI and is refused.
             """),
         Entry(group: .brightness, usage: "brightness get <display>", summary: "Read brightness and its live maximum", detail: ""),
         Entry(group: .brightness, usage: "brightness set <display> <percent>", summary: "Set brightness", detail: """
@@ -611,8 +574,6 @@ enum CrispControlCLIModel {
         // The window server answers inside the app's 10 s wrapper, but the DDC hold
         // ahead of the transaction can wait 15 s and the mode restore after it 3 s.
         case .connectDisplay, .disconnectDisplay, .toggleDisplay: return 30
-        // Three write attempts, each able to sit on a wedged channel for the 6 s I2C timeout.
-        case .powerOffDisplay: return 20
         default: return 2
         }
     }
@@ -692,7 +653,6 @@ enum CrispControlCLIModel {
         case "connect": return .init(command: .connectDisplay, selector: arguments[2])
         case "disconnect": return .init(command: .disconnectDisplay, selector: arguments[2])
         case "toggle": return .init(command: .toggleDisplay, selector: arguments[2])
-        case "poweroff": return .init(command: .powerOffDisplay, selector: arguments[2])
         default: return nil
         }
     }

--- a/Crisp/Services/CrispControlServer.swift
+++ b/Crisp/Services/CrispControlServer.swift
@@ -205,21 +205,6 @@ final class CrispControlServer {
         if let change = result.connectionChange, let error = await apply(change, among: managedDisplays) {
             return CrispControlModel.encode(.failure(error))
         }
-        if let change = result.powerChange {
-            guard let display = managedDisplays.first(where: { $0.displayID == change.displayID }) else {
-                return CrispControlModel.encode(.failure("display not found"))
-            }
-            let taken = await withCheckedContinuation { continuation in
-                DDCService.shared.writeAsync(
-                    displayID: display.displayID,
-                    command: DDCService.powerModeVCP,
-                    value: DDCService.powerModeOff
-                ) { continuation.resume(returning: $0) }
-            }
-            return CrispControlModel.encode(
-                taken ? .success() : .failure("the monitor did not take the DDC power write")
-            )
-        }
         return CrispControlModel.encode(result.response)
     }
 

--- a/Crisp/Services/DDCService.swift
+++ b/Crisp/Services/DDCService.swift
@@ -35,10 +35,6 @@ final class DDCService: ObservableObject, @unchecked Sendable {
     static let brightnessVCP: UInt8 = 0x10
     static let contrastVCP: UInt8   = 0x12
     static let volumeVCP: UInt8     = 0x62
-    /// MCCS power mode. 0x05 is the write-only "switch off" value: the monitor cuts its
-    /// own controller, DDC/CI included, and the power button brings it back.
-    static let powerModeVCP: UInt8  = 0xD6
-    static let powerModeOff: UInt16 = 0x05
 
     /// Diagnostics for support threads. Transitions and failures go out at
     /// notice/error (persisted; reporters run `log show --predicate

--- a/CrispTests/CrispControlModelTests.swift
+++ b/CrispTests/CrispControlModelTests.swift
@@ -73,12 +73,7 @@ final class CrispControlModelTests: XCTestCase {
                 ["display", "disconnect", "DECC7CEF-5E36-4E9B-8F18-CE11AE5902AD"],
                 .init(command: .disconnectDisplay, selector: "DECC7CEF-5E36-4E9B-8F18-CE11AE5902AD")
             ),
-            (["display", "toggle", "42"], .init(command: .toggleDisplay, selector: "42")),
-            (["display", "poweroff", "42"], .init(command: .powerOffDisplay, selector: "42")),
-            (
-                ["display", "poweroff", "decc7cef-5e36-4e9b-8f18-ce11ae5902ad"],
-                .init(command: .powerOffDisplay, selector: "decc7cef-5e36-4e9b-8f18-ce11ae5902ad")
-            )
+            (["display", "toggle", "42"], .init(command: .toggleDisplay, selector: "42"))
         ]
         for (arguments, request) in cases {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .request(request))
@@ -95,10 +90,10 @@ final class CrispControlModelTests: XCTestCase {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .help(.group(.display)), "\(arguments)")
         }
         XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["hdr"]), .help(.group(.hdr)))
-        let power = CrispControlCLIModel.entries.first { $0.usage == "display poweroff <display>" }!
+        let toggle = CrispControlCLIModel.entries.first { $0.usage == "display toggle <display>" }!
         let boostSet = CrispControlCLIModel.entries.first { $0.usage == "brightness boost set <display> on|off" }!
-        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["display", "poweroff", "--help"]), .help(.command(power)))
-        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["display", "poweroff", "3", "-h"]), .help(.command(power)))
+        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["display", "toggle", "--help"]), .help(.command(toggle)))
+        XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["display", "toggle", "3", "-h"]), .help(.command(toggle)))
         XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["brightness", "boost", "set", "--help"]), .help(.command(boostSet)))
         XCTAssertEqual(CrispControlCLIModel.parse(arguments: ["brightness", "nope", "--help"]), .help(.group(.brightness)))
         for arguments in [["version"], ["--version"]] {
@@ -110,7 +105,7 @@ final class CrispControlModelTests: XCTestCase {
         for word in ["help", "version", "crispctl <command>"] {
             XCTAssertTrue(CrispControlCLIModel.help.contains(word), word)
         }
-        XCTAssertEqual(CrispControlCLIModel.entries.count, 11)
+        XCTAssertEqual(CrispControlCLIModel.entries.count, 10)
         for entry in CrispControlCLIModel.entries {
             let columns = entry.columns
             XCTAssertTrue(CrispControlCLIModel.help.contains("  " + columns.command + " "), entry.usage)
@@ -135,8 +130,7 @@ final class CrispControlModelTests: XCTestCase {
             (["brightness", "boost", "set", "42"], "usage: crispctl brightness boost set <display> on|off"),
             (["brightness", "boost"],
              "usage: crispctl brightness boost get <display> or crispctl brightness boost set <display> on|off"),
-            (["display", "poweroff", "42", "now"], "usage: crispctl display poweroff <display>"),
-            (["display", "power", "42", "off"], "unknown command 'display power'; run 'crispctl display' for the display commands")
+            (["display", "toggle", "42", "now"], "usage: crispctl display toggle <display>")
         ]
         for (arguments, message) in cases {
             XCTAssertEqual(CrispControlCLIModel.parse(arguments: arguments), .failure(message), "\(arguments)")
@@ -160,10 +154,7 @@ final class CrispControlModelTests: XCTestCase {
             ["hdr", "set", "42", "true"], ["hdr", "set", "42", "ON"],
             ["hdr", "set", "42", "on", "extra"],
             ["display", "toggle"], ["display", "toggle", ""], ["display", "reboot", "42"],
-            ["display", "toggle", "42", "now"],
-            // Power is one-way by design: there is no on, standby or two-word form.
-            ["display", "poweroff"], ["display", "poweroff", ""], ["display", "poweroff", "42", "off"],
-            ["display", "power", "42", "off"]
+            ["display", "toggle", "42", "now"]
         ]
         for arguments in cases {
             guard case .failure = CrispControlCLIModel.parse(arguments: arguments) else {
@@ -184,7 +175,6 @@ final class CrispControlModelTests: XCTestCase {
         for command in [CrispControlRequest.Command.connectDisplay, .disconnectDisplay, .toggleDisplay] {
             XCTAssertEqual(CrispControlCLIModel.receiveTimeoutSeconds(for: command), 30)
         }
-        XCTAssertEqual(CrispControlCLIModel.receiveTimeoutSeconds(for: .powerOffDisplay), 20)
         for command in [
             CrispControlRequest.Command.list, .getBrightness, .setBrightness, .getBrightnessBoost, .getHDR
         ] {
@@ -656,7 +646,7 @@ final class CrispControlModelTests: XCTestCase {
     private var commands: [CrispControlRequest.Command] {
         [
             .list, .getBrightness, .setBrightness, .getBrightnessBoost, .setBrightnessBoost, .getHDR, .setHDR,
-            .connectDisplay, .disconnectDisplay, .toggleDisplay, .powerOffDisplay
+            .connectDisplay, .disconnectDisplay, .toggleDisplay
         ]
     }
 
@@ -723,29 +713,6 @@ final class CrispControlModelTests: XCTestCase {
             let result = CrispControlModel.handle(Data(request.utf8), displays: displays)
             XCTAssertFalse(result.response.ok, request)
             XCTAssertNil(result.connectionChange, request)
-        }
-    }
-
-    func testPowerOffResolvesAnExternalAndRefusesBuiltinAndHeld() {
-        let builtin = CrispControlDisplay(id: 1, name: "Built-in", brightness: 50, isBuiltin: true, uuid: "B")
-        let displays = [display, held, builtin]
-        for selector in ["7", "37d8832a-2d66-02ca-b9f7-8f30a301b230"] {
-            let result = CrispControlModel.handle(
-                Data(#"{"command":"powerOffDisplay","selector":"\#(selector)"}"#.utf8), displays: displays
-            )
-            XCTAssertTrue(result.response.ok, selector)
-            XCTAssertEqual(result.powerChange, .init(displayID: display.id), selector)
-            XCTAssertNil(result.connectionChange, selector)
-        }
-        for request in [
-            #"{"command":"powerOffDisplay"}"#,
-            #"{"command":"powerOffDisplay","selector":"404"}"#,
-            #"{"command":"powerOffDisplay","selector":"1"}"#,
-            #"{"command":"powerOffDisplay","selector":"9"}"#
-        ] {
-            let result = CrispControlModel.handle(Data(request.utf8), displays: displays)
-            XCTAssertFalse(result.response.ok, request)
-            XCTAssertNil(result.powerChange, request)
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Display commands:
   display connect      <display>            Put a disconnected display back
   display disconnect   <display>            Take a display out of the layout
   display toggle       <display>            Disconnect if connected, connect if not
-  display poweroff     <display>            Ask the monitor to switch itself off
 
 Brightness commands:
   brightness get       <display>            Read brightness and its live maximum
@@ -130,8 +129,6 @@ Crisp must already be running; crispctl never launches it. `brightness set` acce
 For example, `brightness boost get` returns `{"ok":true,"brightnessBoost":{"displayID":7,"eligible":true,"enabled":false}}`. `eligible` is the running Extra Brightness service's current eligibility result; `enabled` is its persisted per-display toggle state, so the two can differ while capability has collapsed and cleanup or auto-disable is pending. `brightness boost set` uses that existing service: `on` is refused when currently ineligible or when enabling fails, while `off` remains available for a connected display regardless of current eligibility. Enabling an external display may wait while the service settles HDR mode. Success means the service returned `true`, not that hardware, EDR headroom, or luminance was independently verified. A transport timeout does not prove the change was not applied; do not retry automatically—run `brightness boost get` first.
 
 `display disconnect`, `connect` and `toggle` are the menu's Disconnect Display and Reconnect from a script, for a KVM desk or a button: Apple Silicon only, and a disconnect is refused when it would leave no active display. A display Crisp is holding disconnected is absent from every macOS display list, so `display list` still shows it with `connected:false` and its last-known id; use the uuid for it. Asking for the state a display is already in succeeds and changes nothing, and the reply comes after the window server has answered, which can take a few seconds.
-
-`display poweroff <display>` tells the monitor to switch itself off over DDC/CI (the MCCS power-mode control, VCP D6). It is one-way: a monitor that has switched itself off has no DDC/CI left to hear an on, so its power button brings it back, and whether a monitor honours the value is up to its firmware. The reply means the monitor took the write, nothing more. The built-in display is refused, since it has no DDC/CI; display sleep is the tool for that one.
 
 `hdr get` and `hdr set` work on the external displays Crisp shows its HDR toggle for; the built-in panel and externals without HDR modes are refused. `get` reads the live state. `set` writes once through the same path as the toggle and reports success only when the read-back agrees; when it cannot tell (a timeout, or the display going away mid-way) it says so and does not retry, so run `hdr get` before retrying. Exit codes are unchanged.
 


### PR DESCRIPTION
The DDC power-off write from #138 works, but it puts a monitor into a state Crisp cannot see. Tried on my own desk tonight: the monitor switched itself off and kept its DisplayPort link up, so macOS kept it in the arrangement with its space reserved, Crisp kept showing it as a live display with a working brightness slider, and only the monitor's own button brought it back. Crisp has no way to read that the display is off. On the #74 asker's headless Mac it is worse, since the disconnect that would release the space is refused for the last display.

A command that leaves Crisp showing a display that is not there does not fit the rule that Crisp shows what is there, so it comes out before 1.6.0 ships. Back when there is a design where Crisp knows the display's power state.

Removes the command, its help entry, receive timeout, tests and README paragraph. `make check` green.
