### PR TITLE
Put the release notes in the update dialog

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -1,31 +1,66 @@
-<?xml version="1.0" standalone="yes"?>
-<!-- sparkle-sign-warning:
+<?xml version="1.0" standalone="yes"?><!-- sparkle-sign-warning:
 IMPORTANT: This file was signed by Sparkle. Any modifications to this file requires re-signing this file with generate_appcast or sign_update! The signed signature will be embedded at the end of this file.
--->
-<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+--><rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
     <channel>
         <title>Crisp</title>
         <item>
             <title>1.6.0</title>
-            <pubDate>Tue, 08 Sep 2026 16:20:24 +0200</pubDate>
+            <pubDate>Tue, 08 Sep 2026 23:44:51 +0200</pubDate>
             <link>https://github.com/didriksg/Crisp/releases</link>
+            <sparkle:fullReleaseNotesLink>https://github.com/didriksg/Crisp/releases</sparkle:fullReleaseNotesLink>
             <sparkle:version>1.6.0</sparkle:version>
             <sparkle:shortVersionString>1.6.0</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/didriksg/Crisp/releases/download/v1.6.0/Crisp.dmg" length="4766696" type="application/octet-stream" sparkle:edSignature="dgqRmGY5U7mhTDmtztHjhT0QJTNQCYASvtME/KoHZdbfMcpPwMRAXT58XJYAnC1aHMHV078ci75PGDH00AwRBQ=="/>
