### PR TITLE
Bind brightness up and down to your own shortcuts (#160)

### DIFF
--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -332,6 +332,16 @@
         }
       }
     },
+    "Brightness Down" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "调低亮度"
+          }
+        }
+      }
+    },
     "Brightness Keys" : {
       "extractionState" : "stale",
       "localizations" : {
@@ -349,6 +359,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "亮度键需要辅助功能权限才能重定向到外接显示器。授权一次即可使用，无需重启。"
+          }
+        }
+      }
+    },
+    "Brightness Up" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "调高亮度"
           }
         }
       }
@@ -1858,6 +1878,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "扬声器音量"
+          }
+        }
+      }
+    },
+    "Steps brightness like the brightness keys, on the same displays. For keyboards without them." : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以与亮度键相同的步进调节亮度，作用于相同的显示器。适用于没有亮度键的键盘。"
           }
         }
       }

--- a/Crisp/Services/BrightnessKeyService.swift
+++ b/Crisp/Services/BrightnessKeyService.swift
@@ -303,29 +303,18 @@ final class BrightnessKeyService: @unchecked Sendable {
     nonisolated private func routeBrightnessPress(up: Bool, event: CGEvent) -> Unmanaged<CGEvent>? {
         // Route by user preference. Read on the main actor, this callback runs on
         // the main run loop (see class docs), so assumeIsolated is safe here.
-        switch MainActor.assumeIsolated({ SettingsService.shared.brightnessKeyTarget }) {
-        case .allDisplays:
-            Task { @MainActor in self.adjustDisplays(DisplayManagerAccessor.shared.displays, up: up) }
-            // Consume: we adjust every display (built-in included) ourselves, so
+        // Which displays a press moves is the same rule for a key and for a bound
+        // shortcut (see adjustFromShortcut). Only the under-cursor case needs the
+        // tap's own pass-through handling, so it is the one that falls through here.
+        // The decision has to be synchronous (consume or not), the work does not.
+        let hasExplicitTargets = MainActor.assumeIsolated { self.explicitTargets() != nil }
+        if hasExplicitTargets {
+            Task { @MainActor in
+                if let targets = self.explicitTargets() { self.adjustDisplays(targets, up: up) }
+            }
+            // Consume: we adjust every target (built-in included) ourselves, so
             // macOS must not also bump the built-in on top.
             return nil
-        case .selected:
-            // Adjust only the chosen displays that are currently attached. If none
-            // are attached, fall through to the under-cursor path so the key still
-            // does something instead of being dead.
-            let selected = MainActor.assumeIsolated { SettingsService.shared.brightnessKeySelectedDisplayUUIDs }
-            let anyAttached = MainActor.assumeIsolated {
-                DisplayManagerAccessor.shared.displays.contains { selected.contains($0.displayUUID) }
-            }
-            if anyAttached {
-                Task { @MainActor in
-                    let targets = DisplayManagerAccessor.shared.displays.filter { selected.contains($0.displayUUID) }
-                    self.adjustDisplays(targets, up: up)
-                }
-                return nil
-            }
-        case .underCursor:
-            break
         }
         // .underCursor (or .selected with none of the chosen displays attached):
         // fall through to the under-cursor path below.
@@ -418,10 +407,47 @@ final class BrightnessKeyService: @unchecked Sendable {
         return nil
     }
 
+    /// The displays the Brightness Keys target setting names outright, or nil when
+    /// it leaves the choice to the pointer: the under-cursor setting, and the chosen
+    /// subset with none of its displays attached, where the pointer is the fallback
+    /// so a press still does something instead of being dead.
+    private func explicitTargets() -> [DisplayInfo]? {
+        let displays = DisplayManagerAccessor.shared.displays
+        switch SettingsService.shared.brightnessKeyTarget {
+        case .allDisplays:
+            return displays
+        case .selected:
+            let selected = SettingsService.shared.brightnessKeySelectedDisplayUUIDs
+            let targets = displays.filter { selected.contains($0.displayUUID) }
+            return targets.isEmpty ? nil : targets
+        case .underCursor:
+            return nil
+        }
+    }
+
+    /// Steps brightness for a shortcut bound in Settings > Keyboard Shortcuts
+    /// (issue #160), for keyboards whose brightness keys are missing or taken.
+    /// Same stops, same fades, same banner and same targets as the keys.
+    /// One difference, and it cannot be otherwise: with the pointer on the built-in
+    /// the keys hand the event to macOS, while a shortcut has no event to hand over,
+    /// so Crisp moves the built-in itself, as it already does in all-displays mode.
+    func adjustFromShortcut(up: Bool) {
+        if let targets = explicitTargets() {
+            adjustDisplays(targets, up: up)
+            return
+        }
+        let mouse = NSEvent.mouseLocation
+        guard let screen = NSScreen.screens.first(where: { NSMouseInRect(mouse, $0.frame, false) }),
+              let displayID = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID,
+              let display = DisplayManagerAccessor.shared.displays.first(where: { $0.displayID == displayID })
+        else { return }
+        adjustDisplays([display], up: up)
+    }
+
     /// Moves each given display (built-in or external) to its next stop,
     /// through BrightnessService's smooth fade (reusing its DDC/gamma/IOKit paths +
     /// coalescing), and shows the brightness HUD on each display's own screen.
-    /// Backs the `.allDisplays` and `.selected` brightness-key modes.
+    /// Backs the `.allDisplays` and `.selected` key modes and the shortcuts.
     @MainActor
     private func adjustDisplays(_ displays: [DisplayInfo], up: Bool) {
         let screens = NSScreen.screens

--- a/Crisp/Services/HotkeyService.swift
+++ b/Crisp/Services/HotkeyService.swift
@@ -18,6 +18,7 @@ final class HotkeyService {
     private enum Target {
         case preset(UUID)
         case hidpiToggle
+        case brightness(up: Bool)
     }
 
     private var handlerRef: EventHandlerRef?
@@ -32,6 +33,15 @@ final class HotkeyService {
     /// row's stop after the other row's start, so a Bool would re-arm every
     /// hotkey while the second row still records.
     private var suspensions = 0
+
+    /// Held-down repeat for the brightness shortcuts. Carbon hotkeys fire once per
+    /// press and never repeat, where the brightness keys step for as long as they
+    /// are held, so the repeat is ours to run: kEventHotKeyReleased stops it.
+    private var repeatTimer: Timer?
+    /// Stops the repeat even if a release never arrives (another app taking the
+    /// combo, the modifier going up first). Well past a full sweep of the sixteen
+    /// stops at any system repeat rate.
+    private static let repeatCeiling: TimeInterval = 5.0
 
     func beginSuspension() {
         suspensions += 1
@@ -59,6 +69,12 @@ final class HotkeyService {
         if let shortcut = SettingsService.shared.hidpiShortcut {
             register(shortcut, for: .hidpiToggle)
         }
+        if let shortcut = SettingsService.shared.brightnessUpShortcut {
+            register(shortcut, for: .brightness(up: true))
+        }
+        if let shortcut = SettingsService.shared.brightnessDownShortcut {
+            register(shortcut, for: .brightness(up: false))
+        }
         Self.log.info("synced: \(self.registrations.count) hotkey(s) registered")
     }
 
@@ -77,11 +93,17 @@ final class HotkeyService {
         }
     }
 
-    /// One process-wide handler; presses carry the EventHotKeyID that fired.
+    /// One process-wide handler; events carry the EventHotKeyID that fired. Both
+    /// kinds are watched: a press runs the action, a release ends a held brightness
+    /// repeat.
     private func installHandlerIfNeeded() {
         guard handlerRef == nil else { return }
-        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
-                                      eventKind: UInt32(kEventHotKeyPressed))
+        var eventTypes = [
+            EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                          eventKind: UInt32(kEventHotKeyPressed)),
+            EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                          eventKind: UInt32(kEventHotKeyReleased))
+        ]
         let status = InstallEventHandler(GetEventDispatcherTarget(), { _, event, _ in
             // C-function callback, no captures; read which hotkey fired, then
             // hop to the main actor for the action.
@@ -90,9 +112,16 @@ final class HotkeyService {
                               EventParamType(typeEventHotKeyID), nil,
                               MemoryLayout<EventHotKeyID>.size, nil, &hotKeyID)
             let id = hotKeyID.id
-            Task { @MainActor in HotkeyService.shared.fire(id: id) }
+            let pressed = GetEventKind(event) == UInt32(kEventHotKeyPressed)
+            Task { @MainActor in
+                if pressed {
+                    HotkeyService.shared.fire(id: id)
+                } else {
+                    HotkeyService.shared.releaseHeld(id: id)
+                }
+            }
             return noErr
-        }, 1, &eventType, nil, &handlerRef)
+        }, eventTypes.count, &eventTypes, nil, &handlerRef)
         if status != noErr { Self.log.error("InstallEventHandler failed (status \(status))") }
     }
 
@@ -110,9 +139,42 @@ final class HotkeyService {
             Task { await PresetService.shared.applyPreset(preset) }
         case .hidpiToggle:
             toggleHiDPIUnderCursor()
+        case .brightness(let up):
+            BrightnessKeyService.shared.adjustFromShortcut(up: up)
+            startRepeat(up: up)
         case nil:
             break
         }
+    }
+
+    /// A hotkey came back up. Only the brightness shortcuts repeat, so only they
+    /// have something to stop; a preset shortcut released while brightness is held
+    /// must not cut that repeat short.
+    private func releaseHeld(id: UInt32) {
+        if case .brightness = registrations[id]?.target { stopRepeat() }
+    }
+
+    /// Keeps stepping while the shortcut is held, after the system's own repeat
+    /// delay and at the system's own rate, so it feels like a held brightness key.
+    private func startRepeat(up: Bool) {
+        stopRepeat()
+        let deadline = Date().addingTimeInterval(Self.repeatCeiling)
+        let timer = Timer(fire: Date().addingTimeInterval(NSEvent.keyRepeatDelay),
+                          interval: NSEvent.keyRepeatInterval,
+                          repeats: true) { timer in
+            // Added to the main run loop below, so it fires on the main actor.
+            MainActor.assumeIsolated {
+                guard Date() < deadline else { timer.invalidate(); return }
+                BrightnessKeyService.shared.adjustFromShortcut(up: up)
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        repeatTimer = timer
+    }
+
+    private func stopRepeat() {
+        repeatTimer?.invalidate()
+        repeatTimer = nil
     }
 
     // MARK: - Action

--- a/Crisp/Services/SettingsService.swift
+++ b/Crisp/Services/SettingsService.swift
@@ -63,6 +63,8 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
         static let brightnessKeyTarget    = "crisp.brightnessKeyTarget"
         static let brightnessKeySelected  = "crisp.brightnessKeySelectedDisplays"
         static let hidpiShortcut          = "crisp.hidpiShortcut"
+        static let brightnessUpShortcut   = "crisp.brightnessUpShortcut"
+        static let brightnessDownShortcut = "crisp.brightnessDownShortcut"
         // Per-display keys use prefix + displayID
         // Brightness is the exception: prefix + display UUID, since displayIDs
         // are reused across reconnects (same reason as crisp.softBrightness.uuid.*).
@@ -136,6 +138,47 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
             } else {
                 defaults.removeObject(forKey: Keys.hidpiShortcut)
             }
+        }
+    }
+
+    /// Global shortcuts that step brightness up and down exactly as the brightness
+    /// keys do, for keyboards without those keys or with them taken (issue #160);
+    /// nil when not set. Registration is the caller's job, as above.
+    @Published var brightnessUpShortcut: KeyboardShortcut? = nil {
+        didSet {
+            if let brightnessUpShortcut, let data = try? JSONEncoder().encode(brightnessUpShortcut) {
+                defaults.set(data, forKey: Keys.brightnessUpShortcut)
+            } else {
+                defaults.removeObject(forKey: Keys.brightnessUpShortcut)
+            }
+        }
+    }
+
+    @Published var brightnessDownShortcut: KeyboardShortcut? = nil {
+        didSet {
+            if let brightnessDownShortcut, let data = try? JSONEncoder().encode(brightnessDownShortcut) {
+                defaults.set(data, forKey: Keys.brightnessDownShortcut)
+            } else {
+                defaults.removeObject(forKey: Keys.brightnessDownShortcut)
+            }
+        }
+    }
+
+    /// One combo, one action: clears `shortcut` off every other Keyboard Shortcuts
+    /// row and off any preset holding it, then `assign` gives it to this one.
+    /// Carbon refuses a second registration of the same combo, so without this the
+    /// row the user just set would be the dead one.
+    func assignStaticShortcut(_ shortcut: KeyboardShortcut?, assign: (KeyboardShortcut?) -> Void) {
+        if let shortcut {
+            if hidpiShortcut?.sameKeys(as: shortcut) == true { hidpiShortcut = nil }
+            if brightnessUpShortcut?.sameKeys(as: shortcut) == true { brightnessUpShortcut = nil }
+            if brightnessDownShortcut?.sameKeys(as: shortcut) == true { brightnessDownShortcut = nil }
+        }
+        assign(shortcut)
+        if let shortcut {
+            PresetService.shared.stealShortcutFromPresets(shortcut)  // persists and syncs
+        } else {
+            HotkeyService.shared.syncRegistrations()
         }
     }
 
