### PR TITLE
Site: a command line card on both home pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -83,6 +83,7 @@
         <div class="card reveal"><h3>Native toggles</h3><p>Flip macOS Dark Mode, Night Shift, and True Tone right from the panel, no System Settings trip.</p></div>
         <div class="card reveal"><h3>Color</h3><p>ICC profile switching, HDR on/off per display, plus gamma, contrast, and gain adjustment.</p></div>
         <div class="card reveal"><h3>Virtual displays</h3><p>Create HiDPI virtual screens for streaming, sidecar setups, or headless Macs.</p></div>
+        <div class="card reveal"><h3>Command line</h3><p>crispctl ships inside the app: read and set brightness, HDR and Extra Brightness, or connect and disconnect a display, from the terminal, a script, or an Apple Shortcut.</p></div>
         <div class="card reveal"><h3>Extras</h3><p>Combined brightness slider, auto brightness sync, keep awake, notch hiding, launch at login.</p></div>
       </div>
     </div>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -82,6 +82,7 @@
         <div class="card reveal"><h3>系统开关</h3><p>深色模式、夜览、原彩显示，直接在面板里切，不用进系统设置。</p></div>
         <div class="card reveal"><h3>色彩</h3><p>ICC 配置切换、每块屏独立开关 HDR，外加 gamma、对比度、增益微调。</p></div>
         <div class="card reveal"><h3>虚拟显示器</h3><p>创建 HiDPI 虚拟屏，用于直播、随航或无头 Mac。</p></div>
+        <div class="card reveal"><h3>命令行</h3><p>App 内置 crispctl：在终端、脚本或快捷指令里读取和设置亮度、开关 HDR 与额外亮度，或连接、断开某块显示器。</p></div>
         <div class="card reveal"><h3>更多</h3><p>合并亮度滑块、自动亮度跟随内建屏、防止睡眠、隐藏刘海、开机启动。</p></div>
       </div>
     </div>


### PR DESCRIPTION
crispctl ships inside the app from 1.6.0 and the feature grid never mentioned it, in either language. One card on each home page, next to Extras, naming crispctl, the terminal, scripts and Shortcuts, which is also what people search for when they want a scriptable display tool.

Meta descriptions left alone: they are already 187 characters, past where Google truncates, so lengthening them would cost more than it gains.