### PR TITLE
Add optional system Night Shift temperature slider

### DIFF
--- a/Crisp/App/AppDelegate.swift
+++ b/Crisp/App/AppDelegate.swift
@@ -719,6 +719,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             || CoreBrightnessService.shared.trueToneAvailable {
             blocks.append(block("effects") { ScreenEffectsView() })
         }
+        if let temperature = CoreBrightnessService.shared.nightShiftTemperature {
+            blocks.append(block("nightShiftTemperature", isOpen: { settings.showNightShiftTemperature }) {
+                NightShiftTemperatureView(temperature: temperature)
+            })
+        }
         blocks.append(block("presets") {
             VStack(alignment: .leading, spacing: 0) {
                 SectionDivider()
@@ -800,6 +805,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             Task { @MainActor in self?.canvas.refreshAppearance() }
         }
         SettingsService.shared.$showCombinedBrightness
+            .dropFirst()
+            .sink { [weak self] _ in self?.canvas.requestApply() }
+            .store(in: &canvasCancellables)
+        SettingsService.shared.$showNightShiftTemperature
             .dropFirst()
             .sink { [weak self] _ in self?.canvas.requestApply() }
             .store(in: &canvasCancellables)

--- a/Crisp/Models/NightShiftTemperatureController.swift
+++ b/Crisp/Models/NightShiftTemperatureController.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Combine
+
+/// The system owns the strength and schedule. Keep only a live UI snapshot here.
+/// Reads cannot pull the thumb backward during a drag; writes are serialized and
+/// coalesced so a slow CoreBrightness round-trip does not queue every mouse event.
+@MainActor
+final class NightShiftTemperatureController: ObservableObject {
+    @Published private(set) var strength: Double?
+
+    private let read: @Sendable () async -> Float?
+    private let write: @Sendable (Float) async -> Bool
+    private var revision: UInt64 = 0
+    private var isEditing = false
+    private var isWriting = false
+    private var pendingStrength: Float?
+
+    init(read: @escaping @Sendable () async -> Float?, write: @escaping @Sendable (Float) async -> Bool) {
+        self.read = read
+        self.write = write
+    }
+
+    func refresh() async {
+        guard !isEditing, !isWriting else { return }
+        revision &+= 1
+        let request = revision
+        let value = await read()
+        guard request == revision, !isEditing, !isWriting else { return }
+        strength = value.flatMap { $0.isFinite ? Double(min(1, max(0, $0))) : nil }
+    }
+
+    func setEditing(_ editing: Bool) {
+        isEditing = editing
+        revision &+= 1
+    }
+
+    func setStrength(_ value: Double) async {
+        guard value.isFinite else { return }
+        let target = Float(min(1, max(0, value)))
+        revision &+= 1
+        strength = Double(target)
+        pendingStrength = target
+        guard !isWriting else { return }
+        isWriting = true
+        while let next = pendingStrength {
+            pendingStrength = nil
+            // Always read back after the last write, including failures. A failed
+            // read disables the control instead of displaying an invented value.
+            _ = await write(next)
+        }
+        isWriting = false
+        await refresh()
+    }
+}

--- a/Crisp/Resources/Localizable.xcstrings
+++ b/Crisp/Resources/Localizable.xcstrings
@@ -1224,6 +1224,16 @@
         }
       }
     },
+    "Less Warm" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "较冷"
+          }
+        }
+      }
+    },
     "Links crispctl into /usr/local/bin" : {
       "localizations" : {
         "zh-Hans" : {
@@ -1282,6 +1292,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更多空间"
+          }
+        }
+      }
+    },
+    "More Warm" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "较暖"
           }
         }
       }
@@ -1346,6 +1366,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "夜览"
+          }
+        }
+      }
+    },
+    "Night Shift Temperature" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "夜览色温"
           }
         }
       }
@@ -1838,6 +1868,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示合并亮度"
+          }
+        }
+      }
+    },
+    "Show Night Shift Temperature" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示夜览色温"
           }
         }
       }

