### PR TITLE
Site: Crisp does CLI automation now, and centre the table headers

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,7 +13,7 @@ never break, they just see no update).
 
 ## crispctl
 
-`release.sh` compiles `crispctl` universal from the same source list as the `crispctl` target in `project.yml` and puts it at `Crisp.app/Contents/MacOS/crispctl`, signed inside-out before the app like Sparkle's nested code. Settings links it into `/usr/local/bin`; the cask needs the same link once. Right after the first release that ships it, send homebrew/cask one PR by hand with the version bump, the new sha256 and `binary "#{appdir}/Crisp.app/Contents/MacOS/crispctl"` under the `app` stanza (`brew bump-cask-pr crisp --version X.Y.Z` builds the bump; add the line to the same commit). Do not wait for autobump: it only moves the version, and a `binary` line against a release whose bundle has no crispctl breaks `brew install`.
+`release.sh` compiles `crispctl` universal from the same source list as the `crispctl` target in `project.yml` and puts it at `Crisp.app/Contents/MacOS/crispctl`, signed inside-out before the app like Sparkle's nested code. Settings links it into `/usr/local/bin`; the cask needs the same link once, through a `binary "#{appdir}/Crisp.app/Contents/MacOS/crispctl"` line under the `app` stanza. That line has to land *after* a version bump that ships crispctl, never before: Homebrew raises `CaskError, "It seems the binary source ... is not there"` (`cask/artifact/symlinked.rb`) when the target is missing, so a `binary` line against a cask still pinned to a release without crispctl fails every `brew install`. Since the version bump belongs to the bot (see Homebrew below), the order is: wait for the autobump PR to merge, then send one PR adding the single `binary` line. Done once, for 1.6.0; later releases need nothing here.
 
 ## Signing and notarization
 