-        </item>
-        <item>
-            <title>1.5.0</title>
-            <pubDate>Wed, 19 Aug 2026 03:56:17 +0200</pubDate>
-            <link>https://github.com/didriksg/Crisp/releases</link>
-            <sparkle:version>1.5.0</sparkle:version>
-            <sparkle:shortVersionString>1.5.0</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://github.com/didriksg/Crisp/releases/download/v1.5.0/Crisp.dmg" length="4134145" type="application/octet-stream" sparkle:edSignature="387tQdp/1P0YbKVMstUg4YrPF1UTFvya0XWkV0ypio/gXbqGgCNAhgDfQFrdav/RwoUMAKIsKTYivaYwdPHrCg=="/>
+            <description sparkle:format="markdown"><![CDATA[Crisp 1.6.0 ships crispctl, a command line tool, inside the app, draws its own brightness and volume OSD on macOS 26, and remembers the displays you disconnect. It also fixes a freeze when reconnecting a display, one slow monitor holding up the others, resolutions jumping after a wake, and colour temperature after display sleep.
+
+## New
+
+- **crispctl.** The command line tool now ships inside Crisp.app, and a Command Line Tool switch in Settings links it into /usr/local/bin. It talks to the running app over a same-user socket: `display list`, `connect`, `disconnect` and `toggle`, `brightness get` and `set`, `brightness boost get` and `set` for Extra Brightness, and `hdr get` and `set`, all by display id or uuid, with a help page per group and per command. Bind one to a key with a Shortcut and you have a desk button. (#75, #81, #97, #98, #102, #116)
+- **A native OSD on macOS 26.** When you press the brightness or volume keys on an external, Crisp draws the capsule itself now. macOS 26 moved its own HUD to a capsule under the menu bar and left the old bottom-centre bezel to third parties, which is what Crisp showed before. The new one hangs under Crisp's menu bar item the way the system's sits under the Sound item, and it is fitted to the system HUD: the same glass, blur and edge bend, the same entry and exit, a slider when you hover with a close badge, Reduce Transparency, and the midline placement over a full-screen app. macOS 14 and 15 keep the system bezel, which still matches there. (#76)
+- **Disconnects that stick.** A display you disconnect in Crisp stays disconnected across relaunch, sleep and reboot, until you reconnect it from the panel or from crispctl, and the card says so. Before, Crisp forgot the moment the display came back online. If a disconnect ever leaves you with no viewable screen, a dock pulled while the Mac slept for instance, Crisp brings a screen back within seconds. (#91, #93, #101, #104, #112)
+- **HiDPI past the cap on ultrawides.** WindowServer refuses scaled backings wider than about 6720 px, so a 5120x1440 panel never got the top of its scaling ladder. Crisp now routes those stops through a mirrored virtual display, so the panel gets them anyway. The mirror stays out of the display list and presets capture it. Wider panels only for now: 16:9 4K and 5K hit the same cap, but I haven't verified them, so they keep the old ladder. (#65)
+- **Combined Brightness by light output.** With Show Combined Brightness on, the built-in now tracks the external by estimated nits from each display's EDID instead of by percentage, so a 1000-nit monitor and a 500-nit panel land on the same brightness. One caveat: the only luminance an EDID carries is the HDR block, so an HDR monitor reports its HDR peak even in SDR, and the built-in tops out early beside it. The ratio slider in Settings is the way to balance that. (#83)
+- **Keys on the system's stops.** The brightness and volume keys move between the same sixteen stops macOS uses, so the fill lands on the dots, and a held key steps once per repeat at the system's rate instead of crawling toward the first stop. Keyboards that send F14 and F15, Logitech MX Keys among them, step brightness too. (#69)
+- **True Tone after wake.** Some externals came back from a full sleep with the tint computed while they were still link-training. Crisp now re-asserts True Tone once after a full wake, as soon as an external is back. Display sleep is left alone. (#131)
+- **Managed Macs.** A configuration profile for com.crisp.app with crisp.disableKeepAwake set to true keeps Keep Awake off on company Macs. Crisp hides the row and never takes the assertion, and a user's own defaults cannot override it. (#70)
+- **Diagnostics.** Crisp writes to the unified log under com.crisp.app, with categories for ddc, brightness, volume, keys, display and app, and the bug report form now asks for that capture. `defaults write com.crisp.app crisp.showBrightnessControlMode -bool true` puts DDC or Software under each slider, so you can see which route a monitor is on. (#88, #90)
+
+## Fixed
+
+- Reconnecting a display through Crisp no longer freezes the Mac for seconds. WindowServer's enable was waiting behind a DDC read in flight, so Crisp now keeps DDC off the bus while a display is enabled or disabled. This should also be the freeze reported through a Lenovo hub (#33); I haven't had that one confirmed yet. (#110)
+- Disconnecting one display no longer drags the others to a different resolution, turns a portrait panel back to landscape, or switches a monitor into HDR. macOS applies the arrangement it remembers for the smaller set of displays, and Crisp puts all three back. (#108)
+- One slow DDC monitor no longer delays brightness changes on the others. (#71, #72)
+- A saved resolution no longer jumps to another display after a wake. It is keyed by the display's uuid now, not by its runtime id.
+- The brightness slider no longer comes up on 50 for a display that just reconnected. It was a placeholder that never got replaced when a monitor is slow to answer its first DDC read, and the next key press or click on the track then took the monitor to about half. Crisp remembers what each display was last at instead. (#151)
+- Crisp no longer changes a display's resolution at wake because of a mode you picked on a different desk. It used to remember a resolution per display forever and re-apply it at every wake, so a mode chosen with a monitor attached could override the one macOS correctly restores when that monitor is gone. It now only puts back a mode the sleep itself changed, and logs it when it does. (#152)
+- Colour temperature comes back after a display-only sleep. (#82)
+- Switching Extra Brightness off puts the monitor back in SDR when it was the boost that switched it to HDR.
+- The HDR toggle no longer sends a second request when it resyncs after a change.
+- The Show Volume Sliders row appears as soon as Volume Control is switched on for a display.
+- A crash reading XDR presets from the panel. (#87)
+- The menu panel keeps its window level, so another app's utility window can no longer draw over it.
+
+## Changed
+
+- The panel's icon chips are lighter, matching the system menus. (#85)
+
+## Contributors
+
+- @Juns-g: crispctl (#75), its display metadata (#81), and the Extra Brightness (#102) and HDR (#116) commands
+- @ncchen99: remembered disconnects (#101), the card caption (#104), and two rounds on the blackout rescue (#132, #133)
+- @DEOWL-kan: the slow DDC monitor fix (#71)
+- @alexlee2046: Combined Brightness by light output (#83)
+- @celsinho17: the crispctl connect, disconnect and toggle commands (#97)
+- @dboleslawski: the presets crash (#87)
+
+## Supporting Crisp
+
+Crisp is free and always will be. The nicest thank-you costs nothing: star the repo or tell a friend. If you'd like to help cover the $99/year Apple fee that keeps every build signed and notarized, there's [GitHub Sponsors](https://github.com/sponsors/didriksg), [Ko-fi](https://ko-fi.com/didriksg), or [Afdian (爱发电)](https://ifdian.net/a/didriksg). Thank you @rebelvg, @kuldipmaharjan, @arnor-ingthorsson and @BarryBarrywu for chipping in toward keeping Crisp signed and notarized.
+]]></description>
+            <enclosure url="https://github.com/didriksg/Crisp/releases/download/v1.6.0/Crisp.dmg" length="4766696" type="application/octet-stream" sparkle:edSignature="dgqRmGY5U7mhTDmtztHjhT0QJTNQCYASvtME/KoHZdbfMcpPwMRAXT58XJYAnC1aHMHV078ci75PGDH00AwRBQ=="></enclosure>
         </item>
     </channel>
-</rss>
-<!-- sparkle-signatures:
-edSignature: eTz6+wdFKpAFkis82/VuU4ff0LOUENTbzaD+spwfSo1ndR5JGj47gI8VMr8vvGGxzae9DtyUD6QAYHBxmF51Ag==
-length: 1751
+</rss><!-- sparkle-signatures:
+edSignature: p9H53SZSsOmIsHKloaThIcsFN2L+ObkdoSNBUFH04ZhBPkWQJoZ4XDPB5j/tfunmxUC4cDFfJIMXtiKWorcgAw==
+length: 8477
 -->

--- a/docs/crisp-vs-betterdisplay-zh.html
+++ b/docs/crisp-vs-betterdisplay-zh.html
@@ -4,13 +4,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>免费开源的 BetterDisplay 平替（macOS）：Crisp 对比 BetterDisplay / Lunar / MonitorControl</title>
-<meta name="description" content="在找免费的 BetterDisplay 平替？Crisp 是一个开源（MIT）的 macOS 菜单栏 App：灵活的 HiDPI 缩放、DDC 亮度、预设、排列全都免费，没有 Pro 分层、没有授权码，也不用破解。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
+<meta name="description" content="在找免费的 BetterDisplay 平替？Crisp 是一个开源（MIT）的 macOS 菜单栏 App：灵活的 HiDPI 缩放、DDC 亮度、预设、排列和命令行工具全都免费，没有 Pro 分层、没有授权码，也不用破解。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
 <link rel="canonical" href="https://crispmac.app/crisp-vs-betterdisplay-zh.html">
 <link rel="alternate" hreflang="zh-Hans" href="https://crispmac.app/crisp-vs-betterdisplay-zh.html">
 <link rel="alternate" hreflang="en" href="https://crispmac.app/crisp-vs-betterdisplay.html">
 <link rel="alternate" hreflang="x-default" href="https://crispmac.app/crisp-vs-betterdisplay.html">
 <meta property="og:title" content="免费开源的 BetterDisplay 平替（macOS）：Crisp">
-<meta property="og:description" content="Crisp 是一个免费开源（MIT）的 macOS 显示器管理工具：灵活 HiDPI、DDC 亮度、预设、排列全免费。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
+<meta property="og:description" content="Crisp 是一个免费开源（MIT）的 macOS 显示器管理工具：灵活 HiDPI、DDC 亮度、预设、排列、命令行工具全免费。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
 <meta property="og:image" content="https://crispmac.app/og-card-zh.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -18,7 +18,7 @@
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="免费开源的 BetterDisplay 平替（macOS）：Crisp">
-<meta name="twitter:description" content="Crisp 是一个免费开源（MIT）的 macOS 显示器管理工具：灵活 HiDPI、DDC 亮度、预设、排列全免费。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
+<meta name="twitter:description" content="Crisp 是一个免费开源（MIT）的 macOS 显示器管理工具：灵活 HiDPI、DDC 亮度、预设、排列、命令行工具全免费。和 BetterDisplay、Lunar、MonitorControl 逐项对比。">
 <meta name="twitter:image" content="https://crispmac.app/og-card-zh.png">
 <link rel="icon" href="icon.png">
 <script type="application/ld+json">
@@ -199,7 +199,7 @@
     <p class="note">价格和免费 / Pro 的划分参考各自的官方文档整理（BetterDisplay、Lunar，截至 2026 年年中）。功能会在版本间调整，具体以官网为准。</p>
 
     <h2>为什么选 Crisp</h2>
-    <p>如果你要的只是 1440p 或 4K 显示器上清晰的 HiDPI，再加上亮度（Mac 的亮度键也能直接调外接屏，和内建屏一样）、预设和排列，Crisp 全都免费给你。现在还包括 <strong>XDR/HDR 亮度增强</strong>，把 XDR MacBook 和 HDR 显示器推过 100%，这项功能 BetterDisplay 和 Lunar 都锁在 Pro 里；另外还能通过 DDC 调显示器自带音箱的音量。<strong>不用重置试用期，不用花钱买授权码，更不用去找破解版</strong>，因为它根本没有付费版。开源（MIT），代码随便看，也能自己编译。</p>
+    <p>如果你要的只是 1440p 或 4K 显示器上清晰的 HiDPI，再加上亮度（Mac 的亮度键也能直接调外接屏，和内建屏一样）、预设和排列，Crisp 全都免费给你。现在还包括 <strong>XDR/HDR 亮度增强</strong>，把 XDR MacBook 和 HDR 显示器推过 100%，这项功能 BetterDisplay 和 Lunar 都锁在 Pro 里；另外还能通过 DDC 调显示器自带音箱的音量。App 里还内置了命令行工具 <code>crispctl</code>，亮度、HDR、额外亮度以及连接或断开显示器，都能在终端、Shell 脚本或快捷指令里完成。<strong>不用重置试用期，不用花钱买授权码，更不用去找破解版</strong>，因为它根本没有付费版。开源（MIT），代码随便看，也能自己编译。</p>
 
     <h2>BetterDisplay Pro 仍然领先的地方</h2>
     <p>先把话说清楚：Crisp 目前<strong>不支持</strong> EDID 覆写和画中画。如果你就是需要这些，<strong>BetterDisplay Pro 更合适</strong>，它成熟、维护得好，21.99 美元也算公道。但如果你要的只是日常的显示器控制，清晰又免费，Crisp 完全够用。</p>

--- a/docs/crisp-vs-betterdisplay.html
+++ b/docs/crisp-vs-betterdisplay.html
@@ -4,13 +4,13 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>A free, open-source BetterDisplay alternative for macOS: Crisp</title>
-<meta name="description" content="Looking for a free BetterDisplay alternative? Crisp is an open-source (MIT) macOS menu bar app with flexible HiDPI scaling, DDC brightness, presets and arrangement, all free, no Pro tier and no license key. Compared side by side with BetterDisplay, Lunar and MonitorControl.">
+<meta name="description" content="Looking for a free BetterDisplay alternative? Crisp is an open-source (MIT) macOS menu bar app with flexible HiDPI scaling, DDC brightness, presets, arrangement and a command line tool, all free, no Pro tier and no license key. Compared side by side with BetterDisplay, Lunar and MonitorControl.">
 <link rel="canonical" href="https://crispmac.app/crisp-vs-betterdisplay.html">
 <link rel="alternate" hreflang="en" href="https://crispmac.app/crisp-vs-betterdisplay.html">
 <link rel="alternate" hreflang="zh-Hans" href="https://crispmac.app/crisp-vs-betterdisplay-zh.html">
 <link rel="alternate" hreflang="x-default" href="https://crispmac.app/crisp-vs-betterdisplay.html">
 <meta property="og:title" content="A free, open-source BetterDisplay alternative for macOS: Crisp">
-<meta property="og:description" content="Crisp is a free, open-source (MIT) macOS display manager. Flexible HiDPI, DDC brightness, presets and arrangement, all free. Compared with BetterDisplay, Lunar and MonitorControl.">
+<meta property="og:description" content="Crisp is a free, open-source (MIT) macOS display manager. Flexible HiDPI, DDC brightness, presets, arrangement and a command line tool, all free. Compared with BetterDisplay, Lunar and MonitorControl.">
 <meta property="og:image" content="https://crispmac.app/og-card.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
@@ -18,7 +18,7 @@
 <meta property="og:type" content="article">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="A free, open-source BetterDisplay alternative for macOS: Crisp">
-<meta name="twitter:description" content="Crisp is a free, open-source (MIT) macOS display manager. Flexible HiDPI, DDC brightness, presets and arrangement, all free. Compared with BetterDisplay, Lunar and MonitorControl.">
+<meta name="twitter:description" content="Crisp is a free, open-source (MIT) macOS display manager. Flexible HiDPI, DDC brightness, presets, arrangement and a command line tool, all free. Compared with BetterDisplay, Lunar and MonitorControl.">
 <meta name="twitter:image" content="https://crispmac.app/og-card.png">
 <link rel="icon" href="icon.png">
 <script type="application/ld+json">
@@ -199,7 +199,7 @@
     <p class="note">Prices and free/Pro splits from each app's own documentation (BetterDisplay and Lunar, mid-2026). Features move between tiers over time, so check their sites for the current state.</p>
 
     <h2>Where Crisp wins</h2>
-    <p>If what you wanted from BetterDisplay was <strong>sharp HiDPI on a 1440p or 4K monitor</strong>, plus brightness (your Mac's own brightness keys drive the external monitors too, just like the built-in), presets and arrangement, Crisp gives you all of it for free. That now includes <strong>XDR/HDR extra brightness</strong>, pushing an XDR MacBook or HDR monitor past 100%, which BetterDisplay and Lunar both keep behind Pro, and DDC volume for the monitor's built-in speakers. There is no trial to reset and no license to buy, because there is no paid tier at all. It is open source, so you can read exactly what it does or build it yourself.</p>
+    <p>If what you wanted from BetterDisplay was <strong>sharp HiDPI on a 1440p or 4K monitor</strong>, plus brightness (your Mac's own brightness keys drive the external monitors too, just like the built-in), presets and arrangement, Crisp gives you all of it for free. That now includes <strong>XDR/HDR extra brightness</strong>, pushing an XDR MacBook or HDR monitor past 100%, which BetterDisplay and Lunar both keep behind Pro, and DDC volume for the monitor's built-in speakers. Crisp also ships <code>crispctl</code>, a command line tool inside the app, so brightness, HDR, Extra Brightness and connecting or disconnecting a display can be driven from the terminal, a shell script or an Apple Shortcut. There is no trial to reset and no license to buy, because there is no paid tier at all. It is open source, so you can read exactly what it does or build it yourself.</p>
 
     <h2>Where BetterDisplay Pro is still ahead</h2>
     <p>Being honest keeps this useful. Crisp does <strong>not</strong> do EDID overrides or picture-in-picture. If you specifically need either of those, <strong>BetterDisplay Pro is the better buy</strong>, it is a mature, well-supported app and $21.99 is fair for what it does. Crisp is the right pick when you want the everyday display controls, sharp and free, without a subscription mindset.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -83,6 +83,7 @@
         <div class="card reveal"><h3>Native toggles</h3><p>Flip macOS Dark Mode, Night Shift, and True Tone right from the panel, no System Settings trip.</p></div>
         <div class="card reveal"><h3>Color</h3><p>ICC profile switching, HDR on/off per display, plus gamma, contrast, and gain adjustment.</p></div>
         <div class="card reveal"><h3>Virtual displays</h3><p>Create HiDPI virtual screens for streaming, sidecar setups, or headless Macs.</p></div>
+        <div class="card reveal"><h3>Command line</h3><p>crispctl ships inside the app: read and set brightness, HDR and Extra Brightness, or connect and disconnect a display, from the terminal, a script, or an Apple Shortcut.</p></div>
         <div class="card reveal"><h3>Extras</h3><p>Combined brightness slider, auto brightness sync, keep awake, notch hiding, launch at login.</p></div>
       </div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,16 +5,16 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="google-site-verification" content="Pb7coFWl3eF3E_6mT6jdH6sbJYJ5VY3iLoSKt-bNy2w">
 <title>Crisp: Free BetterDisplay &amp; Lunar alternative for macOS</title>
-<meta name="description" content="Crisp is a free, open-source, lightweight alternative to BetterDisplay and Lunar for macOS: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar.">
+<meta name="description" content="Crisp is a free, open-source, lightweight alternative to BetterDisplay and Lunar for macOS: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar, plus crispctl, a command line tool for the terminal, scripts and Apple Shortcuts.">
 <meta property="og:title" content="Crisp: Free BetterDisplay &amp; Lunar alternative for macOS">
-<meta property="og:description" content="A free, open-source alternative to BetterDisplay and Lunar: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar.">
+<meta property="og:description" content="A free, open-source alternative to BetterDisplay and Lunar: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar, plus a command line tool.">
 <meta property="og:image" content="https://crispmac.app/og-card.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:url" content="https://crispmac.app/">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Crisp: Free BetterDisplay &amp; Lunar alternative for macOS">
-<meta name="twitter:description" content="A free, open-source alternative to BetterDisplay and Lunar: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar.">
+<meta name="twitter:description" content="A free, open-source alternative to BetterDisplay and Lunar: DDC brightness, HiDPI scaling, presets, virtual displays, and arrangement, all in the menu bar, plus a command line tool.">
 <meta name="twitter:image" content="https://crispmac.app/og-card.png">
 <link rel="canonical" href="https://crispmac.app/">
 <link rel="alternate" hreflang="en" href="https://crispmac.app/">
@@ -22,7 +22,7 @@
 <link rel="alternate" hreflang="x-default" href="https://crispmac.app/">
 <link rel="icon" href="icon.png">
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Crisp","operatingSystem":"macOS 14+","applicationCategory":"UtilitiesApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://crispmac.app/","downloadUrl":"https://github.com/didriksg/Crisp/releases/latest/download/Crisp.dmg","screenshot":"https://crispmac.app/screenshot.png","softwareLicense":"https://github.com/didriksg/Crisp/blob/main/LICENSE","author":{"@type":"Person","name":"Didrik Galteland","url":"https://github.com/didriksg"}}
+{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Crisp","operatingSystem":"macOS 14+","applicationCategory":"UtilitiesApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://crispmac.app/","downloadUrl":"https://github.com/didriksg/Crisp/releases/latest/download/Crisp.dmg","screenshot":"https://crispmac.app/screenshot.png","featureList":["HiDPI scaled resolutions on any external monitor","DDC/CI hardware brightness and volume control","Brightness keys for external displays","Extra Brightness using HDR and XDR headroom","Display presets with keyboard shortcuts","Display arrangement and main display switching","Virtual displays","ICC profiles, HDR toggle, gamma and gain","crispctl command line tool for the terminal, shell scripts and Apple Shortcuts"],"softwareLicense":"https://github.com/didriksg/Crisp/blob/main/LICENSE","author":{"@type":"Person","name":"Didrik Galteland","url":"https://github.com/didriksg"}}
 </script>
 <script type="application/ld+json">
 {"@context":"https://schema.org","@type":"VideoObject","name":"Crisp menu bar demo","description":"A tour of Crisp, a free macOS menu bar app for HiDPI scaling, DDC brightness, presets and display arrangement.","thumbnailUrl":"https://crispmac.app/screenshot.png","uploadDate":"2026-07-31T12:00:00+02:00","contentUrl":"https://crispmac.app/demo.mp4","width":1920,"height":1080}
@@ -127,6 +127,10 @@
         <details>
           <summary>What does Crisp require?</summary>
           <p>macOS 14 (Sonoma) or later, on both Apple Silicon and Intel Macs. A few extras, like disconnecting a display from the menu, are Apple Silicon only.</p>
+        </details>
+        <details>
+          <summary>Can I control my displays from the terminal or a script?</summary>
+          <p>Yes. Crisp ships a command line tool, <code>crispctl</code>, inside the app, and a switch in Settings links it into <code>/usr/local/bin</code>. From the terminal, a shell script, or an Apple Shortcut you can list displays, read and set brightness, switch HDR and Extra Brightness, and connect or disconnect a display, by display id or UUID.</p>
         </details>
         <details>
           <summary>How is Crisp different from BetterDisplay and Lunar?</summary>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,19 +2,19 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://crispmac.app/</loc>
-    <lastmod>2026-08-03</lastmod>
+    <lastmod>2026-09-08</lastmod>
   </url>
   <url>
     <loc>https://crispmac.app/zh.html</loc>
-    <lastmod>2026-08-03</lastmod>
+    <lastmod>2026-09-08</lastmod>
   </url>
   <url>
     <loc>https://crispmac.app/crisp-vs-betterdisplay.html</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-09-08</lastmod>
   </url>
   <url>
     <loc>https://crispmac.app/crisp-vs-betterdisplay-zh.html</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-09-08</lastmod>
   </url>
   <url>
     <loc>https://crispmac.app/fix-blurry-external-monitor-macos.html</loc>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -82,6 +82,7 @@
         <div class="card reveal"><h3>系统开关</h3><p>深色模式、夜览、原彩显示，直接在面板里切，不用进系统设置。</p></div>
         <div class="card reveal"><h3>色彩</h3><p>ICC 配置切换、每块屏独立开关 HDR，外加 gamma、对比度、增益微调。</p></div>
         <div class="card reveal"><h3>虚拟显示器</h3><p>创建 HiDPI 虚拟屏，用于直播、随航或无头 Mac。</p></div>
+        <div class="card reveal"><h3>命令行</h3><p>App 内置 crispctl：在终端、脚本或快捷指令里读取和设置亮度、开关 HDR 与额外亮度，或连接、断开某块显示器。</p></div>
         <div class="card reveal"><h3>更多</h3><p>合并亮度滑块、自动亮度跟随内建屏、防止睡眠、隐藏刘海、开机启动。</p></div>
       </div>
     </div>

--- a/docs/zh.html
+++ b/docs/zh.html
@@ -4,16 +4,16 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Crisp：BetterDisplay 和 Lunar 的免费开源平替（macOS 显示器管理）</title>
-<meta name="description" content="Crisp 是 BetterDisplay 和 Lunar 的免费开源平替：一个轻量的 macOS 菜单栏 App，集成 DDC 亮度、HiDPI 缩放、预设、虚拟显示器和排列，连它们的部分收费功能也免费。">
+<meta name="description" content="Crisp 是 BetterDisplay 和 Lunar 的免费开源平替：一个轻量的 macOS 菜单栏 App，集成 DDC 亮度、HiDPI 缩放、预设、虚拟显示器和排列，连它们的部分收费功能也免费；还内置 crispctl 命令行工具，可以在终端、脚本和快捷指令里控制显示器。">
 <meta property="og:title" content="Crisp：BetterDisplay 和 Lunar 的免费开源平替">
-<meta property="og:description" content="免费开源的 macOS 菜单栏工具：DDC 亮度、HiDPI 缩放、预设、虚拟显示器、排列，一个面板全搞定。">
+<meta property="og:description" content="免费开源的 macOS 菜单栏工具：DDC 亮度、HiDPI 缩放、预设、虚拟显示器、排列，一个面板全搞定，还有命令行工具。">
 <meta property="og:image" content="https://crispmac.app/og-card-zh.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:url" content="https://crispmac.app/zh.html">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Crisp：BetterDisplay 和 Lunar 的免费开源平替">
-<meta name="twitter:description" content="免费开源的 macOS 菜单栏工具：DDC 亮度、HiDPI 缩放、预设、虚拟显示器、排列，一个面板全搞定。">
+<meta name="twitter:description" content="免费开源的 macOS 菜单栏工具：DDC 亮度、HiDPI 缩放、预设、虚拟显示器、排列，一个面板全搞定，还有命令行工具。">
 <meta name="twitter:image" content="https://crispmac.app/og-card-zh.png">
 <link rel="canonical" href="https://crispmac.app/zh.html">
 <link rel="alternate" hreflang="zh-Hans" href="https://crispmac.app/zh.html">
@@ -21,7 +21,7 @@
 <link rel="alternate" hreflang="x-default" href="https://crispmac.app/">
 <link rel="icon" href="icon.png">
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Crisp","operatingSystem":"macOS 14+","applicationCategory":"UtilitiesApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://crispmac.app/zh.html","downloadUrl":"https://github.com/didriksg/Crisp/releases/latest/download/Crisp.dmg","screenshot":"https://crispmac.app/screenshot-zh.png","softwareLicense":"https://github.com/didriksg/Crisp/blob/main/LICENSE","author":{"@type":"Person","name":"Didrik Galteland","url":"https://github.com/didriksg"}}
+{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Crisp","operatingSystem":"macOS 14+","applicationCategory":"UtilitiesApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://crispmac.app/zh.html","downloadUrl":"https://github.com/didriksg/Crisp/releases/latest/download/Crisp.dmg","screenshot":"https://crispmac.app/screenshot-zh.png","featureList":["给任意外接显示器补上 HiDPI 缩放分辨率","DDC/CI 硬件亮度和音量控制","用键盘亮度键控制外接显示器","额外亮度：利用 HDR 和 XDR 亮度余量","显示器预设与全局快捷键","显示器排列与主显示器切换","虚拟显示器","ICC 描述文件、HDR 开关、伽马与增益","crispctl 命令行工具，支持终端、脚本和快捷指令"],"softwareLicense":"https://github.com/didriksg/Crisp/blob/main/LICENSE","author":{"@type":"Person","name":"Didrik Galteland","url":"https://github.com/didriksg"}}
 </script>
 <script type="application/ld+json">
 {"@context":"https://schema.org","@type":"VideoObject","name":"Crisp 菜单栏演示","description":"Crisp 是一个免费的 macOS 菜单栏工具，支持 HiDPI 缩放、DDC 亮度、预设和显示器排列，这是功能演示。","thumbnailUrl":"https://crispmac.app/screenshot-zh.png","uploadDate":"2026-07-31T12:00:00+02:00","contentUrl":"https://crispmac.app/demo.mp4","width":1920,"height":1080}
@@ -126,6 +126,10 @@
         <details>
           <summary>使用 Crisp 需要什么条件？</summary>
           <p>macOS 14（Sonoma）及以上，Apple 芯片和 Intel Mac 都支持。少数功能（如从菜单断开显示器）仅限 Apple 芯片。</p>
+        </details>
+        <details>
+          <summary>可以在终端或脚本里控制显示器吗？</summary>
+          <p>可以。Crisp 在 App 内置了命令行工具 <code>crispctl</code>，在设置里打开开关就会把它链接到 <code>/usr/local/bin</code>。在终端、Shell 脚本或快捷指令里，你可以列出显示器、读取和设置亮度、开关 HDR 和额外亮度，也可以连接或断开某块显示器，按显示器 id 或 UUID 指定。</p>
         </details>
         <details>
           <summary>Crisp 和 BetterDisplay、Lunar 有什么区别？</summary>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -221,13 +221,18 @@ gh release create "$TAG" --title "Crisp ${TAG}" --notes-file "$NOTES" "$DMG"
 # ./vendor/Sparkle/bin/generate_keys) and points the enclosure at the release
 # asset uploaded above.
 # ponytail: single-entry appcast, latest release only; old installs only ever
-# need the newest version. Embed HTML release notes here if ever wanted.
+# need the newest version.
+# generate_appcast reads release notes from a .md/.html/.txt file whose name matches
+# the archive, so the notes we just published to GitHub land in the update dialog too.
 echo "==> Generating Sparkle appcast…"
 APPCAST_STAGE="$BUILD/appcast"; mkdir -p "$APPCAST_STAGE"
 cp "$DMG" "$APPCAST_STAGE/Crisp.dmg"
+cp "$NOTES" "$APPCAST_STAGE/Crisp.md"
 "$ROOT/vendor/Sparkle/bin/generate_appcast" \
   --download-url-prefix "https://github.com/didriksg/Crisp/releases/download/${TAG}/" \
   --link "https://github.com/didriksg/Crisp/releases" \
+  --full-release-notes-url "https://github.com/didriksg/Crisp/releases" \
+  --embed-release-notes \
   -o "$ROOT/docs/appcast.xml" "$APPCAST_STAGE"
 
 echo "==> Released ${TAG}."


### PR DESCRIPTION
Sparkle showed a version number and an empty notes pane, so anyone taking an in-app update had no idea what changed without going to GitHub. Neither the 1.5.0 nor the 1.6.0 item carried a `<description>` or a `sparkle:releaseNotesLink`.

`generate_appcast` reads release notes from a `.md`, `.html` or `.txt` file whose name matches the archive, so `release.sh` now copies the notes file it already requires for `--publish` into the appcast staging directory as `Crisp.md`, and passes `--embed-release-notes` plus a `--full-release-notes-url` pointing at the releases page. Sparkle 2 renders markdown natively (`sparkle:format="markdown"`), so the notes need no conversion and there is no second file to keep in sync. It also cannot be forgotten, because the notes file is already a required argument.

This also regenerates the 1.6.0 entry so people updating now see its notes rather than a blank pane. Verified before pushing: the enclosure signature (`dgqRmGY5U7mh…`) and length (4,766,696) are byte-identical to the live feed, so no download changes, only the description is new; the file is well-formed XML and freshly signed.

The 1.5.0 item drops out of the feed, which changes nothing in practice. Both items declare macOS 14 as their minimum and Sparkle only ever offers the newest item a Mac can run, so 1.5.0 has never been offerable to anyone. It also matches what release.sh already states it intends, a single-entry appcast carrying the latest release only.