### PR TITLE
Seed a reconnected display's slider from its last known brightness

### DIFF
--- a/Crisp/Models/DisplayInfo.swift
+++ b/Crisp/Models/DisplayInfo.swift
@@ -15,7 +15,12 @@ class DisplayInfo: ObservableObject, Identifiable {
     @Published var bounds: CGRect
     @Published var pixelWidth: Int
     @Published var pixelHeight: Int
-    @Published var brightness: Double
+    @Published var brightness: Double {
+        didSet { persistBrightnessIfNeeded() }
+    }
+    /// Last brightness written to defaults, so a glide's per-frame updates
+    /// don't churn the store.
+    private var persistedBrightness: Double?
     /// UI brightness ceiling. 100 normally; above 100 while Extra Brightness
     /// (EDR upscaling) is enabled, where the range 100...maxBrightness maps to
     /// the EDR overlay boost instead of hardware.
@@ -39,12 +44,16 @@ class DisplayInfo: ObservableObject, Identifiable {
     /// A stable identifier for the physical display that persists across sleep/wake
     /// even if macOS reassigns the CGDirectDisplayID.
     var displayUUID: String {
-        if let cfUUID = CGDisplayCreateUUIDFromDisplayID(displayID),
-           let uuidStr = CFUUIDCreateString(nil, cfUUID.takeRetainedValue()) {
-            return uuidStr as String
-        }
         // Fallback: vendor+model+serial hash is more stable than raw displayID
-        return "v\(vendorNumber)-m\(modelNumber)-s\(serialNumber)"
+        Self.cgDisplayUUID(displayID) ?? "v\(vendorNumber)-m\(modelNumber)-s\(serialNumber)"
+    }
+
+    /// CG's UUID for an online display, nil while it is offline. Static because
+    /// init needs it before `self` is fully formed.
+    static func cgDisplayUUID(_ displayID: CGDirectDisplayID) -> String? {
+        guard let cfUUID = CGDisplayCreateUUIDFromDisplayID(displayID),
+              let uuidStr = CFUUIDCreateString(nil, cfUUID.takeRetainedValue()) else { return nil }
+        return uuidStr as String
     }
 
     /// The native (highest non-HiDPI) resolution, used for HiDPI enablement and presets.
@@ -81,9 +90,17 @@ class DisplayInfo: ObservableObject, Identifiable {
         self.bounds = CGDisplayBounds(displayID)
         self.pixelWidth = CGDisplayPixelsWide(displayID)
         self.pixelHeight = CGDisplayPixelsHigh(displayID)
-        // Use persisted brightness as the initial value if available, otherwise 50.0.
-        // BrightnessService will overwrite this with the real hardware value once probed.
-        self.brightness = SettingsService.shared.brightness(for: displayID) ?? 50.0
+        // Seed from the last brightness this physical display was seen at, so a
+        // reconnect (or a displayID reshuffle when another display comes or goes)
+        // doesn't park the slider on a fictional 50 that the next brightness key
+        // or slider click would then write to the monitor. BrightnessService
+        // overwrites it with the real hardware value once the DDC read lands,
+        // which on some panels fails for minutes after link training.
+        let seed = Self.cgDisplayUUID(displayID).flatMap {
+            SettingsService.shared.brightness(forDisplayUUID: $0)
+        }
+        self.brightness = seed ?? 50.0
+        self.persistedBrightness = seed
         self.availableModes = []
         self.currentDisplayMode = DisplayMode.currentMode(for: displayID)
         let vendor = CGDisplayVendorNumber(displayID)
@@ -100,6 +117,17 @@ class DisplayInfo: ObservableObject, Identifiable {
             self.name = NSScreen.screen(for: displayID)?.localizedName ?? String(localized: "Display \(String(displayID))")
         }
 
+    }
+
+    /// Records the brightness this display is at, for the next time it appears.
+    /// Externals only: macOS reports the built-in's real level immediately, and
+    /// its ambient auto-adjust would write on every step. Boost values (above
+    /// 100) are skipped so the stored value stays a plain hardware percentage.
+    private func persistBrightnessIfNeeded() {
+        guard !isBuiltin, brightness <= 100.0 else { return }
+        guard abs(brightness - (persistedBrightness ?? -1)) >= 1.0 else { return }
+        persistedBrightness = brightness
+        SettingsService.shared.setBrightness(brightness, forDisplayUUID: displayUUID)
     }
 
     func loadDetails() async {

--- a/Crisp/Services/SettingsService.swift
+++ b/Crisp/Services/SettingsService.swift
@@ -64,7 +64,9 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
         static let brightnessKeySelected  = "crisp.brightnessKeySelectedDisplays"
         static let hidpiShortcut          = "crisp.hidpiShortcut"
         // Per-display keys use prefix + displayID
-        static let brightnessPrefix       = "crisp.brightness_"
+        // Brightness is the exception: prefix + display UUID, since displayIDs
+        // are reused across reconnects (same reason as crisp.softBrightness.uuid.*).
+        static let brightnessPrefix       = "crisp.brightness.uuid."
         static let contrastPrefix         = "crisp.contrast_"
     }
 
@@ -139,14 +141,16 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
 
     // MARK: - Per-Display Settings
 
-    func brightness(for displayID: CGDirectDisplayID) -> Double? {
-        let key = Keys.brightnessPrefix + "\(displayID)"
+    /// Last known brightness of a physical display, used to seed the slider on
+    /// reconnect until a DDC read lands. Nil for a display never seen before.
+    func brightness(forDisplayUUID uuid: String) -> Double? {
+        let key = Keys.brightnessPrefix + uuid
         guard defaults.object(forKey: key) != nil else { return nil }
         return defaults.double(forKey: key)
     }
 
-    func setBrightness(_ value: Double, for displayID: CGDirectDisplayID) {
-        defaults.set(value, forKey: Keys.brightnessPrefix + "\(displayID)")
+    func setBrightness(_ value: Double, forDisplayUUID uuid: String) {
+        defaults.set(value, forKey: Keys.brightnessPrefix + uuid)
     }
 
     func contrast(for displayID: CGDirectDisplayID) -> Double? {


### PR DESCRIPTION
A display that appears with a new `CGDirectDisplayID` gets a fresh `DisplayInfo`, and that seeded the brightness slider to a hardcoded 50 until a DDC read landed. The persisted value it read, `SettingsService.brightness(for:)`, had no writer anywhere in the app, so it always missed and the seed was always 50. macOS reshuffles display IDs whenever anything is plugged in or unplugged, so this hits every display on the desk, not only the one that moved.

Crisp never writes brightness on a connect or disconnect, so the screen does not move on its own. What moves it is the next thing that works from the slider's value: a brightness key step, a click on the track, a preset. Those take the fictional 50 as the starting point and the monitor really does jump to about half. On a panel whose first reads fail it can sit wrong for a long time. One of my monitors answers the first reads with stale EDID bytes, six failures quarantine reads for 600 s, and the slider stays on 50 for those ten minutes.

Now the brightness is stored per display UUID as it changes and the seed comes from there. Externals only: macOS reports the built-in's real level right away, and its ambient adjustment would write on every step. Values above 100 are skipped so the stored number stays a plain hardware percentage rather than an Extra Brightness one, and a 1 point deadband keeps a glide from writing on every frame. The old `crisp.brightness_<id>` key never held anything, so there is nothing to migrate.

Verified on an external with a build of this branch. A launch read the real 100 over DDC and stored it under the display's UUID. Seeding the store with 73 by hand and relaunching brought the slider up on 73, and that run's reads all failed and quarantined, which is exactly the case that used to show 50. The built-in is left out of the store as intended. `make check` green.