--- a/Crisp/Services/CoreBrightnessService.swift
+++ b/Crisp/Services/CoreBrightnessService.swift
@@ -37,12 +37,20 @@ final class CoreBrightnessService: ObservableObject {
 
     private var blueLightClient: NSObject?
     private var trueToneClient: NSObject?
+    private(set) var nightShiftTemperature: NightShiftTemperatureController?
 
     private init() {
         guard dlopen("/System/Library/PrivateFrameworks/CoreBrightness.framework/CoreBrightness", RTLD_LAZY) != nil else { return }
         if let cls = NSClassFromString("CBBlueLightClient") as? NSObject.Type {
-            blueLightClient = cls.init()
+            let client = cls.init()
+            blueLightClient = client
             nightShiftAvailable = true
+            if let temperatureClient = NightShiftTemperatureClient(client: client) {
+                nightShiftTemperature = NightShiftTemperatureController(
+                    read: { await temperatureClient.read() },
+                    write: { await temperatureClient.write($0) }
+                )
+            }
         }
         if let cls = NSClassFromString("CBTrueToneClient") as? NSObject.Type {
             let client = cls.init()
@@ -82,6 +90,11 @@ final class CoreBrightnessService: ObservableObject {
     /// The reads are XPC round-trips, so they run off the main thread to keep
     /// panel opening snappy; results publish back on main.
     func refresh() {
+        // Strength-only changes do not always emit the status callback. The
+        // existing panel-open and visible-panel refreshes cover those too.
+        if let nightShiftTemperature {
+            Task { await nightShiftTemperature.refresh() }
+        }
         // The CoreBrightness XPC client objects are safe to message from any
         // thread, but NSObject is not Sendable; box them across the hop.
         let blueBox = UncheckedSendable(value: blueLightClient)

--- a/Crisp/Services/NightShiftTemperatureClient.swift
+++ b/Crisp/Services/NightShiftTemperatureClient.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Runtime-only bridge, like the existing Night Shift toggle. No private framework
+/// linkage or stored preference writes; CoreBrightness commits the system setting.
+final class NightShiftTemperatureClient: @unchecked Sendable {
+    private let client: NSObject
+    private let queue = DispatchQueue(label: "com.crisp.nightShiftTemperature", qos: .userInitiated)
+    private let getSelector = NSSelectorFromString("getStrength:")
+    private let setSelector = NSSelectorFromString("setStrength:commit:")
+
+    init?(client: NSObject) {
+        guard client.responds(to: getSelector), client.responds(to: setSelector) else { return nil }
+        self.client = client
+    }
+
+    func read() async -> Float? {
+        await withCheckedContinuation { continuation in
+            queue.async { [self] in
+                typealias Get = @convention(c) (NSObject, Selector, UnsafeMutablePointer<Float>) -> Bool
+                var value: Float = 0
+                let success = unsafeBitCast(client.method(for: getSelector), to: Get.self)(client, getSelector, &value)
+                continuation.resume(returning: success ? value : nil)
+            }
+        }
+    }
+
+    func write(_ value: Float) async -> Bool {
+        await withCheckedContinuation { continuation in
+            queue.async { [self] in
+                typealias Set = @convention(c) (NSObject, Selector, Float, Bool) -> Bool
+                let success = unsafeBitCast(client.method(for: setSelector), to: Set.self)(client, setSelector, value, true)
+                continuation.resume(returning: success)
+            }
+        }
+    }
+}

--- a/Crisp/Services/SettingsService.swift
+++ b/Crisp/Services/SettingsService.swift
@@ -58,6 +58,7 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
         static let showCombinedBrightness = "crisp.showCombinedBrightness"
         static let combinedBuiltinFactor  = "crisp.combinedBuiltinBrightnessAdjustment"
         static let showVolumeSliders      = "crisp.showVolumeSliders"
+        static let showNightShiftTemperature = "crisp.showNightShiftTemperature"
         static let ddcCacheTTL            = "crisp.ddcCacheTTL"
         static let colorPickerHistory     = "crisp.colorPickerHistory"
         static let brightnessKeyTarget    = "crisp.brightnessKeyTarget"
@@ -105,6 +106,11 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
 
     @Published var ddcCacheTTL: Double = 5.0 {
         didSet { defaults.set(ddcCacheTTL, forKey: Keys.ddcCacheTTL) }
+    }
+
+    /// Visibility only; the temperature itself belongs to macOS Night Shift.
+    @Published var showNightShiftTemperature: Bool = false {
+        didSet { defaults.set(showNightShiftTemperature, forKey: Keys.showNightShiftTemperature) }
     }
 
     /// Recently sampled colors (hex strings, newest first, max 20).
@@ -255,6 +261,7 @@ final class SettingsService: ObservableObject, @unchecked Sendable {
         }
         showVolumeSliders = defaults.object(forKey: Keys.showVolumeSliders) != nil
             ? defaults.bool(forKey: Keys.showVolumeSliders) : true
+        showNightShiftTemperature = defaults.bool(forKey: Keys.showNightShiftTemperature)
         ddcCacheTTL = defaults.object(forKey: Keys.ddcCacheTTL) != nil
             ? defaults.double(forKey: Keys.ddcCacheTTL) : 5.0
         colorPickerHistory = defaults.stringArray(forKey: Keys.colorPickerHistory) ?? []

--- a/Crisp/Views/MenuBarView.swift
+++ b/Crisp/Views/MenuBarView.swift
@@ -656,6 +656,26 @@ struct SettingsView: View {
                 .padding(.vertical, 3)
             }
 
+            if CoreBrightnessService.shared.nightShiftTemperature != nil {
+                Toggle(isOn: Binding(
+                    get: { settings.showNightShiftTemperature },
+                    set: { newValue in withAnimation(.panelResize) { settings.showNightShiftTemperature = newValue } }
+                )) {
+                    HStack(spacing: 8) {
+                        MenuItemIcon(systemName: "thermometer.medium", color: .orange,
+                                     active: settings.showNightShiftTemperature)
+                            .accessibilityHidden(true)
+                        Text("Show Night Shift Temperature")
+                            .font(.body)
+                        Spacer()
+                    }
+                }
+                .toggleStyle(.switch)
+                .controlSize(.small)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 3)
+            }
+
             // Which displays the hardware brightness keys adjust. Once Accessibility is granted,
             // an expandable row + checkmark list (the Resolution / Color Profile idiom). Before
             // that there is no row or target subtitle at all, only the opt-in toggle, so enabling

--- a/Crisp/Views/NightShiftTemperatureView.swift
+++ b/Crisp/Views/NightShiftTemperatureView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// One global Night Shift control, below the system effects and above Presets.
+struct NightShiftTemperatureView: View {
+    @ObservedObject var temperature: NightShiftTemperatureController
+    @ObservedObject private var effects = CoreBrightnessService.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Night Shift Temperature")
+                .font(.callout)
+            Slider(value: Binding(
+                get: { temperature.strength ?? 0 },
+                set: { value in Task { await temperature.setStrength(value) } }
+            ), in: 0...1) { editing in
+                temperature.setEditing(editing)
+                if !editing { Task { await temperature.refresh() } }
+            }
+            .controlSize(.small)
+            .accessibilityLabel("Night Shift Temperature")
+            HStack {
+                Text("Less Warm")
+                Spacer()
+                Text("More Warm")
+            }
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+        .disabled(!effects.nightShiftEnabled || temperature.strength == nil)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .onReceive(NotificationCenter.default.publisher(for: .crispPanelDidClose)) { _ in
+            temperature.setEditing(false)
+            Task { await temperature.refresh() }
+        }
+    }
+}

--- a/CrispTests/NightShiftTemperatureControllerTests.swift
+++ b/CrispTests/NightShiftTemperatureControllerTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+
+final class NightShiftTemperatureControllerTests: XCTestCase {
+    @MainActor
+    func testRefreshFollowsSystemChangesWithoutWriting() async {
+        let backend = TemperatureBackend()
+        let controller = makeController(backend)
+        await controller.refresh()
+        XCTAssertEqual(controller.strength, Double(Float(0.3)))
+        await backend.setSystemStrength(0.7)
+        await controller.refresh()
+        XCTAssertEqual(controller.strength, Double(Float(0.7)))
+        let writes = await backend.writes
+        XCTAssertTrue(writes.isEmpty)
+    }
+
+    @MainActor
+    func testFailedReadClearsTheSnapshot() async {
+        let backend = TemperatureBackend()
+        let controller = makeController(backend)
+        await controller.refresh()
+        await backend.setSystemStrength(nil)
+        await controller.refresh()
+        XCTAssertNil(controller.strength)
+        await backend.setSystemStrength(.nan)
+        await controller.refresh()
+        XCTAssertNil(controller.strength)
+    }
+
+    @MainActor
+    func testFailedWriteRestoresActualSystemValue() async {
+        let backend = TemperatureBackend()
+        let controller = makeController(backend)
+        await backend.rejectWrites()
+        await controller.setStrength(0.9)
+        XCTAssertEqual(controller.strength, Double(Float(0.3)))
+    }
+
+    @MainActor
+    func testWritesClampToSystemRangeAndRejectNonFiniteValues() async {
+        let backend = TemperatureBackend()
+        let controller = makeController(backend)
+        await controller.setStrength(-2)
+        await controller.setStrength(4)
+        await controller.setStrength(.nan)
+        await controller.setStrength(.infinity)
+        let writes = await backend.writes
+        XCTAssertEqual(writes, [0, 1])
+        XCTAssertEqual(controller.strength, 1)
+    }
+
+    @MainActor
+    func testOldReadCannotUndoANewerWrite() async {
+        let backend = TemperatureBackend()
+        let controller = makeController(backend)
+        await backend.blockNextRead()
+        let oldRead = Task { await controller.refresh() }
+        await waitUntil { await backend.hasBlockedRead }
+        await controller.setStrength(0.8)
+        await backend.releaseRead()
+        await oldRead.value
+        XCTAssertEqual(controller.strength, Double(Float(0.8)))
+    }
+
+    @MainActor
+    func testDragIgnoresReadbackUntilEditingEnds() async {
+        let backend = TemperatureBackend()
+        let controller = makeController(backend)
+        controller.setEditing(true)
+        await controller.setStrength(0.8)
+        await backend.setSystemStrength(0.5)
+        await controller.refresh()
+        XCTAssertEqual(controller.strength, Double(Float(0.8)))
+        controller.setEditing(false)
+        await controller.refresh()
+        XCTAssertEqual(controller.strength, Double(Float(0.5)))
+    }
+
+    @MainActor
+    func testSlowWriteCoalescesToLatestValueWithoutConcurrentWrites() async {
+        let backend = TemperatureBackend()
+        let controller = makeController(backend)
+        await backend.blockNextWrite()
+        let firstWrite = Task { await controller.setStrength(0.2) }
+        await waitUntil { await backend.hasBlockedWrite }
+        await controller.setStrength(0.4)
+        await controller.setStrength(0.9)
+        let pendingWrites = await backend.writes
+        XCTAssertEqual(pendingWrites, [0.2])
+        await backend.releaseWrite()
+        await firstWrite.value
+        let writes = await backend.writes
+        XCTAssertEqual(writes, [0.2, 0.9])
+        XCTAssertEqual(controller.strength, Double(Float(0.9)))
+    }
+
+    @MainActor
+    private func makeController(_ backend: TemperatureBackend) -> NightShiftTemperatureController {
+        NightShiftTemperatureController(read: { await backend.read() }, write: { await backend.write($0) })
+    }
+
+    private func waitUntil(_ condition: () async -> Bool) async {
+        let deadline = ContinuousClock.now.advanced(by: .seconds(3))
+        while !(await condition()) {
+            guard ContinuousClock.now < deadline else {
+                XCTFail("Backend did not reach the expected suspension point")
+                return
+            }
+            await Task.yield()
+        }
+    }
+}
+
+private actor TemperatureBackend {
+    private var systemStrength: Float? = 0.3
+    private var shouldRejectWrites = false
+    private var shouldBlockRead = false
+    private var shouldBlockWrite = false
+    private var blockedRead: CheckedContinuation<Void, Never>?
+    private var blockedWrite: CheckedContinuation<Void, Never>?
+    private(set) var writes: [Float] = []
+    var hasBlockedRead: Bool { blockedRead != nil }
+    var hasBlockedWrite: Bool { blockedWrite != nil }
+
+    func setSystemStrength(_ value: Float?) { systemStrength = value }
+    func rejectWrites() { shouldRejectWrites = true }
+    func blockNextRead() { shouldBlockRead = true }
+    func blockNextWrite() { shouldBlockWrite = true }
+
+    func releaseRead() {
+        blockedRead?.resume()
+        blockedRead = nil
+    }
+
+    func releaseWrite() {
+        blockedWrite?.resume()
+        blockedWrite = nil
+    }
+
+    func read() async -> Float? {
+        let snapshot = systemStrength
+        if shouldBlockRead {
+            shouldBlockRead = false
+            await withCheckedContinuation { blockedRead = $0 }
+        }
+        return snapshot
+    }
+
+    func write(_ value: Float) async -> Bool {
+        writes.append(value)
+        if shouldBlockWrite {
+            shouldBlockWrite = false
+            await withCheckedContinuation { blockedWrite = $0 }
+        }
+        guard !shouldRejectWrites else { return false }
+        systemStrength = value
+        return true
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test: vendor
 	xcodegen generate
 	xcodebuild -quiet test -project Crisp.xcodeproj -scheme Crisp \
 		-destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO \
-		SWIFT_VERSION=5 SWIFT_STRICT_CONCURRENCY=minimal \
+		SWIFT_STRICT_CONCURRENCY=minimal \
 		SWIFT_TREAT_WARNINGS_AS_ERRORS=YES
 
 lint:
@@ -84,7 +84,7 @@ loc-check: vendor
 	xcodegen generate
 	xcodebuild -quiet -exportLocalizations -project Crisp.xcodeproj \
 		-localizationPath build/loc CODE_SIGNING_ALLOWED=NO \
-		SWIFT_EMIT_LOC_STRINGS=YES SWIFT_VERSION=5 SWIFT_STRICT_CONCURRENCY=minimal
+		SWIFT_EMIT_LOC_STRINGS=YES SWIFT_STRICT_CONCURRENCY=minimal
 	python3 scripts/check-localization-keys.py build/loc/en.xcloc \
 		Crisp/Resources/Localizable.xcstrings scripts/i18n-missing-allowlist.txt
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Installed from `didriksg/tap` earlier? `brew upgrade` moves you to the main cask
 - **Presets**: save named display configurations (resolution, brightness, arrangement) with custom icons and colors, apply with one click, update in place. Image adjustment (gamma, color temperature, contrast) is per-display and not stored in presets
 - **Display arrangement**: drag-to-arrange canvas, main display switching
 - **Disconnect displays**: turn physical displays off and back on from the menu, remembered across sleep/wake (Apple Silicon)
-- **System toggles**: Dark Mode, Night Shift, and True Tone, one click from the menu bar
+- **System toggles**: Dark Mode, Night Shift, and True Tone, one click from the menu bar. Enable Show Night Shift Temperature in Settings for a system warmth slider below the toggles
 - **Color**: ICC profile switching, XDR reference presets, HDR on/off per display, and image adjustment (gamma, contrast, gain, invert colors)
 - **Virtual displays**: create HiDPI virtual screens
 - **Extras**: combined brightness slider, auto brightness following the built-in display, a toggle for macOS's own ambient auto-brightness, keep awake, notch hiding, launch at login

--- a/project.yml
+++ b/project.yml
@@ -83,6 +83,7 @@ targets:
       - path: Crisp/Models/BrightnessKeySteps.swift
       - path: Crisp/Models/PhantomPortCap.swift
       - path: Crisp/Models/DDCVolumeMax.swift
+      - path: Crisp/Models/NightShiftTemperatureController.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.crisp.tests

--- a/project.yml
+++ b/project.yml
@@ -33,7 +33,8 @@ targets:
         INFOPLIST_KEY_LSUIElement: true
         INFOPLIST_KEY_NSHumanReadableCopyright: "Crisp - Free & Open Source"
         INFOPLIST_KEY_NSAppleEventsUsageDescription: "Crisp uses System Events to switch Dark Mode with the system's animated transition."
-        SWIFT_VERSION: "6.0"
+        # Match the Swift 5 language mode used by the dev and release builds.
+        SWIFT_VERSION: "5.0"
         CODE_SIGN_ENTITLEMENTS: Crisp/Crisp.entitlements
         ENABLE_HARDENED_RUNTIME: YES
         CODE_SIGNING_REQUIRED: YES
@@ -60,7 +61,7 @@ targets:
     settings:
       base:
         PRODUCT_NAME: crispctl
-        SWIFT_VERSION: "6.0"
+        SWIFT_VERSION: "5.0"
         SWIFT_STRICT_CONCURRENCY: minimal
   CrispTests:
     type: bundle.unit-test
@@ -88,7 +89,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.crisp.tests
         GENERATE_INFOPLIST_FILE: YES
-        SWIFT_VERSION: "6.0"
+        SWIFT_VERSION: "5.0"
         SWIFT_STRICT_CONCURRENCY: minimal
         TEST_HOST: ""
         BUNDLE_LOADER: ""


### PR DESCRIPTION
Crisp can toggle Night Shift, but adjusting its system warmth still requires opening macOS System Settings. This adds an optional **Night Shift Temperature** slider below the system effects buttons and above Presets.

Years ago I added this control to my [NativeDisplayBrightness](https://github.com/Anywhere-Music-Player/NativeDisplayBrightness) app. After moving to Crisp for multiple displays, I wanted that same convenient access to the system Night Shift setting, which motivated this PR.

- Enable it with **Settings → Show Night Shift Temperature** (off by default).
- The slider uses **Less Warm / More Warm** endpoints and is disabled while Night Shift is off. The existing Night Shift button remains the on/off control.
- It reads and writes system strength through the existing CoreBrightness client, with runtime selector checks. macOS continues to own the temperature and schedule; Crisp persists only visibility.
- Writes run off the main thread, are serialized, and coalesce to the latest value. Stale reads cannot overwrite an active drag. External changes are picked up by the existing status, panel-open, and visible-panel refresh paths; strength-only changes do not reliably emit a status callback on the tested Mac.
- The control uses a separate panel canvas block and includes English and Simplified Chinese strings.
- Align the generated Xcode project with the Swift 5 language mode already used by the dev and CI builds, and remove the language overrides from `make test` and `make loc-check` so those checks exercise the project default. The unchanged base commit also fails a default Swift 6 build in ArrangementView, BrightnessSliderView, and UpdateService.

Validation:

- `make check`: strict SwiftLint, application build and 142 passing unit tests, x86_64 typecheck, and localization key validation, using the project language mode without a command-line override.
- Build and all seven Night Shift controller tests passed in the open Xcode 27 RC workspace, using local ad-hoc signing and the project language mode. The PR does not change project signing defaults.
- Seven new controller tests cover external changes, failed reads/writes, invalid values, stale reads, dragging, and write coalescing.
- On macOS 26.6.2, verified the runtime method signatures and actual CoreBrightness write/readback, then restored and verified the original system strength. Also verified synchronization through the existing refresh path after a separate client changed strength.
- Rendered the actual SwiftUI slider component offscreen at the default 320-point panel width.

Full-panel mouse interaction and sleep/wake behavior have not been manually verified. Smooth brightness stepping is outside this PR.