@@ -47,13 +47,39 @@ instead of shipping.
 ## Homebrew
 
 The cask lives in homebrew/cask (`Casks/c/crisp.rb`, added in
-Homebrew/homebrew-cask#283611). Homebrew's autobump job runs every three
-hours, sees the new GitHub release through livecheck, and opens and merges
-the version bump itself. Nothing to do per release. If a release is still
-missing from `brew info --cask crisp` after a day, open the bump by hand:
-`brew bump-cask-pr crisp --version X.Y.Z`. `auto_updates true` is in the
-cask, so `brew upgrade` reconciles against the on-disk version instead of
-reinstalling over an app that updated itself.
+Homebrew/homebrew-cask#283611), and there is nothing to do per release.
+
+Every cask in the official repo is autobumped unless it says otherwise, so
+BrewTestBot owns the version and sha256. It checks every three hours and opens
+the bump PR itself. Bumping by hand is not an option and not just discouraged:
+`brew bump-cask-pr crisp --version X.Y.Z` refuses with "has its version update
+pull requests automatically opened by BrewTestBot", there is no `--force`, and
+`brew livecheck --cask crisp` answers "Skipping crisp as it is autobumped".
+Only a cask carrying `no_autobump!`, a `livecheck` block with `skip`, or an
+active `deprecate!`/`disable!` is bumped by hand. Anything that is not a
+version bump, the `binary` line above for instance, is still an ordinary PR.
+
+How the bot finds a release: the cask has no `livecheck` block, so livecheck
+picks the `GithubLatest` strategy off the download URL and turns it into
+`https://api.github.com/repos/didriksg/Crisp/releases/latest`, reading the
+version off the tag with `v?(\d+(?:\.\d+)+)`. That endpoint ignores drafts
+and prereleases, so marking a release as a prerelease hides it from Homebrew
+entirely.
+
+`auto_updates true` does not mean brew stops upgrading Crisp. With it,
+`brew upgrade` compares the *installed app bundle's* CFBundleShortVersionString
+against the cask version (`Cask#outdated_version`, gated on
+`HOMEBREW_UPGRADE_AUTO_UPDATES_CASKS`, which defaults to true) instead of
+trusting its own install receipt. So a user still on the old build gets the
+new one from a plain `brew upgrade`, with no `--greedy`, while a user whose app
+already updated itself through Sparkle is skipped rather than having a running
+app quit and replaced by the same version. `--greedy` only matters for
+`version :latest` casks or when `HOMEBREW_NO_UPGRADE_AUTO_UPDATES_CASKS` is set.
+
+One consequence for crispctl: the `binary` symlink is created by a cask
+install, so it appears for new installs and for anyone whose `brew upgrade`
+actually reinstalls. Someone who moves version through Sparkle keeps the tool
+inside the bundle and uses the Command Line Tool switch in Settings.
 
 The old tap (`didriksg/homebrew-tap`) only carries a `tap_migrations.json`
 entry now; installs from it move to the main cask on their next

--- a/docs/crisp-vs-betterdisplay-zh.html
+++ b/docs/crisp-vs-betterdisplay-zh.html
@@ -27,7 +27,7 @@
 <script type="application/ld+json">
 {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Crisp","item":"https://crispmac.app/zh.html"},{"@type":"ListItem","position":2,"name":"Crisp 对比 BetterDisplay / Lunar / MonitorControl"}]}
 </script>
-<link rel="stylesheet" href="styles.css?v=8">
+<link rel="stylesheet" href="styles.css?v=9">
 </head>
 <body>
 <header class="nav">
@@ -187,7 +187,7 @@
           </tr>
           <tr>
             <th>快捷指令 / 命令行</th>
-            <td class="c col-me"><span class="no">✗</span></td>
+            <td class="c col-me"><span class="yes">✓</span> 命令行</td>
             <td class="c"><span class="yes">✓</span></td>
             <td class="c"><span class="yes">✓</span> 命令行</td>
             <td class="c">~</td>
@@ -202,7 +202,7 @@
     <p>如果你要的只是 1440p 或 4K 显示器上清晰的 HiDPI，再加上亮度（Mac 的亮度键也能直接调外接屏，和内建屏一样）、预设和排列，Crisp 全都免费给你。现在还包括 <strong>XDR/HDR 亮度增强</strong>，把 XDR MacBook 和 HDR 显示器推过 100%，这项功能 BetterDisplay 和 Lunar 都锁在 Pro 里；另外还能通过 DDC 调显示器自带音箱的音量。<strong>不用重置试用期，不用花钱买授权码，更不用去找破解版</strong>，因为它根本没有付费版。开源（MIT），代码随便看，也能自己编译。</p>
 
     <h2>BetterDisplay Pro 仍然领先的地方</h2>
-    <p>先把话说清楚：Crisp 目前<strong>不支持</strong> EDID 覆写、画中画，也没有快捷指令和命令行自动化。如果你就是需要这些，<strong>BetterDisplay Pro 更合适</strong>，它成熟、维护得好，21.99 美元也算公道。但如果你要的只是日常的显示器控制，清晰又免费，Crisp 完全够用。</p>
+    <p>先把话说清楚：Crisp 目前<strong>不支持</strong> EDID 覆写和画中画。如果你就是需要这些，<strong>BetterDisplay Pro 更合适</strong>，它成熟、维护得好，21.99 美元也算公道。但如果你要的只是日常的显示器控制，清晰又免费，Crisp 完全够用。</p>
 
     <h2>Crisp 对比 BetterDisplay、Lunar、MonitorControl</h2>
     <p><strong>Crisp 对比 BetterDisplay：</strong>日常功能高度重合，但 BetterDisplay 把灵活的 HiDPI 缩放和 XDR/HDR 亮度增强锁进了 Pro（21.99 美元），还多了 EDID 覆写、画中画这些 Crisp 没有的功能。想免费用上清晰的 HiDPI、亮度、XDR/HDR 增强和预设，就选 Crisp；需要那些进阶功能，就买 BetterDisplay Pro。</p>

--- a/docs/crisp-vs-betterdisplay.html
+++ b/docs/crisp-vs-betterdisplay.html
@@ -27,7 +27,7 @@
 <script type="application/ld+json">
 {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Crisp","item":"https://crispmac.app/"},{"@type":"ListItem","position":2,"name":"Crisp vs BetterDisplay, Lunar and MonitorControl"}]}
 </script>
-<link rel="stylesheet" href="styles.css?v=8">
+<link rel="stylesheet" href="styles.css?v=9">
 </head>
 <body>
 <header class="nav">
@@ -187,7 +187,7 @@
           </tr>
           <tr>
             <th>Apple Shortcuts / CLI automation</th>
-            <td class="c col-me"><span class="no">✗</span></td>
+            <td class="c col-me"><span class="yes">✓</span> CLI</td>
             <td class="c"><span class="yes">✓</span></td>
             <td class="c"><span class="yes">✓</span> CLI</td>
             <td class="c">~</td>
@@ -202,7 +202,7 @@
     <p>If what you wanted from BetterDisplay was <strong>sharp HiDPI on a 1440p or 4K monitor</strong>, plus brightness (your Mac's own brightness keys drive the external monitors too, just like the built-in), presets and arrangement, Crisp gives you all of it for free. That now includes <strong>XDR/HDR extra brightness</strong>, pushing an XDR MacBook or HDR monitor past 100%, which BetterDisplay and Lunar both keep behind Pro, and DDC volume for the monitor's built-in speakers. There is no trial to reset and no license to buy, because there is no paid tier at all. It is open source, so you can read exactly what it does or build it yourself.</p>
 
     <h2>Where BetterDisplay Pro is still ahead</h2>
-    <p>Being honest keeps this useful. Crisp does <strong>not</strong> do EDID overrides, picture-in-picture, or Apple Shortcuts and CLI automation. If you specifically need any of those, <strong>BetterDisplay Pro is the better buy</strong>, it is a mature, well-supported app and $21.99 is fair for what it does. Crisp is the right pick when you want the everyday display controls, sharp and free, without a subscription mindset.</p>
+    <p>Being honest keeps this useful. Crisp does <strong>not</strong> do EDID overrides or picture-in-picture. If you specifically need either of those, <strong>BetterDisplay Pro is the better buy</strong>, it is a mature, well-supported app and $21.99 is fair for what it does. Crisp is the right pick when you want the everyday display controls, sharp and free, without a subscription mindset.</p>
 
     <h2>Crisp vs BetterDisplay, Lunar, and MonitorControl</h2>
     <p><strong>Crisp vs BetterDisplay:</strong> the everyday features overlap, but BetterDisplay keeps flexible HiDPI and XDR/HDR brightness behind Pro ($21.99), and adds EDID overrides and picture-in-picture that Crisp doesn't have. Choose Crisp for sharp HiDPI, brightness, XDR/HDR boost and presets at no cost; choose BetterDisplay Pro if you need those advanced extras.</p>

--- a/docs/fix-blurry-external-monitor-macos.html
+++ b/docs/fix-blurry-external-monitor-macos.html
@@ -27,7 +27,7 @@
 <script type="application/ld+json">
 {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Crisp","item":"https://crispmac.app/"},{"@type":"ListItem","position":2,"name":"Why is my external monitor blurry or tiny on a Mac?"}]}
 </script>
-<link rel="stylesheet" href="styles.css?v=8">
+<link rel="stylesheet" href="styles.css?v=9">
 </head>
 <body>
 <header class="nav">
@@ -90,7 +90,7 @@
 
     <h2>Crisp vs BetterDisplay and Lunar</h2>
     <p>The feature overlap is large; the difference is the price. <strong>Crisp is completely free, with no Pro tier, no license key, and no daily limits.</strong> Things the others reserve for a paid tier, flexible HiDPI scaling (BetterDisplay Pro is $21.99), auto-brightness that follows your built-in screen (Lunar Pro), and turning a display off and back on (Lunar's BlackOut), are free in Crisp. Lunar's free tier also caps you at 100 adjustments a day; Crisp has no cap. It's open source (MIT), so you can read the code or build it yourself.</p>
-    <p class="note">To be fair about the gaps: Crisp does not (yet) do XDR/HDR brightness boost, EDID overrides, picture-in-picture, or Apple Shortcuts and CLI automation. If you need those specifically, BetterDisplay Pro is the better fit. For sharp HiDPI, brightness, presets, and arrangement without paying, Crisp covers it.</p>
+    <p class="note">To be fair about the gaps: Crisp does not do EDID overrides or picture-in-picture. If you need those specifically, BetterDisplay Pro is the better fit. For sharp HiDPI, brightness, presets, and arrangement without paying, Crisp covers it.</p>
     <p><a href="crisp-vs-betterdisplay.html">See the full side-by-side: Crisp vs BetterDisplay, Lunar &amp; MonitorControl →</a></p>
 
     <h2>FAQ</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
 {"@context":"https://schema.org","@type":"VideoObject","name":"Crisp menu bar demo","description":"A tour of Crisp, a free macOS menu bar app for HiDPI scaling, DDC brightness, presets and display arrangement.","thumbnailUrl":"https://crispmac.app/screenshot.png","uploadDate":"2026-07-31T12:00:00+02:00","contentUrl":"https://crispmac.app/demo.mp4","width":1920,"height":1080}
 </script>
 <script>document.documentElement.classList.add('js')</script>
-<link rel="stylesheet" href="styles.css?v=8">
+<link rel="stylesheet" href="styles.css?v=9">
 </head>
 <body>
 <header class="nav">

--- a/docs/mac-hidpi.html
+++ b/docs/mac-hidpi.html
@@ -27,7 +27,7 @@
 <script type="application/ld+json">
 {"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Crisp","item":"https://crispmac.app/zh.html"},{"@type":"ListItem","position":2,"name":"外接显示器在 Mac 上发虚？怎么修"}]}
 </script>
-<link rel="stylesheet" href="styles.css?v=8">
+<link rel="stylesheet" href="styles.css?v=9">
 </head>
 <body>
 <header class="nav">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -192,6 +192,7 @@ tbody th { font-weight: 600; color: var(--text); }
 tbody tr:last-child td, tbody tr:last-child th { border-bottom: none; }
 td { color: var(--muted); }
 td.c { text-align: center; }
+thead th:not(:first-child) { text-align: center; }
 .yes { color: var(--good); font-weight: 700; }
 .no { color: var(--no); }
 .pro { color: var(--pro); font-weight: 600; font-size: 13px; }

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -27,7 +27,7 @@
 {"@context":"https://schema.org","@type":"VideoObject","name":"Crisp 菜单栏演示","description":"Crisp 是一个免费的 macOS 菜单栏工具，支持 HiDPI 缩放、DDC 亮度、预设和显示器排列，这是功能演示。","thumbnailUrl":"https://crispmac.app/screenshot-zh.png","uploadDate":"2026-07-31T12:00:00+02:00","contentUrl":"https://crispmac.app/demo.mp4","width":1920,"height":1080}
 </script>
 <script>document.documentElement.classList.add('js')</script>
-<link rel="stylesheet" href="styles.css?v=8">
+<link rel="stylesheet" href="styles.css?v=9">
 </head>
 <body>
 <header class="nav">


### PR DESCRIPTION
crispctl ships inside the app from 1.6.0, so the comparison table's *Apple Shortcuts / CLI automation* row now reads "✓ CLI" for Crisp, the way it already does for Lunar, in both the English and Chinese pages. The honesty paragraphs under both tables drop that gap.

While in there: the blog page's gap list still claimed Crisp has no XDR/HDR brightness boost, which the comparison table one page over contradicts, so that claim is gone too. Shout if you'd rather I left that alone.

The header cells were left-aligned while the columns under them are centred, which reads as a wobble on the wider columns. `thead th:not(:first-child)` is centred now, so the feature-name column stays left. The stylesheet query is bumped to v=9 so the CSS reaches anyone with the old one cached.