### PR TITLE
Site: name the command line tool where search can see it

### DIFF
--- a/docs/crisp-vs-betterdisplay-zh.html
+++ b/docs/crisp-vs-betterdisplay-zh.html
@@ -4,13 +4,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>免费开源的 BetterDisplay 平替（macOS）：Crisp 对比 BetterDisplay / Lunar / MonitorControl</title>
-<meta name="description" content="在找免费的 BetterDisplay 平替？Crisp 是一个开源（MIT）的 macOS 菜单栏 App：灵活的 HiDPI 缩放、DDC 亮度、预设、排列全都免费，没有 Pro 分层、没有授权码，也不用破解。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
+<meta name="description" content="在找免费的 BetterDisplay 平替？Crisp 是一个开源（MIT）的 macOS 菜单栏 App：灵活的 HiDPI 缩放、DDC 亮度、预设、排列和命令行工具全都免费，没有 Pro 分层、没有授权码，也不用破解。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
 <link rel="canonical" href="https://crispmac.app/crisp-vs-betterdisplay-zh.html">
 <link rel="alternate" hreflang="zh-Hans" href="https://crispmac.app/crisp-vs-betterdisplay-zh.html">
 <link rel="alternate" hreflang="en" href="https://crispmac.app/crisp-vs-betterdisplay.html">
 <link rel="alternate" hreflang="x-default" href="https://crispmac.app/crisp-vs-betterdisplay.html">
 <meta property="og:title" content="免费开源的 BetterDisplay 平替（macOS）：Crisp">
-<meta property="og:description" content="Crisp 是一个免费开源（MIT）的 macOS 显示器管理工具：灵活 HiDPI、DDC 亮度、预设、排列全免费。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
+<meta property="og:description" content="Crisp 是一个免费开源（MIT）的 macOS 显示器管理工具：灵活 HiDPI、DDC 亮度、预设、排列、命令行工具全免费。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
 <meta property="og:image" content="https://crispmac.app/og-card-zh.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -18,7 +18,7 @@
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="免费开源的 BetterDisplay 平替（macOS）：Crisp">
-<meta name="twitter:description" content="Crisp 是一个免费开源（MIT）的 macOS 显示器管理工具：灵活 HiDPI、DDC 亮度、预设、排列全免费。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
+<meta name="twitter:description" content="Crisp 是一个免费开源（MIT）的 macOS 显示器管理工具：灵活 HiDPI、DDC 亮度、预设、排列、命令行工具全免费。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
 <meta name="twitter:image" content="https://crispmac.app/og-card-zh.png">
 <link rel="icon" href="icon.png">
 <script type="application/ld+json">
@@ -199,7 +199,7 @@
     <p class="note">价格和免费 / Pro 的划分参考各自的官方文档整理（BetterDisplay、Lunar，截至 2026 年年中）。功能会在版本间调整，具体以官网为准。</p>
 
     <h2>为什么选 Crisp</h2>
-    <p>如果你要的只是 1440p 或 4K 显示器上清晰的 HiDPI，再加上亮度（Mac 的亮度键也能直接调外接屏，和内建屏一样）、预设和排列，Crisp 全都免费给你。现在还包括 <strong>XDR/HDR 亮度增强</strong>，把 XDR MacBook 和 HDR 显示器推过 100%，这项功能 BetterDisplay 和 Lunar 都锁在 Pro 里；另外还能通过 DDC 调显示器自带音箱的音量。<strong>不用重置试用期，不用花钱买授权码，更不用去找破解版</strong>，因为它根本没有付费版。开源（MIT），代码随便看，也能自己编译。</p>
+    <p>如果你要的只是 1440p 或 4K 显示器上清晰的 HiDPI，再加上亮度（Mac 的亮度键也能直接调外接屏，和内建屏一样）、预设和排列，Crisp 全都免费给你。现在还包括 <strong>XDR/HDR 亮度增强</strong>，把 XDR MacBook 和 HDR 显示器推过 100%，这项功能 BetterDisplay 和 Lunar 都锁在 Pro 里；另外还能通过 DDC 调显示器自带音箱的音量。App 里还内置了命令行工具 <code>crispctl</code>，亮度、HDR、额外亮度以及连接或断开显示器，都能在终端、Shell 脚本或快捷指令里完成。<strong>不用重置试用期，不用花钱买授权码，更不用去找破解版</strong>，因为它根本没有付费版。开源（MIT），代码随便看，也能自己编译。</p>
 
     <h2>BetterDisplay Pro 仍然领先的地方</h2>
     <p>先把话说清楚：Crisp 目前<strong>不支持</strong> EDID 覆写和画中画。如果你就是需要这些，<strong>BetterDisplay Pro 更合适</strong>，它成熟、维护得好，21.99 美元也算公道。但如果你要的只是日常的显示器控制，清晰又免费，Crisp 完全够用。</p>

