### PR TITLE
Read the DDC volume max from its low byte

### DIFF
--- a/Crisp/Models/DDCVolumeMax.swift
+++ b/Crisp/Models/DDCVolumeMax.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// The speaker volume maximum that DDC volume writes scale by, from the max
+/// field of a VCP 0x62 reply.
+///
+/// Speaker volume is a one-byte value: ddcutil reads 0x62 from the low byte
+/// alone in every MCCS version. Some firmware fills the high byte of the max
+/// anyway. The Dell S2725DSM replies 0xFF64 (65380) for a range of 0 to 100
+/// (#162), and scaled by that, every level above zero landed past the
+/// monitor's top, so the keys and the slider gave only mute or full volume.
+enum DDCVolumeMax {
+    static func from(_ reported: UInt16) -> UInt16 {
+        let low = reported & 0xFF
+        // A low byte of 0 would scale every write to 0, which is mute; 100 is
+        // what a forced write-only display assumes too.
+        return low == 0 ? 100 : low
+    }
+}

--- a/Crisp/Services/VolumeService.swift
+++ b/Crisp/Services/VolumeService.swift
@@ -16,7 +16,8 @@ final class VolumeService: ObservableObject {
 
     private static let log = Logger(subsystem: "com.crisp.app", category: "volume")
 
-    /// Raw DDC max volume per display (usually 100), from the probe read.
+    /// DDC max volume per display (usually 100), from the probe read through
+    /// DDCVolumeMax.
     private var ddcMax: [CGDirectDisplayID: UInt16] = [:]
     /// Volume to restore on unmute, captured when toggleMute drops to zero.
     private var preMuteVolume: [CGDirectDisplayID: Double] = [:]
@@ -96,16 +97,17 @@ final class VolumeService: ObservableObject {
                     }
                     return
                 }
+                let volumeMax = DDCVolumeMax.from(result.max)
                 if !self.rememberedCapable.contains(uuid) {
-                    Self.log.notice("\(display.name, privacy: .public): volume probe ok \(result.current, privacy: .public)/\(result.max, privacy: .public), slider shown")
+                    Self.log.notice("\(display.name, privacy: .public): volume probe ok \(result.current, privacy: .public)/\(volumeMax, privacy: .public), slider shown")
                 }
-                self.ddcMax[id] = result.max
+                self.ddcMax[id] = volumeMax
                 display.volumeSupported = true
                 self.rememberCapable(uuid)
                 // Adopt the hardware level only while our writer is idle, so a
                 // stale cached read never fights an in-flight drag.
                 if self.pending[id] == nil, !self.pumpActive.contains(id) {
-                    display.volume = Double(result.current) / Double(result.max) * 100.0
+                    display.volume = Double(result.current) / Double(volumeMax) * 100.0
                 }
             }
         }

--- a/CrispTests/DDCVolumeMaxTests.swift
+++ b/CrispTests/DDCVolumeMaxTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+/// Headless tests for the speaker volume maximum taken from a VCP 0x62 reply.
+///
+/// `DDCVolumeMax` is compiled directly into this test target (see `project.yml`
+/// sources), so no `@testable import Crisp` is needed.
+final class DDCVolumeMaxTests: XCTestCase {
+
+    /// The Dell S2725DSM replies 0xFF64 for a range of 0 to 100 (#162).
+    func testFilledHighByteIsIgnored() {
+        XCTAssertEqual(DDCVolumeMax.from(0xFF64), 100)
+    }
+
+    /// A plain reply is kept as it is, whatever range the monitor has.
+    func testPlainMaximumIsKept() {
+        XCTAssertEqual(DDCVolumeMax.from(100), 100)
+        XCTAssertEqual(DDCVolumeMax.from(30), 30)
+    }
+
+    /// A low byte of 0 would scale every write to 0, which is mute.
+    func testZeroLowByteFallsBackToOneHundred() {
+        XCTAssertEqual(DDCVolumeMax.from(0xFF00), 100)
+    }
+}

--- a/docs/ddc-notes.md
+++ b/docs/ddc-notes.md
@@ -85,6 +85,7 @@ write restarts the fade. Seen on other Dells too; accepted as a quirk.
 | One display's I2C blocks for seconds | Every other display's slider stalls with it | Per-display serial queues; coalesced latest-wins writes; immediate software preview while the write is outstanding |
 | Channel goes deaf (no ack) | Writes fail cleanly | 3-failure latch to full-range software gamma; recovery on reconnect |
 | Monitor in HDR discards DDC writes (still acks) | 15-100% of slider dead, ack-based detection blind | HDR state routes the whole 0-100 range to software gamma |
+| Firmware fills the high byte of the volume max (Dell S2725DSM replies 0xFF64 for 0 to 100, #162) | Volume keys and slider give only mute or full volume | Volume max taken from the low byte (`DDCVolumeMax`), the byte ddcutil reads 0x62 from |
 
 ## Recovery, in order of escalation
 

--- a/project.yml
+++ b/project.yml
@@ -82,6 +82,7 @@ targets:
       - path: Crisp/Models/CrispControlModel.swift
       - path: Crisp/Models/BrightnessKeySteps.swift
       - path: Crisp/Models/PhantomPortCap.swift
+      - path: Crisp/Models/DDCVolumeMax.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.crisp.tests


### PR DESCRIPTION
The Dell S2725DSM answers a VCP 0x62 read with a max of 0xFF64 (65380) for a volume range of 0 to 100, so every volume write above zero went past the monitor's top and the keys and the slider gave only mute or full volume (#162). Speaker volume is a one-byte value and ddcutil reads 0x62 from the low byte alone, so VolumeService now takes the max from the low byte (DDCVolumeMax, three tests), with 100 when that byte is 0. A max from 1 to 255 comes through unchanged, and brightness and the other VCP codes are untouched.

make check is green. Not tested on the monitor, since there is no S2725DSM here; the reporter's log shows the raw reply.