@@ -219,6 +262,10 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
             .flatMap(BrightnessKeyTarget.init(rawValue:)) ?? .underCursor
         brightnessKeySelectedDisplayUUIDs = Set(defaults.stringArray(forKey: Keys.brightnessKeySelected) ?? [])
         hidpiShortcut = defaults.data(forKey: Keys.hidpiShortcut)
+            .flatMap { try? JSONDecoder().decode(KeyboardShortcut.self, from: $0) }
+        brightnessUpShortcut = defaults.data(forKey: Keys.brightnessUpShortcut)
+            .flatMap { try? JSONDecoder().decode(KeyboardShortcut.self, from: $0) }
+        brightnessDownShortcut = defaults.data(forKey: Keys.brightnessDownShortcut)
             .flatMap { try? JSONDecoder().decode(KeyboardShortcut.self, from: $0) }
     }
 }

--- a/Crisp/Views/ShortcutsSectionView.swift
+++ b/Crisp/Views/ShortcutsSectionView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 /// Settings > Shortcuts: the curated list of named global-shortcut actions
-/// (issue #61). One action today, Toggle HiDPI; the bar for adding another is
-/// "someone asked" (see the 2026-08-18 spec). Per-preset shortcuts live on the
+/// (issue #61). Toggle HiDPI, plus brightness up and down for keyboards whose
+/// brightness keys are missing or taken (issue #160); the bar for adding another
+/// is "someone asked" (see the 2026-08-18 spec). Per-preset shortcuts live on the
 /// presets themselves, not here. Expands in place per DESIGN.md.
 struct ShortcutsSection: View {
     @ObservedObject private var settings = SettingsService.shared
@@ -14,7 +15,9 @@ struct ShortcutsSection: View {
         VStack(alignment: .leading, spacing: 0) {
             ExpandableRow(
                 icon: "command",
-                iconActive: settings.hidpiShortcut != nil,
+                iconActive: settings.hidpiShortcut != nil
+                    || settings.brightnessUpShortcut != nil
+                    || settings.brightnessDownShortcut != nil,
                 // No combo subtitle: the header names a category, and a single
                 // binding there reads as the section's own shortcut. Bindings
                 // show only on their action rows inside.
@@ -24,29 +27,42 @@ struct ShortcutsSection: View {
             if expanded {
                 ShortcutRecorderRow(
                     label: "Toggle HiDPI",
-                    shortcut: Binding(
-                        get: { settings.hidpiShortcut },
-                        set: { newValue in
-                            // Commits immediately (no form): store, steal the
-                            // combo from any preset holding it, re-register.
-                            settings.hidpiShortcut = newValue
-                            if let newValue {
-                                PresetService.shared.stealShortcutFromPresets(newValue)
-                            } else {
-                                HotkeyService.shared.syncRegistrations()
-                            }
-                        }
-                    ),
+                    // Commits immediately (no form): store, take the combo off
+                    // whatever else held it, re-register.
+                    shortcut: binding(\.hidpiShortcut) { settings.hidpiShortcut = $0 },
                     leadingInset: 34
                 )
-                Text("Switches the display under the pointer between HiDPI and low resolution.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.horizontal, 12)
-                    .padding(.leading, 34)
-                    .padding(.bottom, 4)
+                caption("Switches the display under the pointer between HiDPI and low resolution.")
+                ShortcutRecorderRow(
+                    label: "Brightness Up",
+                    shortcut: binding(\.brightnessUpShortcut) { settings.brightnessUpShortcut = $0 },
+                    leadingInset: 34
+                )
+                ShortcutRecorderRow(
+                    label: "Brightness Down",
+                    shortcut: binding(\.brightnessDownShortcut) { settings.brightnessDownShortcut = $0 },
+                    leadingInset: 34
+                )
+                caption("Steps brightness like the brightness keys, on the same displays. For keyboards without them.")
             }
         }
+    }
+
+    private func binding(_ path: KeyPath<SettingsService, KeyboardShortcut?>,
+                         assign: @escaping (KeyboardShortcut?) -> Void) -> Binding<KeyboardShortcut?> {
+        Binding(
+            get: { settings[keyPath: path] },
+            set: { newValue in settings.assignStaticShortcut(newValue, assign: assign) }
+        )
+    }
+
+    private func caption(_ text: LocalizedStringKey) -> some View {
+        Text(text)
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, 12)
+            .padding(.leading, 34)
+            .padding(.bottom, 4)
     }
 }


### PR DESCRIPTION
Crisp already steps brightness from the keyboard, but only through the brightness keys themselves. If a keyboard has no brightness keys, or something else has taken F1 and F2, there was no keyboard path at all. That is the request in #160.

Brightness Up and Brightness Down now sit in Settings > Keyboard Shortcuts next to Toggle HiDPI, bound to whatever combo you like, unset by default. They are Carbon hotkeys like the rest of that list, so unlike Brightness Keys they need no Accessibility permission.

They behave like the keys because they run the keys' code. `adjustFromShortcut` steps to the next of the same sixteen macOS stops from the in-flight fade target, clamps to the display's maximum so Extra Brightness carries past 100, fades through `BrightnessService` and shows the same banner. The target rule (all displays, the chosen subset, else the display under the pointer) moved into one `explicitTargets()` that the key tap and the shortcut both read, so the two cannot drift apart.

Two things a shortcut cannot copy exactly. With the pointer on the built-in a brightness key is passed through for macOS to handle, and a shortcut has no event to hand over, so Crisp moves the built-in itself, which is what all-displays mode already does. And Carbon hotkeys fire once per press with no repeat, where a held brightness key keeps stepping, so `HotkeyService` now watches `kEventHotKeyReleased` and runs the repeat itself at the system's own delay and rate, with a five second ceiling in case a release never arrives.

One combo drives one action: assigning a shortcut clears it off the other rows in the section and off any preset holding it, since Carbon refuses a duplicate registration and the row set last would otherwise be the dead one.

No step size setting. The sixteen stops are macOS's own and the banner's tick dots mark them, so a seven percent step would land the fill between dots on every press.

Tested on this Mac with a release-signed build: single press, held repeat, the pointer on the built-in, and a combo taken from another row. `make check` green.

Fixes #160