--- a/docs/crisp-vs-betterdisplay.html
+++ b/docs/crisp-vs-betterdisplay.html
@@ -4,13 +4,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>A free, open-source BetterDisplay alternative for macOS: Crisp</title>
-<meta name="description" content="Looking for a free BetterDisplay alternative? Crisp is an open-source (MIT) macOS menu bar app with flexible HiDPI scaling, DDC brightness, presets and arrangement, all free, no Pro tier and no license key. Compared side by side with BetterDisplay, Lunar and MonitorControl.">
+<meta name="description" content="Looking for a free BetterDisplay alternative? Crisp is an open-source (MIT) macOS menu bar app with flexible HiDPI scaling, DDC brightness, presets, arrangement and a command line tool, all free, no Pro tier and no license key. Compared side by side with BetterDisplay, Lunar and MonitorControl.">
 <link rel="canonical" href="https://crispmac.app/crisp-vs-betterdisplay.html">
 <link rel="alternate" hreflang="en" href="https://crispmac.app/crisp-vs-betterdisplay.html">
 <link rel="alternate" hreflang="zh-Hans" href="https://crispmac.app/crisp-vs-betterdisplay-zh.html">
 <link rel="alternate" hreflang="x-default" href="https://crispmac.app/crisp-vs-betterdisplay.html">
 <meta property="og:title" content="A free, open-source BetterDisplay alternative for macOS: Crisp">
-<meta property="og:description" content="Crisp is a free, open-source (MIT) macOS display manager. Flexible HiDPI, DDC brightness, presets and arrangement, all free. Compared with BetterDisplay, Lunar and MonitorControl.">
+<meta property="og:description" content="Crisp is a free, open-source (MIT) macOS display manager. Flexible HiDPI, DDC brightness, presets, arrangement and a command line tool, all free. Compared with BetterDisplay, Lunar and MonitorControl.">
 <meta property="og:image" content="https://crispmac.app/og-card.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -18,7 +18,7 @@
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="A free, open-source BetterDisplay alternative for macOS: Crisp">
-<meta name="twitter:description" content="Crisp is a free, open-source (MIT) macOS display manager. Flexible HiDPI, DDC brightness, presets and arrangement, all free. Compared with BetterDisplay, Lunar and MonitorControl.">
+<meta name="twitter:description" content="Crisp is a free, open-source (MIT) macOS display manager. Flexible HiDPI, DDC brightness, presets, arrangement and a command line tool, all free. Compared with BetterDisplay, Lunar and MonitorControl.">
 <meta name="twitter:image" content="https://crispmac.app/og-card.png">
 <link rel="icon" href="icon.png">
 <script type="application/ld+json">
@@ -199,7 +199,7 @@
     <p class="note">Prices and free/Pro splits from each app's own documentation (BetterDisplay and Lunar, mid-2026). Features move between tiers over time, so check their sites for the current state.</p>
 
     <h2>Where Crisp wins</h2>
-    <p>If what you wanted from BetterDisplay was <strong>sharp HiDPI on a 1440p or 4K monitor</strong>, plus brightness (your Mac's own brightness keys drive the external monitors too, just like the built-in), presets and arrangement, Crisp gives you all of it for free. That now includes <strong>XDR/HDR extra brightness</strong>, pushing an XDR MacBook or HDR monitor past 100%, which BetterDisplay and Lunar both keep behind Pro, and DDC volume for the monitor's built-in speakers. There is no trial to reset and no license to buy, because there is no paid tier at all. It is open source, so you can read exactly what it does or build it yourself.</p>
+    <p>If what you wanted from BetterDisplay was <strong>sharp HiDPI on a 1440p or 4K monitor</strong>, plus brightness (your Mac's own brightness keys drive the external monitors too, just like the built-in), presets and arrangement, Crisp gives you all of it for free. That now includes <strong>XDR/HDR extra brightness</strong>, pushing an XDR MacBook or HDR monitor past 100%, which BetterDisplay and Lunar both keep behind Pro, and DDC volume for the monitor's built-in speakers. Crisp also ships <code>crispctl</code>, a command line tool inside the app, so brightness, HDR, Extra Brightness and connecting or disconnecting a display can be driven from the terminal, a shell script or an Apple Shortcut. There is no trial to reset and no license to buy, because there is no paid tier at all. It is open source, so you can read exactly what it does or build it yourself.</p>
 
     <h2>Where BetterDisplay Pro is still ahead</h2>
     <p>Being honest keeps this useful. Crisp does <strong>not</strong> do EDID overrides or picture-in-picture. If you specifically need either of those, <strong>BetterDisplay Pro is the better buy</strong>, it is a mature, well-supported app and $21.99 is fair for what it does. Crisp is the right pick when you want the everyday display controls, sharp and free, without a subscription mindset.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -83,6 +83,7 @@
         <div class="card reveal"><h3>Native toggles</h3><p>Flip macOS Dark Mode, Night Shift, and True Tone right from the panel, no System Settings trip.</p></div>
         <div class="card reveal"><h3>Color</h3><p>ICC profile switching, HDR on/off per display, plus gamma, contrast, and gain adjustment.</p></div>
         <div class="card reveal"><h3>Virtual displays</h3><p>Create HiDPI virtual screens for streaming, sidecar setups, or headless Macs.</p></div>
+        <div class="card reveal"><h3>Command line</h3><p>crispctl ships inside the app: read and set brightness, HDR and Extra Brightness, or connect and disconnect a display, from the terminal, a script, or an Apple Shortcut.</p></div>
         <div class="card reveal"><h3>Extras</h3><p>Combined brightness slider, auto brightness sync, keep awake, notch hiding, launch at login.</p></div>
       </div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,16 +5,16 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="google-site-verification" content="Pb7coFWl3eF3E_6mT6jdH6sbJYJ5VY3iLoSKt-bNy2w">
 <title>Crisp: Free BetterDisplay &amp; Lunar alternative for macOS</title>
-<meta name="description" content="Crisp is a free, open-source, lightweight alternative to BetterDisplay and Lunar for macOS: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar.">
+<meta name="description" content="Crisp is a free, open-source, lightweight alternative to BetterDisplay and Lunar for macOS: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar, plus crispctl, a command line tool for the terminal, scripts and Apple Shortcuts.">
 <meta property="og:title" content="Crisp: Free BetterDisplay &amp; Lunar alternative for macOS">
-<meta property="og:description" content="A free, open-source alternative to BetterDisplay and Lunar: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar.">
+<meta property="og:description" content="A free, open-source alternative to BetterDisplay and Lunar: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar, plus a command line tool.">
 <meta property="og:image" content="https://crispmac.app/og-card.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:url" content="https://crispmac.app/">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Crisp: Free BetterDisplay &amp; Lunar alternative for macOS">
-<meta name="twitter:description" content="A free, open-source alternative to BetterDisplay and Lunar: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar.">
+<meta name="twitter:description" content="A free, open-source alternative to BetterDisplay and Lunar: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar, plus a command line tool.">
 <meta name="twitter:image" content="https://crispmac.app/og-card.png">
 <link rel="canonical" href="https://crispmac.app/">
 <link rel="alternate" hreflang="en" href="https://crispmac.app/">
@@ -22,7 +22,7 @@
 <link rel="alternate" hreflang="x-default" href="https://crispmac.app/">
 <link rel="icon" href="icon.png">
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Crisp","operatingSystem":"macOS 14+","applicationCategory":"UtilitiesApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://crispmac.app/","downloadUrl":"https://github.com/didriksg/Crisp/releases/latest/download/Crisp.dmg","screenshot":"https://crispmac.app/screenshot.png","softwareLicense":"https://github.com/didriksg/Crisp/blob/main/LICENSE","author":{"@type":"Person","name":"Didrik Galteland","url":"https://github.com/didriksg"}}
+{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Crisp","operatingSystem":"macOS 14+","applicationCategory":"UtilitiesApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://crispmac.app/","downloadUrl":"https://github.com/didriksg/Crisp/releases/latest/download/Crisp.dmg","screenshot":"https://crispmac.app/screenshot.png","featureList":["HiDPI scaled resolutions on any external monitor","DDC/CI hardware brightness and volume control","Brightness keys for external displays","Extra Brightness using HDR and XDR headroom","Display presets with keyboard shortcuts","Display arrangement and main display switching","Virtual displays","ICC profiles, HDR toggle, gamma and gain","crispctl command line tool for the terminal, shell scripts and Apple Shortcuts"],"softwareLicense":"https://github.com/didriksg/Crisp/blob/main/LICENSE","author":{"@type":"Person","name":"Didrik Galteland","url":"https://github.com/didriksg"}}
 </script>
 <script type="application/ld+json">
 {"@context":"https://schema.org","@type":"VideoObject","name":"Crisp menu bar demo","description":"A tour of Crisp, a free macOS menu bar app for HiDPI scaling, DDC brightness, presets and display arrangement.","thumbnailUrl":"https://crispmac.app/screenshot.png","uploadDate":"2026-07-31T12:00:00+02:00","contentUrl":"https://crispmac.app/demo.mp4","width":1920,"height":1080}
@@ -127,6 +127,10 @@
         <details>
           <summary>What does Crisp require?</summary>
           <p>macOS 14 (Sonoma) or later, on both Apple Silicon and Intel Macs. A few extras, like disconnecting a display from the menu, are Apple Silicon only.</p>
+        </details>
+        <details>
+          <summary>Can I control my displays from the terminal or a script?</summary>
+          <p>Yes. Crisp ships a command line tool, <code>crispctl</code>, inside the app, and a switch in Settings links it into <code>/usr/local/bin</code>. From the terminal, a shell script, or an Apple Shortcut you can list displays, read and set brightness, switch HDR and Extra Brightness, and connect or disconnect a display, by display id or UUID.</p>
         </details>
         <details>
           <summary>How is Crisp different from BetterDisplay and Lunar?</summary>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://crispmac.app/</loc>
-    <lastmod>2026-08-03</lastmod>
+    <lastmod>2026-09-08</lastmod>
   </url>
   <url>
     <loc>https://crispmac.app/zh.html</loc>
-    <lastmod>2026-08-03</lastmod>
+    <lastmod>2026-09-08</lastmod>
   </url>
   <url>
     <loc>https://crispmac.app/crisp-vs-betterdisplay.html</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-09-08</lastmod>
   </url>
   <url>
     <loc>https://crispmac.app/crisp-vs-betterdisplay-zh.html</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-09-08</lastmod>
   </url>
   <url>
     <loc>https://crispmac.app/fix-blurry-external-monitor-macos.html</loc>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -82,6 +82,7 @@
         <div class="card reveal"><h3>系统开关</h3><p>深色模式、夜览、原彩显示，直接在面板里切，不用进系统设置。</p></div>
         <div class="card reveal"><h3>色彩</h3><p>ICC 配置切换、每块屏独立开关 HDR，外加 gamma、对比度、增益微调。</p></div>
         <div class="card reveal"><h3>虚拟显示器</h3><p>创建 HiDPI 虚拟屏，用于直播、随航或无头 Mac。</p></div>
+        <div class="card reveal"><h3>命令行</h3><p>App 内置 crispctl：在终端、脚本或快捷指令里读取和设置亮度、开关 HDR 与额外亮度，或连接、断开某块显示器。</p></div>
         <div class="card reveal"><h3>更多</h3><p>合并亮度滑块、自动亮度跟随内建屏、防止睡眠、隐藏刘海、开机启动。</p></div>
       </div>
     </div>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -4,16 +4,16 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Crisp：BetterDisplay 和 Lunar 的免费开源平替（macOS 显示器管理）</title>
-<meta name="description" content="Crisp 是 BetterDisplay 和 Lunar 的免费开源平替：一个轻量的 macOS 菜单栏 App，集成 DDC 亮度、HiDPI 缩放、预设、虚拟显示器和排列，连它们的部分收费功能也免费。">
+<meta name="description" content="Crisp 是 BetterDisplay 和 Lunar 的免费开源平替：一个轻量的 macOS 菜单栏 App，集成 DDC 亮度、HiDPI 缩放、预设、虚拟显示器和排列，连它们的部分收费功能也免费；还内置 crispctl 命令行工具，可以在终端、脚本和快捷指令里控制显示器。">
 <meta property="og:title" content="Crisp：BetterDisplay 和 Lunar 的免费开源平替">
-<meta property="og:description" content="免费开源的 macOS 菜单栏工具：DDC 亮度、HiDPI 缩放、预设、虚拟显示器、排列，一个面板全搞定。">
+<meta property="og:description" content="免费开源的 macOS 菜单栏工具：DDC 亮度、HiDPI 缩放、预设、虚拟显示器、排列，一个面板全搞定，还有命令行工具。">
 <meta property="og:image" content="https://crispmac.app/og-card-zh.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:url" content="https://crispmac.app/zh.html">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Crisp：BetterDisplay 和 Lunar 的免费开源平替">
-<meta name="twitter:description" content="免费开源的 macOS 菜单栏工具：DDC 亮度、HiDPI 缩放、预设、虚拟显示器、排列，一个面板全搞定。">
+<meta name="twitter:description" content="免费开源的 macOS 菜单栏工具：DDC 亮度、HiDPI 缩放、预设、虚拟显示器、排列，一个面板全搞定，还有命令行工具。">
 <meta name="twitter:image" content="https://crispmac.app/og-card-zh.png">
 <link rel="canonical" href="https://crispmac.app/zh.html">
 <link rel="alternate" hreflang="zh-Hans" href="https://crispmac.app/zh.html">
@@ -21,7 +21,7 @@
 <link rel="alternate" hreflang="x-default" href="https://crispmac.app/">
 <link rel="icon" href="icon.png">
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Crisp","operatingSystem":"macOS 14+","applicationCategory":"UtilitiesApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://crispmac.app/zh.html","downloadUrl":"https://github.com/didriksg/Crisp/releases/latest/download/Crisp.dmg","screenshot":"https://crispmac.app/screenshot-zh.png","softwareLicense":"https://github.com/didriksg/Crisp/blob/main/LICENSE","author":{"@type":"Person","name":"Didrik Galteland","url":"https://github.com/didriksg"}}
+{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Crisp","operatingSystem":"macOS 14+","applicationCategory":"UtilitiesApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://crispmac.app/zh.html","downloadUrl":"https://github.com/didriksg/Crisp/releases/latest/download/Crisp.dmg","screenshot":"https://crispmac.app/screenshot-zh.png","featureList":["给任意外接显示器补上 HiDPI 缩放分辨率","DDC/CI 硬件亮度和音量控制","用键盘亮度键控制外接显示器","额外亮度：利用 HDR 和 XDR 亮度余量","显示器预设与全局快捷键","显示器排列与主显示器切换","虚拟显示器","ICC 描述文件、HDR 开关、伽马与增益","crispctl 命令行工具，支持终端、脚本和快捷指令"],"softwareLicense":"https://github.com/didriksg/Crisp/blob/main/LICENSE","author":{"@type":"Person","name":"Didrik Galteland","url":"https://github.com/didriksg"}}
 </script>
 <script type="application/ld+json">
 {"@context":"https://schema.org","@type":"VideoObject","name":"Crisp 菜单栏演示","description":"Crisp 是一个免费的 macOS 菜单栏工具，支持 HiDPI 缩放、DDC 亮度、预设和显示器排列，这是功能演示。","thumbnailUrl":"https://crispmac.app/screenshot-zh.png","uploadDate":"2026-07-31T12:00:00+02:00","contentUrl":"https://crispmac.app/demo.mp4","width":1920,"height":1080}
@@ -126,6 +126,10 @@
         <details>
           <summary>使用 Crisp 需要什么条件？</summary>
           <p>macOS 14（Sonoma）及以上，Apple 芯片和 Intel Mac 都支持。少数功能（如从菜单断开显示器）仅限 Apple 芯片。</p>
+        </details>
+        <details>
+          <summary>可以在终端或脚本里控制显示器吗？</summary>
+          <p>可以。Crisp 在 App 内置了命令行工具 <code>crispctl</code>，在设置里打开开关就会把它链接到 <code>/usr/local/bin</code>。在终端、Shell 脚本或快捷指令里，你可以列出显示器、读取和设置亮度、开关 HDR 和额外亮度，也可以连接或断开某块显示器，按显示器 id 或 UUID 指定。</p>
         </details>
         <details>
           <summary>Crisp 和 BetterDisplay、Lunar 有什么区别？</summary>


### PR DESCRIPTION
crispctl shipped in 1.6.0, but the site only mentioned it in one feature card. The page titles, descriptions, structured data and FAQ never said the app has a command line at all.

What changed, on all four pages that needed it:

- meta, og and twitter descriptions name the command line tool
- `featureList` added to the SoftwareApplication schema on both home pages, with crispctl as an entry
- a new FAQ entry on both home pages, "Can I control my displays from the terminal or a script?"
- one sentence in the comparison pages' Where Crisp wins section
- sitemap `lastmod` bumped on the four changed pages, so they get recrawled

Left alone on purpose: the home page title, which is the highest-value slot and currently earns on the BetterDisplay query; the two guide pages, where a command line is off-topic and would dilute them; and FAQPage schema, since Google restricted FAQ rich results to authoritative government and health sites in 2023.

Worth recording that Search Console does not show demand for this yet. Across 175 distinct queries in Google and Bing, on both the old and new domains, not one mentions a terminal, a command line or m1ddc. These edits cost nothing and cannot hurt, but the dedicated CLI page I suggested earlier is not justified by the data.